### PR TITLE
Fix te_mlp_fc_only behavior

### DIFF
--- a/networks/dylora.py
+++ b/networks/dylora.py
@@ -268,7 +268,12 @@ def create_network_from_weights(multiplier, file, vae, text_encoder, unet, weigh
 class DyLoRANetwork(torch.nn.Module):
     UNET_TARGET_REPLACE_MODULE = ["Transformer2DModel"]
     UNET_TARGET_REPLACE_MODULE_CONV2D_3X3 = ["ResnetBlock2D", "Downsample2D", "Upsample2D"]
-    TEXT_ENCODER_TARGET_REPLACE_MODULE = ["CLIPAttention", "CLIPSdpaAttention", "CLIPMLP"]
+    DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE = [
+        "CLIPAttention",
+        "CLIPSdpaAttention",
+        "CLIPMLP",
+    ]
+    TEXT_ENCODER_TARGET_REPLACE_MODULE = DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE.copy()
     LORA_PREFIX_UNET = "lora_unet"
     LORA_PREFIX_TEXT_ENCODER = "lora_te"
 

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -866,7 +866,12 @@ class LoRANetwork(torch.nn.Module):
 
     UNET_TARGET_REPLACE_MODULE = ["Transformer2DModel"]
     UNET_TARGET_REPLACE_MODULE_CONV2D_3X3 = ["ResnetBlock2D", "Downsample2D", "Upsample2D"]
-    TEXT_ENCODER_TARGET_REPLACE_MODULE = ["CLIPAttention", "CLIPSdpaAttention", "CLIPMLP"]
+    DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE = [
+        "CLIPAttention",
+        "CLIPSdpaAttention",
+        "CLIPMLP",
+    ]
+    TEXT_ENCODER_TARGET_REPLACE_MODULE = DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE.copy()
     LORA_PREFIX_UNET = "lora_unet"
     LORA_PREFIX_TEXT_ENCODER = "lora_te"
 
@@ -1033,6 +1038,8 @@ class LoRANetwork(torch.nn.Module):
             self.text_encoder_loras.extend(text_encoder_loras)
             skipped_te += skipped
         logger.info(f"create LoRA for Text Encoder: {len(self.text_encoder_loras)} modules.")
+        for lora in self.text_encoder_loras:
+            logger.info(f"\t{lora.lora_name}")
 
         # extend U-Net target modules if conv2d 3x3 is enabled, or load from weights
         target_modules = LoRANetwork.UNET_TARGET_REPLACE_MODULE

--- a/networks/lora_diffusers.py
+++ b/networks/lora_diffusers.py
@@ -278,7 +278,12 @@ def merge_lora_weights(pipe, weights_sd: Dict, multiplier: float = 1.0):
 class LoRANetwork(torch.nn.Module):
     UNET_TARGET_REPLACE_MODULE = ["Transformer2DModel"]
     UNET_TARGET_REPLACE_MODULE_CONV2D_3X3 = ["ResnetBlock2D", "Downsample2D", "Upsample2D"]
-    TEXT_ENCODER_TARGET_REPLACE_MODULE = ["CLIPAttention", "CLIPSdpaAttention", "CLIPMLP"]
+    DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE = [
+        "CLIPAttention",
+        "CLIPSdpaAttention",
+        "CLIPMLP",
+    ]
+    TEXT_ENCODER_TARGET_REPLACE_MODULE = DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE.copy()
     LORA_PREFIX_UNET = "lora_unet"
     LORA_PREFIX_TEXT_ENCODER = "lora_te"
 

--- a/networks/lora_fa.py
+++ b/networks/lora_fa.py
@@ -755,7 +755,12 @@ class LoRANetwork(torch.nn.Module):
 
     UNET_TARGET_REPLACE_MODULE = ["Transformer2DModel"]
     UNET_TARGET_REPLACE_MODULE_CONV2D_3X3 = ["ResnetBlock2D", "Downsample2D", "Upsample2D"]
-    TEXT_ENCODER_TARGET_REPLACE_MODULE = ["CLIPAttention", "CLIPSdpaAttention", "CLIPMLP"]
+    DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE = [
+        "CLIPAttention",
+        "CLIPSdpaAttention",
+        "CLIPMLP",
+    ]
+    TEXT_ENCODER_TARGET_REPLACE_MODULE = DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE.copy()
     LORA_PREFIX_UNET = "lora_unet"
     LORA_PREFIX_TEXT_ENCODER = "lora_te"
 

--- a/sdxl_train_network.py
+++ b/sdxl_train_network.py
@@ -28,6 +28,10 @@ class SdxlNetworkTrainer(train_network.NetworkTrainer):
                     network_module.LoRANetwork.TEXT_ENCODER_TARGET_REPLACE_MODULE = [
                         "CLIPMLP"
                     ]
+                    logger.info(
+                        "Text encoder target modules: %s",
+                        network_module.LoRANetwork.TEXT_ENCODER_TARGET_REPLACE_MODULE,
+                    )
             except Exception as e:
                 logger.warning(f"failed to set text encoder target modules: {e}")
 


### PR DESCRIPTION
## Summary
- update LoRA network modules so `DEFAULT_TEXT_ENCODER_TARGET_REPLACE_MODULE` is available
- log the text encoder target modules when `--te_mlp_fc_only` is used
- print registered TextEncoder LoRA module names

## Testing
- `typos --config _typos.toml` *(fails: command not found)*