### PR TITLE
feat: te options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | `--downscale_freq_shift` | `0.0` | **時間埋め込みの周波数ダウンスケール**を 1.0 (従来値) に戻す。キャラクター LoRA で *identity* が定着しやすい傾向。 | `library/sdxl_original_unet.py`<br>本家 PR #1187 で 1.0→0.0 に変更された挙動を選択式に復活。|
 | `--te_mlp_fc_only` | 全層 | Text Encoder の学習対象を **MLP (全結合) 層だけ**に限定。キーワードベースのキャラ LoRA で“語彙を固めつつ柔軟性を保つ”目的。 | 本家 PR #1964 以前の挙動を再現。|
 | `--fp16_safe_norms` | `False` | 縮約系（LayerNorm/GroupNorm/Softmax）だけ **fp32 で演算**し、重みと他演算は fp16 のまま。fp16 + 小バッチ（例: `batch_size=1`）で学習安定性を向上。 | `library/sdxl_original_unet.py` にラッパ実装。<br>注意: Softmax の fp32 化は通常のAttention経路のみ（`--xformers`/`--sdpa` 使用時は各実装に依存）。Normは全経路でfp32化。|
+| `--network_te_train_targets`,<br>`--text_encoder_lr1`,<br>`--text_encoder_lr2` | `None` | SDXLの2系統Text EncoderのLoRA学習対象と学習率を個別に制御。未指定時は従来通り両方を同じ学習率で更新。 | 詳細は [docs/sdxl_lora_te_options-ja.md](docs/sdxl_lora_te_options-ja.md) を参照。|
 | `--skip_grad_norm` | ― | 直近 *N = 200* step の **勾配 L2 ノルムの移動平均 + 2.5σ** を動的しきい値とし、超過 step の更新をスキップ。NaN/Inf も既定でスキップ。 | 破綻防止・fp16 の安定化補助。しきい値は `--skip_grad_norm_max` で上限可。|
 | `--skip_grad_norm_max` | 無制限 | `--skip_grad_norm` が計算する動的しきい値の**上限キャップ**。 | 例: `--skip_grad_norm_max 200000` |
 | `--grad_norm_log` | 無効 | 100 step ごとに **(epoch, step, norm, threshold, loss, ThreshOff)** を `gradient_logs+<LoRA名>.txt` へ追記。<br>ThreshOffは、0=閾値有効, 1=閾値がNaNで無効, 2=閾値が`--idle_free_phase`で無効 | スキップを *OFF* にすれば純ログモード。 |

--- a/docs/sdxl_lora_te_options-ja.md
+++ b/docs/sdxl_lora_te_options-ja.md
@@ -1,0 +1,44 @@
+# SDXL LoRA テキストエンコーダー設定オプション
+
+SDXL の LoRA 学習では ViT-L (Text Encoder 1) と BiG-G (Text Encoder 2) の 2 系統が同時に利用されます。今回追加したオプションを使うと、学習対象となるテキストエンコーダーを選択したり、それぞれに個別の学習率を割り当てたりできます。いずれも既定値は従来と同じで、オプションを指定しなければ両方のテキストエンコーダーが同じ学習率で学習されます。
+
+## 追加された引数
+
+### `--network_te_train_targets`
+- 形式: `--network_te_train_targets {te1|te2} [{te1|te2} ...]`
+- `te1` は ViT-L、`te2` は BiG-G を指します。
+- 未指定時は両方を学習します。
+- `te2` を指定した場合は SDXL の 2 本目のテキストエンコーダーが読み込まれている必要があります。SD1.x/SD2.x など 1 本だけの場合に `te2` を指定するとエラーになります。
+- `--network_train_unet_only` が指定されているときは無効です。
+
+### `--text_encoder_lr1`, `--text_encoder_lr2`
+- それぞれ Text Encoder 1 / 2 の学習率。未指定時は `--text_encoder_lr`、さらに未指定なら `--learning_rate` を使用します。
+- 対象外のテキストエンコーダーに対して値を指定しても無視されます。例: `--network_te_train_targets te2` のときに `--text_encoder_lr1` を指定しても警告を出してスキップします。
+- 値に `0` を指定するとそのテキストエンコーダーの LoRA パラメータは最適化対象から除外されます。
+
+## 使用例
+
+```bash
+# Text Encoder 1 のみを学習し、学習率は共通値 (learning_rate) を使用
+python sdxl_train_network.py \
+  --network_module networks.lora \
+  --network_te_train_targets te1 \
+  --train_data_dir <datasets> ...
+
+# 両方学習するが Text Encoder 1 を低い学習率に抑える
+python sdxl_train_network.py \
+  --network_te_train_targets te1 te2 \
+  --text_encoder_lr1 5e-6 \
+  --text_encoder_lr2 1e-5 \
+  --text_encoder_lr 1e-5 ...
+
+# TOML 設定ファイルの例
+[train]
+network_te_train_targets = ["te2"]
+text_encoder_lr2 = 3.0e-6
+```
+
+## 注意点
+- 既定挙動を変えないように設計されています。オプションを指定しなければ従来通り両方のテキストエンコーダーが同じ学習率で更新されます。
+- LoRA ネットワーク以外 (DyLoRA / LoRA-FA など) でも同じオプションが利用できます。
+- `text_encoder_lr1` / `text_encoder_lr2` を指定していても、該当するテキストエンコーダーを学習対象から外すと自動的に無視されます。

--- a/tools/sdxl_prune_te.py
+++ b/tools/sdxl_prune_te.py
@@ -1,0 +1,136 @@
+# SDXL用LoRAからテキストエンコーダー(TE1/TE2)向けのLoRA層を取り除いた派生ファイルを一括生成するユーティリティです。
+# 元のLoRAを読み込み、TE1のみ削除・TE2のみ削除・両方削除の3パターンを出力します。
+#
+# 使い方の例:
+#   python tools/sdxl_prune_te.py my_lora.safetensors --output-dir pruned --overwrite
+#   python tools/sdxl_prune_te.py my_lora.safetensors --suffix-te1 _clipL --suffix-te2 _clipG
+
+import argparse
+import logging
+import os
+from typing import Dict, Iterable, Tuple
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import load_file, save_file
+
+from library.utils import add_logging_arguments, setup_logging
+
+logger = logging.getLogger(__name__)
+
+SDXL_TE1_PREFIX = "lora_te1"
+SDXL_TE2_PREFIX = "lora_te2"
+
+
+def load_lora(path: str) -> Tuple[Dict[str, torch.Tensor], str, Dict[str, str]]:
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".safetensors":
+        state_dict = load_file(path)
+        metadata: Dict[str, str] = {}
+        try:
+            with safe_open(path, framework="pt", device="cpu") as st_file:
+                metadata = dict(st_file.metadata())
+        except Exception as ex:  # metadata が壊れていても処理は続行する
+            logger.warning("メタデータの読み込みに失敗しました: %s", ex)
+        return state_dict, "safetensors", metadata
+
+    state_dict = torch.load(path, map_location="cpu")
+    if not isinstance(state_dict, dict):
+        raise TypeError("LoRAファイルはstate_dict形式である必要があります")
+    return state_dict, "pt", {}
+
+
+def save_lora(state_dict: Dict[str, torch.Tensor], path: str, fmt: str, metadata: Dict[str, str]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if fmt == "safetensors":
+        save_file(state_dict, path, metadata=metadata or {})
+    else:
+        torch.save(state_dict, path)
+
+
+def strip_by_prefix(state_dict: Dict[str, torch.Tensor], prefixes: Iterable[str]) -> Tuple[Dict[str, torch.Tensor], int]:
+    drop_prefixes = tuple(prefixes)
+    removed = 0
+    filtered: Dict[str, torch.Tensor] = {}
+    for key, value in state_dict.items():
+        lora_id = key.split(".")[0]
+        if any(lora_id.startswith(prefix) for prefix in drop_prefixes):
+            removed += 1
+            continue
+        filtered[key] = value
+    return filtered, removed
+
+
+def build_output_path(input_path: str, output_dir: str, suffix: str) -> str:
+    base_name = os.path.splitext(os.path.basename(input_path))[0]
+    ext = os.path.splitext(input_path)[1]
+    return os.path.join(output_dir, f"{base_name}{suffix}{ext}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="SDXL LoRAからText Encoder(TE)のLoRA層を削除したバリエーションを同時に出力するユーティリティ"
+    )
+    parser.add_argument("model", type=str, help="入力となるLoRAファイル (.safetensorsまたは.pt)")
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="出力先ディレクトリ。省略時は入力ファイルと同じ場所に保存",
+    )
+    parser.add_argument(
+        "--suffix-te1",
+        type=str,
+        default="_no-te1",
+        help="TE1を削除したファイル名に付加するサフィックス",
+    )
+    parser.add_argument(
+        "--suffix-te2",
+        type=str,
+        default="_no-te2",
+        help="TE2を削除したファイル名に付加するサフィックス",
+    )
+    parser.add_argument(
+        "--suffix-both",
+        type=str,
+        default="_no-te12",
+        help="TE1とTE2両方を削除したファイル名に付加するサフィックス",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="既存の出力ファイルを上書きする")
+    add_logging_arguments(parser)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    setup_logging(args, reset=True)
+
+    output_dir = args.output_dir or os.path.dirname(os.path.abspath(args.model)) or "."
+
+    logger.info("LoRAを読み込み中: %s", args.model)
+    state_dict, fmt, metadata = load_lora(args.model)
+    logger.info("テンソル数: %d", len(state_dict))
+
+    variants = [
+        (args.suffix_te1, (SDXL_TE1_PREFIX,), "TE1のみ削除"),
+        (args.suffix_te2, (SDXL_TE2_PREFIX,), "TE2のみ削除"),
+        (args.suffix_both, (SDXL_TE1_PREFIX, SDXL_TE2_PREFIX), "TE1+TE2を削除"),
+    ]
+
+    for suffix, prefixes, label in variants:
+        output_path = build_output_path(args.model, output_dir, suffix)
+        if os.path.exists(output_path) and not args.overwrite:
+            logger.error("出力先が既に存在するためスキップしました: %s", output_path)
+            continue
+
+        filtered, removed = strip_by_prefix(state_dict, prefixes)
+        logger.info("%s: %d 個のLoRAパラメータを削除", label, removed)
+        if removed == 0:
+            logger.warning("%s 対象のパラメータが見つかりませんでした", label)
+
+        save_lora(filtered, output_path, fmt, metadata)
+        logger.info("保存しました: %s (残りテンソル %d)", output_path, len(filtered))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# SDXL LoRA テキストエンコーダー設定オプション

SDXL の LoRA 学習では ViT-L (Text Encoder 1) と BiG-G (Text Encoder 2) の 2 系統が同時に利用されます。今回追加したオプションを使うと、学習対象となるテキストエンコーダーを選択したり、それぞれに個別の学習率を割り当てたりできます。いずれも既定値は従来と同じで、オプションを指定しなければ両方のテキストエンコーダーが同じ学習率で学習されます。

## 追加された引数

### `--network_te_train_targets`
- 形式: `--network_te_train_targets {te1|te2} [{te1|te2} ...]`
- `te1` は ViT-L、`te2` は BiG-G を指します。
- 未指定時は両方を学習します。
- `te2` を指定した場合は SDXL の 2 本目のテキストエンコーダーが読み込まれている必要があります。SD1.x/SD2.x など 1 本だけの場合に `te2` を指定するとエラーになります。
- `--network_train_unet_only` が指定されているときは無効です。

### `--text_encoder_lr1`, `--text_encoder_lr2`
- それぞれ Text Encoder 1 / 2 の学習率。未指定時は `--text_encoder_lr`、さらに未指定なら `--learning_rate` を使用します。
- 対象外のテキストエンコーダーに対して値を指定しても無視されます。例: `--network_te_train_targets te2` のときに `--text_encoder_lr1` を指定しても警告を出してスキップします。
- 値に `0` を指定するとそのテキストエンコーダーの LoRA パラメータは最適化対象から除外されます。

## 使用例

```bash
# Text Encoder 1 のみを学習し、学習率は共通値 (learning_rate) を使用
python sdxl_train_network.py \
  --network_module networks.lora \
  --network_te_train_targets te1 \
  --train_data_dir <datasets> ...

# 両方学習するが Text Encoder 1 を低い学習率に抑える
python sdxl_train_network.py \
  --network_te_train_targets te1 te2 \
  --text_encoder_lr1 5e-6 \
  --text_encoder_lr2 1e-5 \
  --text_encoder_lr 1e-5 ...

# TOML 設定ファイルの例
[train]
network_te_train_targets = ["te2"]
text_encoder_lr2 = 3.0e-6
```

## 注意点
- 既定挙動を変えないように設計されています。オプションを指定しなければ従来通り両方のテキストエンコーダーが同じ学習率で更新されます。
- LoRA ネットワーク以外 (DyLoRA / LoRA-FA など) でも同じオプションが利用できます。
- `text_encoder_lr1` / `text_encoder_lr2` を指定していても、該当するテキストエンコーダーを学習対象から外すと自動的に無視されます。
