### PR TITLE
Add options for gradient norm handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 | `--skip_grad_norm` | 直近 **200 step のnormの移動平均 + 2.5 σ** を閾値にし、それを超えた **step をスキップ**（パラメータ更新を無視）します。`--skip_grad_norm_max` で動的閾値の上限を指定可能。 | ― | 勾配爆発の瞬間を丸ごと飛ばすことで安定化を狙う実験的機能。 |
 | `--skip_grad_norm_max` | `--skip_grad_norm` 使用時の dynamic_threshold の上限値を指定します。省略時は無制限。 | ― | 参考：200000 |
 | `--grad_norm_log` | **100 step ごと**に `(epoch, step, norm, threshold, loss)` を `gradient_logs+LoRAファイル名.txt` に追記します。`--skip_grad_norm` を付けない場合はスキップせずログのみ記録されます。既存ファイルがあれば上書き。 | ― | 閾値設定の妥当性チェックや勾配爆発の確認に利用。 |
+| `--nan_to_window` | NaN を移動平均窓へ入れる | False ↔ **True** | 現行互換が既定 |
+| `--inf_to_window` | Inf を移動平均窓へ入れる | False ↔ **True** | 同上 |
+| `--skip_nan_immediate` / `--no-skip_nan_immediate` | NaN が出た step を閾値に関係なく skip | **True** ↔ False | “安全が既定” |
+| `--skip_inf_immediate` / `--no-skip_inf_immediate` | Inf が出た step を同上 | **True** ↔ False | Inf は破壊力大なので既定で True を維持 |
+| `--auto_cap_release` | 停滞と判断したら一時的にキャップを開放する | False ↔ **True** | |
+| `--cap_release_trigger_ratio` | `dynamic_threshold ≥ ratio × skip_grad_norm_max` が連続 `trigger_steps` 回続いたら発動 | 0.66 | |
+| `--cap_release_trigger_steps` | 〃 | 200 | |
+| `--cap_release_length` | 発動後、何 step キャップを開放するか | 200 | |
+| `--cap_release_scale` | 開放中に `skip_grad_norm_max` を何倍にするか | 3.0 | |
 | `--te_mlp_fc_only` | Text Encoder（TE）の学習対象を **MLP (FC) 層のみに限定**します。 | TE 全層 ↔ **MLP のみ** | 本家 PR [#1964](https://github.com/kohya-ss/sd-scripts/pull/1964) 以前の挙動を再現。単純キーワードでキャラを学習する場合、MLP だけの方が安定しやすい印象。 |
 
 

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -357,6 +357,57 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
         action="store_true",
         help="output gradient norm logs to gradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txt; without --skip_grad_norm only logging is performed / 勾配ノルムとlossのログをgradient_logs+LoRA\u30d5\u30a1\u30a4\u30eb\u540d.txtに出力します。--skip_grad_normを付けない場合はスキップせずログのみ記録されます",
     )
+    parser.add_argument(
+        "--nan_to_window",
+        action="store_true",
+        help="add NaN gradient norm to moving average window / NaN を移動平均窓に追加する",
+    )
+    parser.add_argument(
+        "--inf_to_window",
+        action="store_true",
+        help="add Inf gradient norm to moving average window / Inf を移動平均窓に追加する",
+    )
+    parser.add_argument(
+        "--skip_nan_immediate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="skip step immediately if gradient norm is NaN / NaN が出た step を閾値に関係なくスキップする",
+    )
+    parser.add_argument(
+        "--skip_inf_immediate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="skip step immediately if gradient norm is Inf / Inf が出た step を閾値に関係なくスキップする",
+    )
+    parser.add_argument(
+        "--auto_cap_release",
+        action="store_true",
+        help="temporarily relax skip_grad_norm_max when stagnation detected / 停滞時に一時的にキャップを緩和する",
+    )
+    parser.add_argument(
+        "--cap_release_trigger_ratio",
+        type=float,
+        default=0.66,
+        help="trigger ratio for --auto_cap_release / auto_cap_release 発動の閾値比率",
+    )
+    parser.add_argument(
+        "--cap_release_trigger_steps",
+        type=int,
+        default=200,
+        help="trigger steps for --auto_cap_release / auto_cap_release 発動までの連続ステップ数",
+    )
+    parser.add_argument(
+        "--cap_release_length",
+        type=int,
+        default=200,
+        help="release length in steps for --auto_cap_release / auto_cap_release 発動後の開放ステップ数",
+    )
+    parser.add_argument(
+        "--cap_release_scale",
+        type=float,
+        default=3.0,
+        help="multiplier for skip_grad_norm_max during release / 開放中の skip_grad_norm_max の倍率",
+    )
 
 
 def verify_sdxl_training_args(args: argparse.Namespace, supportTextEncoderCaching: bool = True):

--- a/train_network.py
+++ b/train_network.py
@@ -854,8 +854,17 @@ class NetworkTrainer:
         skip_grad_norm = getattr(args, "skip_grad_norm", False)
         log_grad_norm = getattr(args, "grad_norm_log", False)
         skip_grad_norm_max = getattr(args, "skip_grad_norm_max", None)
+        nan_to_window = getattr(args, "nan_to_window", False)
+        inf_to_window = getattr(args, "inf_to_window", False)
+        skip_nan_immediate = getattr(args, "skip_nan_immediate", True)
+        skip_inf_immediate = getattr(args, "skip_inf_immediate", True)
+        auto_cap_release = getattr(args, "auto_cap_release", False)
+        cap_release_trigger_ratio = getattr(args, "cap_release_trigger_ratio", 0.66)
+        cap_release_trigger_steps = getattr(args, "cap_release_trigger_steps", 200)
+        cap_release_length = getattr(args, "cap_release_length", 200)
+        cap_release_scale = getattr(args, "cap_release_scale", 3.0)
         logger.info(
-            f"skip_grad_norm: {skip_grad_norm}, grad_norm_log: {log_grad_norm}, skip_grad_norm_max: {skip_grad_norm_max}"
+            f"skip_grad_norm: {skip_grad_norm}, grad_norm_log: {log_grad_norm}, skip_grad_norm_max: {skip_grad_norm_max}, auto_cap_release: {auto_cap_release}"
         )
         use_grad_norm = skip_grad_norm or log_grad_norm
         if use_grad_norm:
@@ -870,7 +879,11 @@ class NetworkTrainer:
                 with open(log_file_path, "w") as f:
                     f.write("Epoch,Step,Gradient Norm,Threshold,Loss\n")
 
+            trigger_count = 0
+            cap_release_counter = 0
+
             def check_gradients_and_skip_update(model, epoch, step, loss_val):
+                nonlocal trigger_count, cap_release_counter
                 device = next(model.parameters()).device
                 gradient_norm = torch.tensor(0.0, device=device)
 
@@ -882,20 +895,44 @@ class NetworkTrainer:
                             gradient_norm += grad.norm() ** 2
                 gradient_norm = gradient_norm.sqrt().item()
 
-                # 勾配ノルムがNaNやinfの場合は窓に追加しない
-                if not math.isnan(gradient_norm) and not math.isinf(gradient_norm):
+                is_nan = math.isnan(gradient_norm)
+                is_inf = math.isinf(gradient_norm)
+
+                if not is_nan and not is_inf:
                     moving_avg_window.append(gradient_norm)
+                else:
+                    if is_nan and nan_to_window:
+                        moving_avg_window.append(gradient_norm)
+                    if is_inf and inf_to_window:
+                        moving_avg_window.append(gradient_norm)
 
                 # 窓がいっぱいになったら平均+2.5σを計算
                 if len(moving_avg_window) == moving_avg_window.maxlen:
                     mean_norm = np.mean(moving_avg_window)
                     std_norm = np.std(moving_avg_window)
-                    dynamic_threshold = mean_norm + 2.5 * std_norm
-                    if skip_grad_norm_max is not None and dynamic_threshold > skip_grad_norm_max:
-                        dynamic_threshold = skip_grad_norm_max
+                    dynamic_threshold_pre_cap = mean_norm + 2.5 * std_norm
                 else:
-                    # 窓が埋まるまでは十分大きい値をセットしてスキップされないようにする
-                    dynamic_threshold = 200_000
+                    dynamic_threshold_pre_cap = 200_000
+
+                effective_max = skip_grad_norm_max
+                if auto_cap_release and skip_grad_norm_max is not None:
+                    if cap_release_counter > 0:
+                        effective_max = skip_grad_norm_max * cap_release_scale
+                        cap_release_counter -= 1
+                    else:
+                        if not math.isnan(dynamic_threshold_pre_cap) and dynamic_threshold_pre_cap >= cap_release_trigger_ratio * skip_grad_norm_max:
+                            trigger_count += 1
+                            if trigger_count >= cap_release_trigger_steps:
+                                cap_release_counter = cap_release_length
+                                trigger_count = 0
+                        else:
+                            trigger_count = 0
+
+                dynamic_threshold = dynamic_threshold_pre_cap
+                if effective_max is not None and dynamic_threshold > effective_max:
+                    dynamic_threshold = effective_max
+                if len(moving_avg_window) < moving_avg_window.maxlen:
+                    dynamic_threshold = dynamic_threshold_pre_cap
 
                 # ログをファイルに出力
                 if log_grad_norm:
@@ -910,11 +947,9 @@ class NetworkTrainer:
                 if not skip_grad_norm:
                     return False
 
-                # 勾配ノルムがNaNやinfの場合もステップをスキップ
-                if math.isnan(gradient_norm) or math.isinf(gradient_norm):
+                if (is_nan and skip_nan_immediate) or (is_inf and skip_inf_immediate):
                     return True
 
-                # 閾値を超えた場合はこのステップをスキップ
                 return gradient_norm > dynamic_threshold
         else:
             def check_gradients_and_skip_update(model, epoch, step, loss_val):


### PR DESCRIPTION
## Summary
- add new options for NaN/Inf handling and skip_grad_norm cap release
- implement new logic in gradient norm check
- update readme with details

## Testing
- `python3 -m py_compile train_network.py library/sdxl_train_util.py`


------
https://chatgpt.com/codex/tasks/task_e_683a716a22548325a2539475256bf0df