### PR TITLE
Log fp16 safe norms option

### DIFF
--- a/sdxl_train_network.py
+++ b/sdxl_train_network.py
@@ -199,6 +199,9 @@ if __name__ == "__main__":
     maruoCfg.downscale_freq_shift = bool(getattr(args, "downscale_freq_shift", False))
     maruoCfg.te_mlp_fc_only = bool(getattr(args, "te_mlp_fc_only", False))
     maruoCfg.fp16_safe_norms = bool(getattr(args, "fp16_safe_norms", False))
+    logger.info(
+        f"fp16_safe_norms is {'enabled' if maruoCfg.fp16_safe_norms else 'disabled'}"
+    )
 
     trainer = SdxlNetworkTrainer()
     trainer.train(args)


### PR DESCRIPTION
## Summary
- log whether `--fp16_safe_norms` was specified when launching `sdxl_train_network`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd2ee0c7948325bda19f6eed602911