### PR TITLE
Feature/te lr after

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 | `--te_mlp_fc_only` | 全層 | Text Encoder の学習対象を **MLP (全結合) 層だけ**に限定。キーワードベースのキャラ LoRA で“語彙を固めつつ柔軟性を保つ”目的。 | 本家 PR #1964 以前の挙動を再現。|
 | `--fp16_safe_norms` | `False` | 縮約系（LayerNorm/GroupNorm/Softmax）だけ **fp32 で演算**し、重みと他演算は fp16 のまま。fp16 + 小バッチ（例: `batch_size=1`）で学習安定性を向上。 | `library/sdxl_original_unet.py` にラッパ実装。<br>注意: Softmax の fp32 化は通常のAttention経路のみ（`--xformers`/`--sdpa` 使用時は各実装に依存）。Normは全経路でfp32化。|
 | `--network_te_train_targets`,<br>`--text_encoder_lr1`,<br>`--text_encoder_lr2` | `None` | SDXLの2系統Text EncoderのLoRA学習対象と学習率を個別に制御。未指定時は従来通り両方を同じ学習率で更新。 | 詳細は [docs/sdxl_lora_te_options-ja.md](docs/sdxl_lora_te_options-ja.md) を参照。|
+| `--te-lr-after <ratio> <mult> [target]` | `None` | 総ステップ数に対する割合 `ratio` を超えたタイミングで、指定Text Encoder（`target=both/te1/te2`）の学習率に倍率 `mult` を一度だけ恒久適用。段切り的に後半だけLRを落ち着かせたいケース向け。 | `train_network.py` ベースで処理。`target=te2` は SDXL など TE2 を持つモデルのみ有効。`ratio` は 0〜1、小数指定可。 |
 | `--skip_grad_norm` | ― | 直近 *N = 200* step の **勾配 L2 ノルムの移動平均 + 2.5σ** を動的しきい値とし、超過 step の更新をスキップ。NaN/Inf も既定でスキップ。 | 破綻防止・fp16 の安定化補助。しきい値は `--skip_grad_norm_max` で上限可。|
 | `--skip_grad_norm_max` | 無制限 | `--skip_grad_norm` が計算する動的しきい値の**上限キャップ**。 | 例: `--skip_grad_norm_max 200000` |
 | `--grad_norm_log` | 無効 | 100 step ごとに **(epoch, step, norm, threshold, loss, ThreshOff)** を `--output_dir/gradient_logs+<LoRA名>.txt` へ追記。<br>ThreshOffは、0=閾値有効, 1=閾値がNaNで無効, 2=閾値が`--idle_free_phase`で無効 | スキップを *OFF* にすれば純ログモード。 |

--- a/train_network.py
+++ b/train_network.py
@@ -525,20 +525,23 @@ class NetworkTrainer:
 
         resume_step = self._te_lr_after_resume_step
         threshold = cfg.get("threshold_step")
+        completed_step = None
+        if resume_step is not None:
+            completed_step = max(0, resume_step - 1)
         if (
             self._te_lr_after_resumed
-            and resume_step is not None
+            and completed_step is not None
             and threshold is not None
-            and resume_step > threshold
+            and completed_step > threshold
         ):
             cfg["applied"] = True
-            cfg["applied_step"] = resume_step
+            cfg["applied_step"] = completed_step
             logger.info(
-                "te_lr_after: resume step %d exceeded threshold %d; assuming multiplier already applied / "
-                "te_lr_after: 再開ステップ %d がしきい値 %d を超えているため、倍率適用済みと見なします",
-                resume_step,
+                "te_lr_after: last completed step %d exceeded threshold %d; assuming multiplier already applied / "
+                "te_lr_after: 再開時点の完了ステップ %d がしきい値 %d を超えているため、倍率適用済みと見なします",
+                completed_step,
                 threshold,
-                resume_step,
+                completed_step,
                 threshold,
             )
     def assert_extra_args(self, args, train_dataset_group):


### PR DESCRIPTION
TE1/TE2 の学習率に対して、総ステップの指定％を超えた以降に指定倍率を恒久適用する（1回きり）

--te-lr-after [target]

総ステップ数に対する割合 ratio を超えたタイミングで、指定Text Encoder（target=both/te1/te2）の学習率に倍率 mult を一度だけ恒久適用。段切り的に後半だけLRを落ち着かせたいケース向け。

例
--te-lr-after 0.3 0.8 te1