### PR TITLE
Add --fp16_safe_norms option

### DIFF
--- a/library/maruo_global_config.py
+++ b/library/maruo_global_config.py
@@ -5,4 +5,4 @@ Imported as `import maruo_global_config as cfg`.
 # Boolean flags – default is False (= option not supplied)
 downscale_freq_shift: bool = False
 te_mlp_fc_only: bool = False
-
+fp16_safe_norms: bool = False

--- a/sdxl_train_network.py
+++ b/sdxl_train_network.py
@@ -181,6 +181,11 @@ def setup_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Enable TE-MLP-FC-only training",
     )
+    parser.add_argument(
+        "--fp16_safe_norms",
+        action="store_true",
+        help="Compute reduction ops (LayerNorm/GroupNorm/Softmax) in fp32 while keeping weights/other ops in fp16.",
+    )
     return parser
 
 
@@ -193,6 +198,7 @@ if __name__ == "__main__":
     # map CLI options to global config
     maruoCfg.downscale_freq_shift = bool(getattr(args, "downscale_freq_shift", False))
     maruoCfg.te_mlp_fc_only = bool(getattr(args, "te_mlp_fc_only", False))
+    maruoCfg.fp16_safe_norms = bool(getattr(args, "fp16_safe_norms", False))
 
     trainer = SdxlNetworkTrainer()
     trainer.train(args)


### PR DESCRIPTION
fp16での学習用オプションの追加

 追加オプション

  - --fp16_safe_norms: LayerNorm/GroupNorm/Softmax など縮約系のみfp32で演算し、重みと他の演算はfp16のまま維持。

  実装ポイント

  - sdxl_train_network.py
      - --fp16_safe_norms を追加し、library/maruo_global_config.py の fp16_safe_norms に反映。
  - library/maruo_global_config.py
      - fp16_safe_norms: bool = False を追加。
  - library/sdxl_original_unet.py
      - GroupNorm: GroupNorm32.forward で fp16_safe_norms 有効時は入力のみ float() に上げて演算・結果を元dtypeに戻す。
      - LayerNorm: BasicTransformerBlock.forward_body 内の norm1/2/3 を F.layer_norm でfp32演算→出力を元dtypeに戻す。
      - GroupNorm(Transformer2Dの最初の正規化): Transformer2DModel.forward で F.group_norm をfp32演算→出力を元dtypeに
  戻す。
      - Softmax: CrossAttention._attention の softmax を fp32 演算→出力を元dtypeに戻す。

  使い方例

  - fp16でLoRA学習しつつ安全なNormにする例（バッチ1）
      - accelerate launch sdxl_train_network.py --mixed_precision fp16 --fp16_safe_norms ...
      - 既存の反復学習やdropout設定は従来どおりの引数で併用可能です。

  注意点

  - Softmaxのfp32化は「通常のAttention経路」に適用されます。--xformers や --sdpa を有効にすると、それらの実装内部の
  softmaxには介入できません（Normはどの経路でもfp32化されます）。
  - パラメータはfp16のまま保持され、演算時に一時的にfp32へキャストします（勾配は自動で戻ります）。
