### PR TITLE
[取消済]refactor: accept numeric downscale_freq_shift

### DIFF
--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -360,7 +360,9 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
     )
     parser.add_argument(
         "--downscale_freq_shift",
-        action="store_true",
+        action="store_const",
+        const=1.0,
+        default=0.0,
         help="set downscale_freq_shift=1 for timestep embeddings / timestep embedding の downscale_freq_shift を1にする",
     )
 


### PR DESCRIPTION
## 背景
`--downscale_freq_shift` は 0/1 の実数を前提としていましたが、  
現状 `action="store_true"` のため `False/True` (bool) が渡ってしまいます。

## 問題点
* bool でも計算上は True =1 False =0 で計算されるため問題ないが分かりにくい
* 将来 0/1 以外を許容したい場合に拡張できない

## この PR の変更
* argparse を `action="store_const", const=1.0, default=0.0, type=float` に変更  
* docstring / help を 0 or 1 の数値指定に合わせて更新

## 動作確認
