### PR TITLE
Add gradient skipping log and progress tracking

### DIFF
--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -365,6 +365,16 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
         default=0.0,
         help="set downscale_freq_shift=1 for timestep embeddings / timestep embedding の downscale_freq_shift を1にする",
     )
+    parser.add_argument(
+        "--skip_grad_norm",
+        action="store_true",
+        help="skip step if gradient norm exceeds moving average + 2.5 sigma / 勾配ノルムが移動平均+2.5σを超える場合にステップをスキップする",
+    )
+    parser.add_argument(
+        "--grad_norm_log",
+        action="store_true",
+        help="output gradient norm logs to gradient_logs.txt / 勾配ノルムのログをgradient_logs.txtに出力する",
+    )
 
 
 def verify_sdxl_training_args(args: argparse.Namespace, supportTextEncoderCaching: bool = True):

--- a/train_network.py
+++ b/train_network.py
@@ -8,6 +8,8 @@ import time
 import json
 from multiprocessing import Value
 import toml
+from collections import deque
+import numpy as np
 
 from tqdm import tqdm
 
@@ -824,6 +826,7 @@ class NetworkTrainer:
                 initial_step = 0  # do not skip
 
         global_step = 0
+        skipped_steps = 0
 
         noise_scheduler = DDPMScheduler(
             beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", num_train_timesteps=1000, clip_sample=False
@@ -846,6 +849,52 @@ class NetworkTrainer:
 
         loss_recorder = train_util.LossRecorder()
         del train_dataset_group
+
+        # prepare gradient skipping if enabled
+        skip_grad_norm = getattr(args, "skip_grad_norm", False)
+        log_grad_norm = getattr(args, "grad_norm_log", False)
+        logger.info(f"skip_grad_norm: {skip_grad_norm}, grad_norm_log: {log_grad_norm}")
+        if skip_grad_norm:
+            moving_avg_window = deque(maxlen=200)
+            log_buffer = []
+            log_file_path = "gradient_logs.txt"
+            if log_grad_norm:
+                with open(log_file_path, "w") as f:
+                    f.write("Epoch,Step,Gradient Norm,Threshold\n")
+
+            def check_gradients_and_skip_update(model, epoch, step):
+                device = next(model.parameters()).device
+                gradient_norm = torch.tensor(0.0, device=device)
+                with torch.no_grad():
+                    for param in model.parameters():
+                        if param.grad is not None:
+                            grad = param.grad
+                            gradient_norm += grad.norm() ** 2
+                gradient_norm = gradient_norm.sqrt().item()
+
+                moving_avg_window.append(gradient_norm)
+                if len(moving_avg_window) == moving_avg_window.maxlen:
+                    mean_norm = np.mean(moving_avg_window)
+                    std_norm = np.std(moving_avg_window)
+                    dynamic_threshold = mean_norm + 2.5 * std_norm
+                    if dynamic_threshold > 200_000:
+                        dynamic_threshold = 200_000
+                else:
+                    dynamic_threshold = 200_000
+
+                if log_grad_norm:
+                    log_buffer.append(
+                        f"{epoch},{step},{gradient_norm},{dynamic_threshold}\n"
+                    )
+                    if step % 100 == 0:
+                        with open(log_file_path, "a") as f:
+                            f.writelines(log_buffer)
+                        log_buffer.clear()
+
+                return gradient_norm > dynamic_threshold
+        else:
+            def check_gradients_and_skip_update(model, epoch, step):
+                return False
 
         # callback for step start
         if hasattr(accelerator.unwrap_model(network), "on_step_start"):
@@ -1011,15 +1060,25 @@ class NetworkTrainer:
                     loss = loss.mean()  # 平均なのでbatch_sizeで割る必要なし
 
                     accelerator.backward(loss)
-                    if accelerator.sync_gradients:
-                        self.all_reduce_network(accelerator, network)  # sync DDP grad manually
-                        if args.max_grad_norm != 0.0:
-                            params_to_clip = accelerator.unwrap_model(network).get_trainable_params()
-                            accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
+                    skip_step = False
+                    if check_gradients_and_skip_update(network, epoch, step):
+                        accelerator.print(
+                            f"Skipping update at Epoch: {epoch}, Step: {step} due to large gradients."
+                        )
+                        skipped_steps += 1
+                        optimizer.zero_grad(set_to_none=True)
+                        skip_step = True
 
-                    optimizer.step()
-                    lr_scheduler.step()
-                    optimizer.zero_grad(set_to_none=True)
+                    if not skip_step:
+                        if accelerator.sync_gradients:
+                            self.all_reduce_network(accelerator, network)  # sync DDP grad manually
+                            if args.max_grad_norm != 0.0:
+                                params_to_clip = accelerator.unwrap_model(network).get_trainable_params()
+                                accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
+
+                        optimizer.step()
+                        lr_scheduler.step()
+                        optimizer.zero_grad(set_to_none=True)
 
                 if args.scale_weight_norms:
                     keys_scaled, mean_norm, maximum_norm = accelerator.unwrap_model(network).apply_max_norm_regularization(
@@ -1054,7 +1113,9 @@ class NetworkTrainer:
                 current_loss = loss.detach().item()
                 loss_recorder.add(epoch=epoch, step=step, loss=current_loss)
                 avr_loss: float = loss_recorder.moving_average
-                logs = {"avr_loss": avr_loss}  # , "lr": lr_scheduler.get_last_lr()[0]}
+                logs = {"avr_loss": avr_loss}
+                if skip_grad_norm:
+                    logs["skipped"] = skipped_steps
                 progress_bar.set_postfix(**logs)
 
                 if args.scale_weight_norms:
@@ -1064,6 +1125,8 @@ class NetworkTrainer:
                     logs = self.generate_step_logs(
                         args, current_loss, avr_loss, lr_scheduler, lr_descriptions, keys_scaled, mean_norm, maximum_norm
                     )
+                    if skip_grad_norm:
+                        logs["train/skipped_steps"] = skipped_steps
                     accelerator.log(logs, step=global_step)
 
                 if global_step >= args.max_train_steps:

--- a/train_network.py
+++ b/train_network.py
@@ -850,14 +850,17 @@ class NetworkTrainer:
         loss_recorder = train_util.LossRecorder()
         del train_dataset_group
 
-        # prepare gradient skipping if enabled
+        # prepare gradient skipping if enabled (複数 GPUではrankごとに判定がズレる恐れありらしい)
         skip_grad_norm = getattr(args, "skip_grad_norm", False)
         log_grad_norm = getattr(args, "grad_norm_log", False)
         logger.info(f"skip_grad_norm: {skip_grad_norm}, grad_norm_log: {log_grad_norm}")
         if skip_grad_norm:
+            # 勾配ノルムの履歴を保持するキュー
             moving_avg_window = deque(maxlen=200)
             log_buffer = []
             log_file_path = "gradient_logs.txt"
+
+            # ログ用のヘッダーを書き出す
             if log_grad_norm:
                 with open(log_file_path, "w") as f:
                     f.write("Epoch,Step,Gradient Norm,Threshold\n")
@@ -865,6 +868,8 @@ class NetworkTrainer:
             def check_gradients_and_skip_update(model, epoch, step):
                 device = next(model.parameters()).device
                 gradient_norm = torch.tensor(0.0, device=device)
+
+                # 各パラメータの勾配ノルムの二乗を加算
                 with torch.no_grad():
                     for param in model.parameters():
                         if param.grad is not None:
@@ -872,7 +877,10 @@ class NetworkTrainer:
                             gradient_norm += grad.norm() ** 2
                 gradient_norm = gradient_norm.sqrt().item()
 
+                # 移動平均窓に追加
                 moving_avg_window.append(gradient_norm)
+
+                # 窓がいっぱいになったら平均+2.5σを計算
                 if len(moving_avg_window) == moving_avg_window.maxlen:
                     mean_norm = np.mean(moving_avg_window)
                     std_norm = np.std(moving_avg_window)
@@ -882,6 +890,7 @@ class NetworkTrainer:
                 else:
                     dynamic_threshold = 200_000
 
+                # ログをファイルに出力
                 if log_grad_norm:
                     log_buffer.append(
                         f"{epoch},{step},{gradient_norm},{dynamic_threshold}\n"
@@ -891,6 +900,7 @@ class NetworkTrainer:
                             f.writelines(log_buffer)
                         log_buffer.clear()
 
+                # 閾値を超えた場合はこのステップをスキップ
                 return gradient_norm > dynamic_threshold
         else:
             def check_gradients_and_skip_update(model, epoch, step):
@@ -1063,7 +1073,7 @@ class NetworkTrainer:
                     skip_step = False
                     if check_gradients_and_skip_update(network, epoch, step):
                         accelerator.print(
-                            f"Skipping update at Epoch: {epoch}, Step: {step} due to large gradients."
+                            f"\nSkipping update at Epoch: {epoch}, Step: {step} due to large gradients."
                         )
                         skipped_steps += 1
                         optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
### 概要
勾配ノルムの外れ値を検知して **その step の重み更新をスキップ** することで、発散を抑制し安定学習を目指す機能を追加しました。

### 変更点
* **library/sdxl_train_util.py**
  * `--skip_grad_norm` : 直近 200 step の移動平均 + 2.5 σ を閾値とし、超過時に step を飛ばします。
  * `--grad_norm_log` : `(epoch, step, norm, threshold)` を *gradient_logs.txt* に追記します。
* **train_network.py**
  * `check_gradients_and_skip_update` を実装。  
    - L2 ノルム算出 → 200 件リングバッファ → 閾値判定  
    - スキップ時は `optimizer.zero_grad()` のみ実行し `skipped_steps` をインクリメント  
  * 進行表示 / TensorBoard ログに `skipped` を追加
* **依存** : `numpy` を新規インポート（既存 requirements に含まれるため追加パッケージなし）

### 今後の課題
マルチ GPU 時の判定同期（All Reduce 後に計算する or rank0 の結果を broadcast）
閾値パラメータ (window, sigma, max_threshold) の CLI 化
