### PR TITLE
Add SDXL downscale_freq_shift option [再]

### DIFF
--- a/library/sdxl_original_unet.py
+++ b/library/sdxl_original_unet.py
@@ -31,6 +31,7 @@ from torch import nn
 from torch.nn import functional as F
 from einops import rearrange
 from .utils import setup_logging
+from . import maruo_global_config as maruoCfg
 
 setup_logging()
 import logging
@@ -1076,7 +1077,12 @@ class SdxlUNet2DConditionModel(nn.Module):
         timesteps = timesteps.expand(x.shape[0])
 
         hs = []
-        t_emb = get_timestep_embedding(timesteps, self.model_channels, downscale_freq_shift=0)  # , repeat_only=False)
+        if maruoCfg.downscale_freq_shift:
+            #改造ルート (downscale_freq_shiftを渡さないことで1になる)
+            t_emb = get_timestep_embedding(timesteps, self.model_channels)  # , repeat_only=False)
+        else:
+            # 通常ルート
+            t_emb = get_timestep_embedding(timesteps, self.model_channels, downscale_freq_shift=0)  # , repeat_only=False)
         t_emb = t_emb.to(x.dtype)
         emb = self.time_embed(t_emb)
 
@@ -1166,7 +1172,12 @@ class InferSdxlUNet2DConditionModel:
         timesteps = timesteps.expand(x.shape[0])
 
         hs = []
-        t_emb = get_timestep_embedding(timesteps, _self.model_channels, downscale_freq_shift=0)  # , repeat_only=False)
+        if maruoCfg.downscale_freq_shift:
+            # 改造ルート (downscale_freq_shiftを渡さないことで1になる)
+            t_emb = get_timestep_embedding(timesteps, _self.model_channels)  # , repeat_only=False)
+        else:
+            # 通常ルート
+            t_emb = get_timestep_embedding(timesteps, _self.model_channels, downscale_freq_shift=0)  # , repeat_only=False)
         t_emb = t_emb.to(x.dtype)
         emb = _self.time_embed(t_emb)
 

--- a/sdxl_train_network.py
+++ b/sdxl_train_network.py
@@ -6,7 +6,7 @@ init_ipex()
 
 from library import sdxl_model_util, sdxl_train_util, train_util
 import train_network
-import maruo_global_config as cfg
+import library.maruo_global_config as maruoCfg
 from library.utils import setup_logging
 setup_logging()
 import logging
@@ -174,12 +174,12 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--downscale_freq_shift",
         action="store_true",
-        help="Enable downscale_freq_shift; sets cfg.downscale_freq_shift = True",
+        help="sdxl_original_unet.py の get_timestep_embedding() で downscale_freq_shift=1 にする（通常は0)",
     )
     parser.add_argument(
         "--te_mlp_fc_only",
         action="store_true",
-        help="Enable TE-MLP-FC-only training; sets cfg.te_mlp_fc_only = True",
+        help="Enable TE-MLP-FC-only training",
     )
     return parser
 
@@ -191,8 +191,8 @@ if __name__ == "__main__":
     train_util.verify_command_line_training_args(args)
     args = train_util.read_config_from_file(args, parser)
     # map CLI options to global config
-    cfg.downscale_freq_shift = bool(getattr(args, "downscale_freq_shift", False))
-    cfg.te_mlp_fc_only = bool(getattr(args, "te_mlp_fc_only", False))
+    maruoCfg.downscale_freq_shift = bool(getattr(args, "downscale_freq_shift", False))
+    maruoCfg.te_mlp_fc_only = bool(getattr(args, "te_mlp_fc_only", False))
 
     trainer = SdxlNetworkTrainer()
     trainer.train(args)


### PR DESCRIPTION
library/sdxl_original_unet.py の中の
get_timestep_embedding() の呼び出し箇所で、downscale_freq_shift の値を変えるオプション

修正前
t_emb = get_timestep_embedding(timesteps, _self.model_channels, downscale_freq_shift=0)

引数 downscale_freq_shif の値が、デフォルトは0だが
オプション --downscale_freq_shift を指定すると 1 になる

※公式で1→0に変わった経緯あり　昔の状態に戻す実験用
https://github.com/kohya-ss/sd-scripts/pull/1187