### PR TITLE
Add options for gradient norm handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 | `--skip_grad_norm` | 直近 **200 step のnormの移動平均 + 2.5 σ** を閾値にし、それを超えた **step をスキップ**（パラメータ更新を無視）します。`--skip_grad_norm_max` で動的閾値の上限を指定可能。 | ― | 勾配爆発の瞬間を丸ごと飛ばすことで安定化を狙う実験的機能。 |
 | `--skip_grad_norm_max` | `--skip_grad_norm` 使用時の dynamic_threshold の上限値を指定します。省略時は無制限。 | ― | 参考：200000 |
 | `--grad_norm_log` | **100 step ごと**に `(epoch, step, norm, threshold, loss)` を `gradient_logs+LoRAファイル名.txt` に追記します。`--skip_grad_norm` を付けない場合はスキップせずログのみ記録されます。既存ファイルがあれば上書き。 | ― | 閾値設定の妥当性チェックや勾配爆発の確認に利用。 |
+| `--nan_to_window` | NaN を移動平均窓へ入れる | False ↔ **True** | 現行互換が既定 |
+| `--inf_to_window` | Inf を移動平均窓へ入れる | False ↔ **True** | 同上 |
+| `--skip_nan_immediate` / `--no-skip_nan_immediate` | NaN が出た step を閾値に関係なく skip | **True** ↔ False | “安全が既定” |
+| `--skip_inf_immediate` / `--no-skip_inf_immediate` | Inf が出た step を同上 | **True** ↔ False | Inf は破壊力大なので既定で True を維持 |
+| `--auto_cap_release` | 停滞と判断したら一時的にキャップを開放する | False ↔ **True** | |
+| `--cap_release_trigger_ratio` | `dynamic_threshold ≥ ratio × skip_grad_norm_max` が連続 `trigger_steps` 回続いたら発動 | 0.66 | |
+| `--cap_release_trigger_steps` | 〃 | 200 | |
+| `--cap_release_length` | 発動後、何 step キャップを開放するか | 200 | |
+| `--cap_release_scale` | 開放中に `skip_grad_norm_max` を何倍にするか | 3.0 | |
 | `--te_mlp_fc_only` | Text Encoder（TE）の学習対象を **MLP (FC) 層のみに限定**します。 | TE 全層 ↔ **MLP のみ** | 本家 PR [#1964](https://github.com/kohya-ss/sd-scripts/pull/1964) 以前の挙動を再現。単純キーワードでキャラを学習する場合、MLP だけの方が安定しやすい印象。 |
 
 

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -357,6 +357,57 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
         action="store_true",
         help="output gradient norm logs to gradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txt; without --skip_grad_norm only logging is performed / 勾配ノルムとlossのログをgradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txtに出力します。--skip_grad_normを付けない場合はスキップせずログのみ記録されます",
     )
+    parser.add_argument(
+        "--nan_to_window",
+        action="store_true",
+        help="add NaN gradient norm to moving average window / NaN を移動平均窓に追加する",
+    )
+    parser.add_argument(
+        "--inf_to_window",
+        action="store_true",
+        help="add Inf gradient norm to moving average window / Inf を移動平均窓に追加する",
+    )
+    parser.add_argument(
+        "--skip_nan_immediate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="skip step immediately if gradient norm is NaN / NaN が出た step を閾値に関係なくスキップする",
+    )
+    parser.add_argument(
+        "--skip_inf_immediate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="skip step immediately if gradient norm is Inf / Inf が出た step を閾値に関係なくスキップする",
+    )
+    parser.add_argument(
+        "--auto_cap_release",
+        action="store_true",
+        help="temporarily relax skip_grad_norm_max when stagnation detected / 停滞時に一時的にキャップを緩和する",
+    )
+    parser.add_argument(
+        "--cap_release_trigger_ratio",
+        type=float,
+        default=0.66,
+        help="trigger ratio for --auto_cap_release / auto_cap_release 発動の閾値比率",
+    )
+    parser.add_argument(
+        "--cap_release_trigger_steps",
+        type=int,
+        default=200,
+        help="trigger steps for --auto_cap_release / auto_cap_release 発動までの連続ステップ数",
+    )
+    parser.add_argument(
+        "--cap_release_length",
+        type=int,
+        default=200,
+        help="release length in steps for --auto_cap_release / auto_cap_release 発動後の開放ステップ数",
+    )
+    parser.add_argument(
+        "--cap_release_scale",
+        type=float,
+        default=3.0,
+        help="multiplier for skip_grad_norm_max during release / 開放中の skip_grad_norm_max の倍率",
+    )
 
 
 def verify_sdxl_training_args(args: argparse.Namespace, supportTextEncoderCaching: bool = True):


### PR DESCRIPTION
## Summary
- add new options for NaN/Inf handling and skip_grad_norm cap release
- implement new logic in gradient norm check
- update readme with details
- add Japanese comments explaining cap release logic

## Testing
- `python3 -m py_compile train_network.py library/sdxl_train_util.py`


------
https://chatgpt.com/codex/tasks/task_e_683a716a22548325a2539475256bf0df