### PR TITLE
Add configurable grad norm skip threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 | オプション | 機能概要 | 既定値 ↔ 指定時 | 備考・出典 |
 | --- | --- | --- | --- |
 | `--downscale_freq_shift` | `library/sdxl_original_unet.py` 内の `get_timestep_embedding()` に渡す **`downscale_freq_shift`** を切り替えます。 | 0.0 → **1.0** | 過去に 1.0 だったものが 0.0 に変更になった経緯あり（本家 PR [#1187](https://github.com/kohya-ss/sd-scripts/pull/1187)）。キャラクター性を学習させるタスクでは 1.0 の方が定着しやすい印象。 |
-| `--skip_grad_norm` | 直近 **200 step のnormの移動平均 + 2.5 σ** を閾値にし、それを超えた **step をスキップ**（パラメータ更新を無視）します。 | ― | 上限などはソース内の定数で調整可。勾配爆発の瞬間を丸ごと飛ばすことで安定化を狙う実験的機能。 |
+| `--skip_grad_norm` | 直近 **200 step のnormの移動平均 + 2.5 σ** を閾値にし、それを超えた **step をスキップ**（パラメータ更新を無視）します。`--skip_grad_norm_max` で動的閾値の上限を指定可能。 | ― | 勾配爆発の瞬間を丸ごと飛ばすことで安定化を狙う実験的機能。 |
+| `--skip_grad_norm_max` | `--skip_grad_norm` 使用時の dynamic_threshold の上限値を指定します。省略時は無制限。 | ― |  |
 | `--grad_norm_log` | **100 step ごと**に `(epoch, step, norm, threshold, loss)` を `gradient_logs+LoRAファイル名.txt` に追記します。`--skip_grad_norm` を付けない場合はスキップせずログのみ記録されます。既存ファイルがあれば上書き。 | ― | 閾値設定の妥当性チェックや勾配爆発の確認に利用。 |
 | `--te_mlp_fc_only` | Text Encoder（TE）の学習対象を **MLP (FC) 層のみに限定**します。 | TE 全層 ↔ **MLP のみ** | 本家 PR [#1964](https://github.com/kohya-ss/sd-scripts/pull/1964) 以前の挙動を再現。単純キーワードでキャラを学習する場合、MLP だけの方が安定しやすい印象。 |
 

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -347,6 +347,12 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
         help="skip step if gradient norm exceeds moving average + 2.5 sigma / 勾配ノルムが移動平均+2.5σを超える場合にステップをスキップする",
     )
     parser.add_argument(
+        "--skip_grad_norm_max",
+        type=float,
+        default=None,
+        help="upper bound of dynamic threshold for --skip_grad_norm; no limit if omitted / skip_grad_norm 使用時の dynamic_threshold の上限値。省略時は無制限",
+    )
+    parser.add_argument(
         "--grad_norm_log",
         action="store_true",
         help="output gradient norm logs to gradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txt; without --skip_grad_norm only logging is performed / 勾配ノルムとlossのログをgradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txtに出力します。--skip_grad_normを付けない場合はスキップせずログのみ記録されます",


### PR DESCRIPTION
## Summary
- add `--skip_grad_norm_max` option for SDXL training scripts
- log `skip_grad_norm_max` value and apply it inside gradient skipping logic
- document the new option

## Testing
- `python -m py_compile train_network.py library/sdxl_train_util.py`