### PR TITLE
Fix grad_norm_log final flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | --- | --- | --- | --- |
 | `--downscale_freq_shift` | `library/sdxl_original_unet.py` 内の `get_timestep_embedding()` に渡す **`downscale_freq_shift`** を切り替えます。 | 0.0 → **1.0** | 過去に 1.0 だったものが 0.0 に変更になった経緯あり（本家 PR [#1187](https://github.com/kohya-ss/sd-scripts/pull/1187)）。キャラクター性を学習させるタスクでは 1.0 の方が定着しやすい印象。 |
 | `--skip_grad_norm` | 直近 **200 step のnormの移動平均 + 2.5 σ** を閾値にし、それを超えた **step をスキップ**（パラメータ更新を無視）します。 | ― | 上限などはソース内の定数で調整可。勾配爆発の瞬間を丸ごと飛ばすことで安定化を狙う実験的機能。 |
-| `--grad_norm_log` | **100 step ごと**に `(epoch, step, norm, threshold, loss)` を `gradient_logs.txt` に追記します。`--skip_grad_norm` を付けない場合はスキップせずログのみ記録されます。既存ファイルがあれば上書き。 | ― | 閾値設定の妥当性チェックや勾配爆発の確認に利用。 |
+| `--grad_norm_log` | **100 step ごと**に `(epoch, step, norm, threshold, loss)` を `gradient_logs+LoRAファイル名.txt` に追記します。`--skip_grad_norm` を付けない場合はスキップせずログのみ記録されます。既存ファイルがあれば上書き。 | ― | 閾値設定の妥当性チェックや勾配爆発の確認に利用。 |
 | `--te_mlp_fc_only` | Text Encoder（TE）の学習対象を **MLP (FC) 層のみに限定**します。 | TE 全層 ↔ **MLP のみ** | 本家 PR [#1964](https://github.com/kohya-ss/sd-scripts/pull/1964) 以前の挙動を再現。単純キーワードでキャラを学習する場合、MLP だけの方が安定しやすい印象。 |
 
 

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -349,7 +349,7 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--grad_norm_log",
         action="store_true",
-        help="output gradient norm logs to gradient_logs.txt; without --skip_grad_norm only logging is performed / 勾配ノルムとlossのログをgradient_logs.txtに出力します。--skip_grad_normを付けない場合はスキップせずログのみ記録されます",
+        help="output gradient norm logs to gradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txt; without --skip_grad_norm only logging is performed / 勾配ノルムとlossのログをgradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txtに出力します。--skip_grad_normを付けない場合はスキップせずログのみ記録されます",
     )
 
 

--- a/train_network.py
+++ b/train_network.py
@@ -859,7 +859,8 @@ class NetworkTrainer:
             # 勾配ノルムの履歴を保持するキュー
             moving_avg_window = deque(maxlen=200)
             log_buffer = []
-            log_file_path = "gradient_logs.txt"
+            model_name = train_util.default_if_none(args.output_name, train_util.DEFAULT_LAST_OUTPUT_NAME)
+            log_file_path = f"gradient_logs+{model_name}.txt"
 
             # ログ用のヘッダーを書き出す
             if log_grad_norm:
@@ -1178,6 +1179,11 @@ class NetworkTrainer:
 
         # metadata["ss_epoch"] = str(num_train_epochs)
         metadata["ss_training_finished_at"] = str(time.time())
+
+        if log_grad_norm and len(log_buffer) > 0:
+            with open(log_file_path, "a") as f:
+                f.writelines(log_buffer)
+            log_buffer.clear()
 
         if is_main_process:
             network = accelerator.unwrap_model(network)


### PR DESCRIPTION
## Summary
- ensure final gradient norm logs are flushed to disk
- name gradient log file using the LoRA model name
- document new filename in help and README

## Testing
- `python -m py_compile train_network.py library/sdxl_train_util.py`
