### PR TITLE
Fix optimizer stats after averaging

### DIFF
--- a/tests/test_avg_cp.py
+++ b/tests/test_avg_cp.py
@@ -7,3 +7,11 @@ def test_uniform_average():
     avg = average_state_dicts([sd1, sd2], mode='uniform')
     assert torch.allclose(avg['lora_a'], torch.tensor(2.0))
     assert torch.allclose(avg['lora_b'], torch.tensor(4.0))
+
+
+def test_key_mismatch():
+    sd1 = {'lora_a': torch.tensor(1.0), 'lora_b': torch.tensor(3.0)}
+    sd2 = {'lora_a': torch.tensor(3.0), 'lora_c': torch.tensor(5.0)}
+    avg = average_state_dicts([sd1, sd2], mode='uniform')
+    assert list(avg.keys()) == ['lora_a']
+    assert torch.allclose(avg['lora_a'], torch.tensor(2.0))

--- a/train_network.py
+++ b/train_network.py
@@ -18,7 +18,7 @@ from library.device_utils import init_ipex, clean_memory_on_device
 
 init_ipex()
 
-from accelerate.utils import set_seed
+from accelerate.utils import set_seed, DistributedType
 from diffusers import DDPMScheduler
 from library import deepspeed_utils, model_util
 
@@ -1321,8 +1321,18 @@ class NetworkTrainer:
                 if len(cp_window) == args.avg_window:
                     avg_sd = average_state_dicts(list(cp_window), args.avg_mode)
                     accelerator.unwrap_model(network).load_state_dict(avg_sd, strict=False)
-                    optimizer.state.clear()
-                    accelerator.wait_for_everyone()
+                    if args.avg_reset_stats:
+                        for p_state in optimizer.state.values():
+                            p_state["step"] = max(p_state.get("step", 0), 1)
+                            for buf in ("exp_avg", "exp_avg_sq", "exp_avg_max"):
+                                if buf in p_state and isinstance(p_state[buf], torch.Tensor):
+                                    p_state[buf].zero_()
+                    if accelerator.distributed_type != DistributedType.NO:
+                        accelerator.wait_for_everyone()
+                        accelerator.broadcast_model(network)
+                        accelerator.wait_for_everyone()
+                    else:
+                        accelerator.wait_for_everyone()
 
             # end of epoch
 
@@ -1479,6 +1489,12 @@ def setup_parser() -> argparse.ArgumentParser:
         default="uniform",
         choices=["uniform", "ema", "metric"],
         help="averaging mode: uniform, ema or metric / 平均化モード",
+    )
+    parser.add_argument(
+        "--avg_reset_stats",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="reset optimizer stats after averaging / 平均化後にOptimizer統計をリセットする",
     )
     # parser.add_argument("--loraplus_lr_ratio", default=None, type=float, help="LoRA+ learning rate ratio")
     # parser.add_argument("--loraplus_unet_lr_ratio", default=None, type=float, help="LoRA+ UNet learning rate ratio")

--- a/train_network.py
+++ b/train_network.py
@@ -47,6 +47,7 @@ from library.avg_ckpt_util import (
     load_lora_state_dict,
 )
 from library.utils import setup_logging, add_logging_arguments
+from accelerate.utils import broadcast
 
 setup_logging()
 import logging
@@ -1323,13 +1324,13 @@ class NetworkTrainer:
                     accelerator.unwrap_model(network).load_state_dict(avg_sd, strict=False)
                     if args.avg_reset_stats:
                         for p_state in optimizer.state.values():
-                            p_state["step"] = max(p_state.get("step", 0), 1)
+                            p_state["step"] = p_state.get("step", 0)  # keep real count
                             for buf in ("exp_avg", "exp_avg_sq", "exp_avg_max"):
                                 if buf in p_state and isinstance(p_state[buf], torch.Tensor):
                                     p_state[buf].zero_()
                     if accelerator.distributed_type != DistributedType.NO:
-                        accelerator.wait_for_everyone()
-                        accelerator.broadcast_model(network)
+                        sd = broadcast(accelerator.unwrap_model(network).state_dict())
+                        accelerator.unwrap_model(network).load_state_dict(sd, strict=False)
                         accelerator.wait_for_everyone()
                     else:
                         accelerator.wait_for_everyone()


### PR DESCRIPTION
## Summary
- reset optimizer state safely when averaging LoRA checkpoints
- add `--avg_reset_stats` flag
- warn on key mismatches during averaging
- broadcast averaged weights in distributed setups
- extend averaging tests for key mismatch

## Testing
- `python -m py_compile train_network.py library/avg_ckpt_util.py tests/test_avg_cp.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6868bc7519108325b6f15eeee5f71e74