### PR TITLE
refactor grad norm presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,8 @@
 | `--fp16_safe_norms` | `False` | 縮約系（LayerNorm/GroupNorm/Softmax）だけ **fp32 で演算**し、重みと他演算は fp16 のまま。fp16 + 小バッチ（例: `batch_size=1`）で学習安定性を向上。 | `library/sdxl_original_unet.py` にラッパ実装。<br>注意: Softmax の fp32 化は通常のAttention経路のみ（`--xformers`/`--sdpa` 使用時は各実装に依存）。Normは全経路でfp32化。|
 | `--network_te_train_targets`,<br>`--text_encoder_lr1`,<br>`--text_encoder_lr2` | `None` | SDXLの2系統Text EncoderのLoRA学習対象と学習率を個別に制御。未指定時は従来通り両方を同じ学習率で更新。 | 詳細は [docs/sdxl_lora_te_options-ja.md](docs/sdxl_lora_te_options-ja.md) を参照。|
 | `--te-lr-after <ratio> <mult> [target]` | `None` | 総ステップ数に対する割合 `ratio` を超えたタイミングで、指定Text Encoder（`target=both/te1/te2`）の学習率に倍率 `mult` を一度だけ恒久適用。段切り的に後半だけLRを落ち着かせたいケース向け。 | `train_network.py` ベースで処理。`target=te2` は SDXL など TE2 を持つモデルのみ有効。`ratio` は 0〜1、小数指定可。 |
-| `--skip_grad_norm` | ― | 直近 *N = 200* step の **勾配 L2 ノルムの移動平均 + 2.5σ** を動的しきい値とし、超過 step の更新をスキップ。NaN/Inf も既定でスキップ。 | 破綻防止・fp16 の安定化補助。しきい値は `--skip_grad_norm_max` で上限可。|
-| `--skip_grad_norm_max` | 無制限 | `--skip_grad_norm` が計算する動的しきい値の**上限キャップ**。 | 例: `--skip_grad_norm_max 200000` |
-| `--grad_norm_log` | 無効 | 100 step ごとに **(epoch, step, norm, threshold, loss, ThreshOff)** を `--output_dir/gradient_logs+<LoRA名>.txt` へ追記。<br>ThreshOffは、0=閾値有効, 1=閾値がNaNで無効, 2=閾値が`--idle_free_phase`で無効 | スキップを *OFF* にすれば純ログモード。 |
-| `--grad_cosine_log` | 無効 | 直前 step との **勾配コサイン類似度** を `grad_norm_log` に追加。 | 経路探索の可視化用。 |
-| `--nan_to_window`, `--inf_to_window` | `False` | NaN / Inf を移動平均窓に**含める／含めない**を切替。含めると *threshold* が NaN となり、窓サイズ分だけスキップ判定が無効化＝“ブレーキ解除”。 | fp16 で意図的にスパイクを許容したい実験用。 |
-| `--skip_nan_immediate`, `--skip_inf_immediate`<br>`--no-skip_nan_immediate`, `--no-skip_inf_immediate` | `True` | NaN / Inf が出た step を **無条件でスキップするかどうか**。スキップしない場合は GradScaler に値が渡るため、fp16 で scale 自動調整が効く。 | |
-| `--nan_inf_until_step N` | `None` | 上記 4 項目の設定を **グローバル step ≤ N** の間だけ有効化し、その後は既定動作に戻す。 | 学習前半だけ GradScaler を安定させ、後半は scale 上昇を狙う用途。|
-| `--auto_cap_release` | `False` | **停滞検知 → 一時的に上限キャップ緩和**。<br>閾値が `ratio × skip_grad_norm_max` を `trigger_steps` 連続で超えたら、以後 `cap_release_length` step だけ `skip_grad_norm_max × cap_release_scale` に拡大。 | デフォルトの各パラメータ:<br>`ratio=0.66`, `trigger_steps=200`, `length=200`, `scale=3.0` |
-| `--idle_free_phase` | `False` | **指定間隔で上限キャップ撤廃**。<br>移動平均窓にNan/Infが `idle_max_steps` 連続で入らなければ発動、 `idle_free_len` step だけスキップ判定が無効化＝“ブレーキ解除” | デフォルトの各パラメータ:<br>`idle_max_steps=4000`, `idle_free_len=200` |
+| `--grad_norm_mode {stable,gamble}` | `None` | `skip_grad_norm` 系の推奨プリセットを一括指定。`stable`=安定重視、`gamble`=当たり狙い。 | 指定時は個別オプションを無視し、`--no-skip_nan_immediate` / `--no-skip_inf_immediate` のみ上書き可。詳細: [docs/skip_grad_norm_refactor_plan-ja.md](docs/skip_grad_norm_refactor_plan-ja.md) |
+| `--skip_grad_norm`, `--skip_grad_norm_max`, `--grad_norm_log`, `--grad_cosine_log`<br>`--nan_to_window`, `--inf_to_window`<br>`--skip_nan_immediate`, `--skip_inf_immediate`,<br>`--no-skip_nan_immediate`, `--no-skip_inf_immediate` | 混在 | 勾配ノルムのスキップ/ログ/NaN・Inf 挙動を詳細制御。<br>`--skip_grad_norm` は *N=200* の移動平均+2.5σで超過更新をスキップし、`--skip_grad_norm_max` で上限キャップ。<br>`--grad_norm_log` は 100 step ごとにログを追記し、`--grad_cosine_log` で類似度を追加。<br>NaN/Inf の窓混入や即時スキップの可否を切替可能。 | 主要既定値: `skip_grad_norm` 無効、`skip_grad_norm_max` 無制限、`grad_norm_log`/`grad_cosine_log` 無効、`nan_to_window`/`inf_to_window` False、`skip_nan_immediate`/`skip_inf_immediate` True。 |
 | `--avg_cp` | **False** | 有効化するとエポック間の LoRA 重みを平均して安定化（SWA/EMA 相当）。<br>  推奨プリセット：`--avg_cp --avg_window 4 --avg_begin 0.6 --avg_mode ema --avg_reset_stats`<br>  併用オプション:<br>  • `--avg_window <int>` 平均に使うチェックポイント数。<br>  • `--avg_begin <0-1>` 学習の進行率。ここを過ぎてから窓に溜め始め、<br>    窓が満杯になったエポック以降で平均が発動。<br>    流れ：①エポック末に raw ckpt を保存 → ②窓が満杯なら平均 → ③平均後の<br>    重みで次エポックを開始。<br>  • `--avg_mode {uniform,ema,metric}` 平均方法。`uniform`=等重み, `ema`=指数移動平均,<br>    `metric`=指標重み付き（準備中）。<br>  • `--avg_reset_stats / --no_avg_reset_stats` 平均直後に Optimizer のモーメンタム統計を<br>    安全にリセットして発散を防ぐかどうか。 | LoRAを学習後に最後の数エポックを平均するといい結果になるという話があるので、学習後半から平均しながら学習を進められるるようにする検証用 |
 | `--dq_delta_step` / `--dq_delta_bits` | `None` | 学習のforwardで、LoRAの“差分出力(Δ)”だけをフェイク量子化（STE）。重み自体は量子化しないため、勾配は恒等で流れる。<br>指定方法は2通り:<br>• `--dq_delta_step <float>` = 等間隔の刻み幅を直接指定。<br>• `--dq_delta_bits <int>` = Nビットの等間隔量子化を模擬（推奨: 8）。`stat`と`range_mul`からスケールを自動算出し、[-Qmax,Qmax]でクランプ（Qmax=2^(N-1)-1）。<br>併用オプション:<br>• `--dq_delta_mode {det,stoch}` `det`=最近傍、`stoch`=確率的丸め。<br>• `--dq_delta_begin <0-1>` 学習進行率。この割合以降のみ有効化。<br>• `--dq_delta_scope {unet,te,both}` 適用対象の限定（U-Netのみ/Text Encoderのみ/両方）。<br>• `--dq_delta_granularity {tensor,channel}` 粒度（テンソル全体/チャネル別）。<br>• `--dq_delta_stat {rms,absmax,none}` bits/stepのスケール基準（per-channel時はチャネルごとに計算）。<br>• `--dq_delta_range_mul <float>` bitsモード×`stat=rms`時の有効レンジ倍率（range=倍率×RMS、既定3.0）。<br>• `--dq_delta_bits_sched 'p1:bits1,p2:bits2,...'` 学習進行率pでビット数を段階的に切替（例: `0.0:6,0.5:8,0.8:10`）。<br>• `--dq_quantize_z` = Δ ではなく z=A(x) を量子化（B(Q(z))）。rank r の z を対象に統計を取るため軽量化。 | 実装は `networks/lora.py` の LoRA forward 内。SDXL でも有効。<br>※ LoRA-FA (`networks/lora_fa.py`) は現在メンテ対象外であり、サポートしていません。<br>※ `--dq_delta_bits` は本ドキュメントの仕様準拠設定を推奨。 |
 | `--dq_delta_log`<br>`--dq_delta_auto_range_mul` | 無効 | **dq_delta のログ**と**range_mul の自動調整**。<br>• `--dq_delta_log` = dq_delta の統計ログを出力。<br>• `--dq_delta_auto_range_mul` = clip_rate を見て range_mul を自動調整。<br>発動条件:<br>• `--dq_delta_log` は dq_delta 有効時のみ。<br>• `--dq_delta_auto_range_mul` は **bits モード + `stat=rms`** の時のみ有効（`--dq_delta_bits` または `--dq_delta_bits_sched` が必要）。 | 詳細は [docs/dq_delta_autotune_spec-ja.md](docs/dq_delta_autotune_spec-ja.md) を参照。 |
@@ -33,12 +26,9 @@
 
 | 名称 | 目的 / 特徴 | 推奨コマンド例 |
 |------|-------------|----------------|
-| **Preset A — “当たり狙い”** | *NaN/Inf もスキップ*。スケールが際限なく上がるため破綻リスクはあるものの、少量高品質データで“化ける”ことがある。 | `--downscale_freq_shift  --te_mlp_fc_only --skip_grad_norm --grad_norm_log --grad_cosine_log` |
-| **Preset B — “安定重視”** | *NaN/Inf をスキップしない*ことで GradScaler の自動調整を生かしつつ、動的しきい値で大スパイクのみ遮断。窓にNaN/Infを入れることで“ブレーキ解除”。最も汎用的。 | `--downscale_freq_shift --te_mlp_fc_only --skip_grad_norm --grad_norm_log --grad_cosine_log --skip_grad_norm_max 200000 --nan_to_window --inf_to_window --no-skip_nan_immediate --no-skip_inf_immediate` |
-| **Preset C — “停滞打破実験”** | Preset B + `--auto_cap_release`。谷底で停滞したら一時的にキャップを緩めて脱出を試みる。効果はケース依存。(あまり効果なし) | `Preset B` に `--auto_cap_release` を追加 |
-| **Preset D' — “停滞打破実験”** | Preset B + `--idle_free_phase`。窓にNaNが長期間入らない場合も定期的に“ブレーキ解除”。(安定しない) | `Preset B` に `--idle_free_phase` を追加 |
-| **Preset E' — “実験”** | Preset B + `--idle_free_phase`。途中のエポックから直近数個のエポックとの平均をとりながら学習を進める。(いいかも) | `Preset B` に `--avg_cp --avg_window 4 --avg_begin 0.6 --avg_mode ema --avg_reset_stats` を追加 |
-| **Preset F — “Optimizer Args Playground”** | 標準機能でoptimizerの wd & β₂ を微調整してLLMの論文（arXiv:2507.07101）の内容を検証。標準は wd = 0.01, β = (0.9, 0.999) で本家同等。<br>— wd↓0.0‑0.005: 過収縮抑制・多様性↑／過学習注意。<br>— wd↑0.02‑0.05: 線細・沈みがち。<br>— β₂↓0.995‑0.998: 刻み↑だが荒れ／発散リスク。<br>— β₂↑0.9994‑0.9999: 平滑・多様化↑、LoRAではキャラ薄傾向。<br>論文は wd = 0 & β₂≈0.99986 を推奨、小バッチで安定。(SDXLのLoRAの学習には逆効果かも)|`--optimizer_type AdamW8bit --optimizer_args "weight_decay=0.01" "betas=0.9,0.999"` ←ここを例: wd=0 / betas=0.9,0.9998 などに書き換えて試行|
+| **Preset A — “当たり狙い”** | *NaN/Inf もスキップ*。スケールが際限なく上がるため破綻リスクはあるものの、少量高品質データで“化ける”ことがある。 | `--downscale_freq_shift  --te_mlp_fc_only --grad_norm_mode gamble` |
+| **Preset B — “安定重視”** | *NaN/Inf をスキップしない*ことで GradScaler の自動調整を生かしつつ、動的しきい値で大スパイクのみ遮断。窓にNaN/Infを入れることで“ブレーキ解除”。最も汎用的。 | `--downscale_freq_shift --te_mlp_fc_only --grad_norm_mode stable` |
+| **Preset E' — “実験”** | Preset B + エポック平均。途中から直近数個のエポックとの平均をとりながら学習を進める。(いいかも) | `Preset B` に `--avg_cp --avg_window 4 --avg_begin 0.6 --avg_mode ema --avg_reset_stats` を追加 |
 | **Preset G — “量子化＋安全正規化”** | Preset B に fp16 安全正規化と LoRA Δ 量子化を組み合わせ、勾配スパイクを抑えつつ高周波を約束的に削るモード。キャラの保持と背景の滑らかさを両立しやすい反面、量子化と追加の正規化計算で処理時間はおおよそ 1.5 倍になる。 | `Preset B` に `--fp16_safe_norms --dq_delta_bits 8 --dq_delta_granularity channel --dq_delta_stat rms --dq_delta_range_mul 3.0 --dq_delta_mode stoch --dq_delta_begin 0 --dq_delta_scope unet --dq_delta_bits_sched "0.0:6,0.4:8,0.9:10"` を追加 |
 
 **ターゲット想定**  
@@ -53,7 +43,6 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 
 1. **まずは Preset B** で学習曲線とログを観察し、`norm` が *skip* されずに推移していることを確認。  
 2. キャラクターの再現度が足りなければ **Preset A** に切り替え、当たり／破綻のリスクをトレードオフ。  
-3. 長時間止まったように見える箇所があれば **`--auto_cap_release`** を追加して挙動を比較。  
 
 ---
 

--- a/docs/skip_grad_norm_README-ja.md
+++ b/docs/skip_grad_norm_README-ja.md
@@ -16,9 +16,10 @@
 
 ## 動的しきい値と関連オプション
 - **基本式**: `threshold = mean(window) + 2.5 * std(window)`（窓サイズ 200）。値は `numpy` 計算で、NaN が混入すると式全体が NaN になり、後続の比較は `False` 扱い。
-- **`--skip_grad_norm_max <float>`**: 動的しきい値の絶対上限。設定しない場合は無制限。`--auto_cap_release` が無効でも、窓が埋まる前は常に 200000 を使用する点に注意。
-- **`--grad_norm_log`**: `--output_dir/gradient_logs+<output_name>.txt` に CSV 形式で `Epoch,Step,Gradient Norm,Threshold,Loss,ThreshOff[,Scale][,CosineSim]` を出力。100 ステップごとに追記。`ThreshOff=1` は NaN 阻害、`2` は idle free フェーズを示す。
+- **`--skip_grad_norm_max <float>`**: 動的しきい値の絶対上限。設定しない場合は無制限。窓が埋まる前は常に 200000 を使用する点に注意。
+- **`--grad_norm_log`**: `--output_dir/gradient_logs+<output_name>.txt` に CSV 形式で `Epoch,Step,Gradient Norm,Threshold,Loss,ThreshOff[,Scale][,CosineSim]` を出力。100 ステップごとに追記。`ThreshOff=1` は NaN によりしきい値が無効化された状態を示す。
 - **`--grad_cosine_log`**: `--grad_norm_log` 併用時に有効。前ステップの勾配テンソルを複製保持し、コサイン類似度を計算・出力する。保持コストが掛かるが挙動には影響しない。
+- **`--grad_norm_mode {stable,gamble}`**: 推奨プリセットを一括指定。`stable` は安定重視、`gamble` は当たり狙い。指定時は個別オプションを無視し、`--no-skip_nan_immediate` / `--no-skip_inf_immediate` のみ上書き可能。
 - **GradScaler との関係**: スケール適用前の勾配に切り替えると学習結果が変わったため、仕様として「スケール適用済みの勾配ノルムで平均を作る」ことを前提にしている。スケールが変動した瞬間は窓の平均が追随するまでスキップ判定が遅れる。
 
 ## NaN/Inf 取り扱い関連
@@ -26,15 +27,14 @@
 - **`--skip_nan_immediate` / `--skip_inf_immediate`**: 既定値は `True`。オンのままだと NaN/Inf 発生時に即スキップし、GradScaler のヒステリシスが働かずスケールが上がり続けるケースがある。
   - `--no-skip_nan_immediate --no-skip_inf_immediate` を付けると NaN/Inf が出てもステップをスキップしないため、GradScaler が `found_inf` を検知してスケールを下げるトリガーが復活する。
   - このとき `--nan_to_window --inf_to_window` を併用すると、窓が NaN で満たされスキップが完全に停止する「隙間時間」がランダムに挿入され、実運用ではこの不規則性が好ましいとされている。
-- **`--nan_inf_until_step <int>`**: 指定ステップまでは NaN/Inf 関連オプションを尊重し、以降は `nan_to_window=False`, `inf_to_window=False`, `skip_nan_immediate=True`, `skip_inf_immediate=True` に強制復帰する仕組み。よく使うプリセットでは未使用。
 
 ## よく使うプリセットの挙動
-- **設定 1**<br>`--skip_grad_norm --grad_norm_log --grad_cosine_log --skip_grad_norm_max 200000 --nan_to_window --inf_to_window --no-skip_nan_immediate --no-skip_inf_immediate`
+- **設定 1（`--grad_norm_mode stable`）**<br>`--grad_norm_mode stable`
   - 200 ステップ窓を維持しつつしきい値は 200000 にキャップ。ログはノルム・閾値・GradScaler スケール・勾配類似度まで記録。
   - NaN/Inf を窓に混入させ、即スキップは無効化するため、ランダムな「スキップ停止区間」が生まれ、GradScaler によるスケール調整も維持される。
   - 実質的に「極端なスパイクのみスキップし、NaN/Inf は学習を止めずにスケール調整へ渡す」挙動になる。
-- **設定 2**<br>`--skip_grad_norm --grad_norm_log`
-  - 最小構成。移動平均 + 2.5σ を超えたステップをスキップし、ログにはノルムと閾値と Loss のみを出力。
+- **設定 2（`--grad_norm_mode gamble`）**<br>`--grad_norm_mode gamble`
+  - 最小構成。移動平均 + 2.5σ を超えたステップをスキップし、ログにはノルム・閾値・Loss・勾配類似度が出力される。
   - NaN/Inf は即時スキップする（デフォルト値）ため、GradScaler がトリガーされずスケールが上昇し続ける場合がある点に注意。
 
 ## 学習進行への影響
@@ -48,11 +48,10 @@
 - 主な列:
   - `Gradient Norm`: そのステップの L2 ノルム（スケール適用済み）。
   - `Threshold`: 動的しきい値（NaN の場合は空欄になる）。
-  - `ThreshOff`: `0`=通常、`1`=しきい値が NaN で無効、`2`=idle free フェーズ。
+  - `ThreshOff`: `0`=通常、`1`=しきい値が NaN で無効。
   - `Scale`: `--grad_norm_log` かつ GradScaler 利用時のみ。`torch.cuda.amp.GradScaler.get_scale()` の生値。
   - `CosineSim`: `--grad_cosine_log` 追加時のみ。直前ステップと現ステップの勾配のコサイン類似度。前ステップが存在しない場合は `NaN`。
 
 ## 注意事項と既知の挙動
 - `skip_grad_norm` をオフにしても `--grad_norm_log` だけでログ記録が可能。その場合はステップスキップは一切行われない。
 - `--nan_to_window` で窓に NaN を入れると移動平均が NaN のまま残るが、窓から押し出されるまで自動で回復する。強制的にリセットする仕組みはない。
-- `idle_free_phase` 系オプションが残っているが、LoRA SDXL 学習では未調整のままであり、通常は無効化のまま使用することを想定している。

--- a/docs/skip_grad_norm_refactor_plan-ja.md
+++ b/docs/skip_grad_norm_refactor_plan-ja.md
@@ -1,0 +1,39 @@
+# skip_grad_norm 系リファクタリングメモ
+
+## 解読結果（現状挙動の整理）
+- 対象ロジックは `train_network.py` の `GradNormGuardian` / `GradNormGuardianConfig` と、引数定義は `library/sdxl_train_util.py`。
+- 判定タイミングは `accelerator.backward(loss)` の直後。`check_gradients_and_skip_update()` が呼ばれ、`True` ならその step は `optimizer.step()` を実行せずにスキップ（`global_step` は進む）。`skipped_steps` が進捗/ログに記録される。
+- 勾配ノルムは **GradScaler による unscale 前の値（スケール適用済み）**で計算。スケール変動に対する補正は行わない。
+- 移動平均窓は `moving_avg_window=200`。窓が満たされるまでの暫定しきい値は `initial_threshold=200000` 固定。
+- 動的しきい値は `mean + 2.5 * std`。`skip_grad_norm_max` があれば上限キャップ。ただし **窓が埋まるまではキャップを無視**し、常に `initial_threshold` が使われる。
+- NaN/Inf の扱い:
+  - `nan_to_window` / `inf_to_window` が有効だと NaN/Inf を窓に入れる。窓が NaN/Inf で満たされると `threshold` が NaN になり比較が常に `False` → その間はスキップ無効（意図的な“ブレーキ解除”）。
+  - `skip_nan_immediate` / `skip_inf_immediate` が `True` だと NaN/Inf の step は即スキップ（GradScaler の `found_inf` が働きにくい）。
+- ログ（`--grad_norm_log`）は `gradient_logs+<output_name>.txt` に CSV 出力。`ThreshOff` は `0`=通常、`1`=しきい値が NaN で無効。`--grad_cosine_log` で追加列。
+
+## リファクタリング計画（判定結果は不変）
+1. **プリセット選択式の導入**
+   - 新オプション: `--grad_norm_mode {stable,gamble}`。
+   - `stable` は現行「基本設定」（`--skip_grad_norm --grad_norm_log --grad_cosine_log --skip_grad_norm_max 200000 --nan_to_window --inf_to_window --no-skip_nan_immediate --no-skip_inf_immediate`）。
+   - `gamble` は現行「博打設定」（`--skip_grad_norm --grad_norm_log --grad_cosine_log`）。
+   - 既存オプションは **後方互換のため残すが、プリセット指定時は否定フラグのみ上書き可**にする。
+
+2. **設定組み立ての共通化**
+   - `train_network.py` 側の大量の `getattr(args, ...)` をヘルパー関数へ集約。
+   - プリセット適用 → 明示オプション上書き → `GradNormGuardianConfig` 生成、の順で単一路線化。
+
+3. **ログ出力の維持**
+   - `--grad_norm_log` の CSV 形式を維持し、`ThreshOff` は `0/1` のみで運用する。
+   - 新プリセット導入後も `gradient_logs+<output_name>.txt` の列構成・出力頻度は不変にする。
+
+4. **未使用オプションの削除**
+   - `--nan_inf_until_step`、`--auto_cap_release`、`--idle_free_phase` を **ソースとドキュメントから削除**。
+   - 関連する内部フラグや補助パラメータ（`cap_release_*` など）も併せて削除し、現行の判定結果を崩さない範囲で簡素化する。
+
+5. **ドキュメント更新**
+   - `docs/skip_grad_norm_README-ja.md` と `README.md` のプリセット記述を **新オプション表記へ置換**。
+   - 既存オプションは「上級者向けの手動調整」として併記し、優先順位ルールを明記。
+
+6. **検証方針**
+   - 既存 2 プリセットで **スキップ判定が完全一致**することを確認。
+   - `grad_norm_log` の出力列/頻度が変わらないことを差分比較（ログの行数・ヘッダ）。

--- a/library/sdxl_train_util.py
+++ b/library/sdxl_train_util.py
@@ -342,6 +342,13 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
         help="disable mmap load for safetensors. Speed up model loading in WSL environment / safetensorsのmmapロードを無効にする。WSL環境等でモデル読み込みを高速化できる",
     )
     parser.add_argument(
+        "--grad_norm_mode",
+        type=str,
+        default=None,
+        choices=["stable", "gamble"],
+        help="preset for skip_grad_norm options: stable or gamble / skip_grad_norm関連のプリセット指定（stable または gamble）",
+    )
+    parser.add_argument(
         "--skip_grad_norm",
         action="store_true",
         help="skip step if gradient norm exceeds moving average + 2.5 sigma / 勾配ノルムが移動平均+2.5σを超える場合にステップをスキップする",
@@ -383,58 +390,6 @@ def add_sdxl_training_arguments(parser: argparse.ArgumentParser):
         action=argparse.BooleanOptionalAction,
         default=True,
         help="skip step immediately if gradient norm is Inf / Inf が出た step を閾値に関係なくスキップする",
-    )
-    parser.add_argument(
-        "--nan_inf_until_step",
-        type=int,
-        default=None,
-        help="use nan/inf related options only until the specified step, then revert to default / 指定stepまでNaN/Inf処理を適用し、その後デフォルトに戻す",
-    )
-    parser.add_argument(
-        "--auto_cap_release",
-        action="store_true",
-        help="temporarily relax skip_grad_norm_max when stagnation detected / 停滞時に一時的にキャップを緩和する",
-    )
-    parser.add_argument(
-        "--cap_release_trigger_ratio",
-        type=float,
-        default=0.66,
-        help="trigger ratio for --auto_cap_release / auto_cap_release 発動の閾値比率",
-    )
-    parser.add_argument(
-        "--cap_release_trigger_steps",
-        type=int,
-        default=200,
-        help="trigger steps for --auto_cap_release / auto_cap_release 発動までの連続ステップ数",
-    )
-    parser.add_argument(
-        "--cap_release_length",
-        type=int,
-        default=200,
-        help="release length in steps for --auto_cap_release / auto_cap_release 発動後の開放ステップ数",
-    )
-    parser.add_argument(
-        "--cap_release_scale",
-        type=float,
-        default=3.0,
-        help="multiplier for skip_grad_norm_max during release / 開放中の skip_grad_norm_max の倍率",
-    )
-    parser.add_argument(
-        "--idle_free_phase",
-        action="store_true",
-        help="enable forced threshold-free phase when idle / 閾値撤廃フェーズを有効にする",
-    )
-    parser.add_argument(
-        "--idle_max_steps",
-        type=int,
-        default=4000,
-        help="max idle steps before free phase / 閾値撤廃フェーズに入るまでの無トリガstep数",
-    )
-    parser.add_argument(
-        "--idle_free_len",
-        type=int,
-        default=200,
-        help="length of forced free phase / 閾値撤廃フェーズの長さ",
     )
 
 

--- a/train_network.py
+++ b/train_network.py
@@ -71,14 +71,6 @@ class GradNormGuardianConfig:
     inf_to_window: bool
     skip_nan_immediate: bool
     skip_inf_immediate: bool
-    auto_cap_release: bool
-    cap_release_trigger_ratio: float
-    cap_release_trigger_steps: int
-    cap_release_length: int
-    cap_release_scale: float
-    idle_free_phase: bool
-    idle_max_steps: int
-    idle_free_len: int
     moving_avg_window: int = 200
     log_flush_interval: int = 100
     initial_threshold: float = 200_000.0
@@ -99,11 +91,6 @@ class GradNormGuardian:
         self.log_buffer: List[str] = []
         self.prev_grad_list = None
         self.prev_grad_norm = None
-        self.trigger_count = 0
-        self.cap_release_counter = 0
-        self.idle_counter = 0
-        self.idle_free_counter = 0
-        self.in_idle_free = False
 
         if self.config.log_grad_norm and self.log_file_path is not None:
             with open(self.log_file_path, "w") as f:
@@ -113,22 +100,6 @@ class GradNormGuardian:
                 if self.config.log_grad_cosine:
                     header += ",CosineSim"
                 f.write(header + "\n")
-
-    def update_nan_inf_behavior(
-        self,
-        nan_to_window: Optional[bool] = None,
-        inf_to_window: Optional[bool] = None,
-        skip_nan_immediate: Optional[bool] = None,
-        skip_inf_immediate: Optional[bool] = None,
-    ):
-        if nan_to_window is not None:
-            self.config.nan_to_window = nan_to_window
-        if inf_to_window is not None:
-            self.config.inf_to_window = inf_to_window
-        if skip_nan_immediate is not None:
-            self.config.skip_nan_immediate = skip_nan_immediate
-        if skip_inf_immediate is not None:
-            self.config.skip_inf_immediate = skip_inf_immediate
 
     def observe(self, model, epoch: int, step: int, loss_val: float) -> bool:
         device = next(model.parameters()).device
@@ -166,31 +137,13 @@ class GradNormGuardian:
         is_nan = math.isnan(current_grad_norm)
         is_inf = math.isinf(current_grad_norm)
 
-        appended = False
         if not is_nan and not is_inf:
             self.moving_avg_window.append(current_grad_norm)
         else:
             if is_nan and self.config.nan_to_window:
                 self.moving_avg_window.append(current_grad_norm)  # NOTE: intentionally poison the window so threshold stays NaN
-                appended = True
             if is_inf and self.config.inf_to_window:
                 self.moving_avg_window.append(current_grad_norm)  # NOTE: same idea for Inf; keep threshold disabled until flushed out
-                appended = True
-
-        if self.in_idle_free:
-            self.idle_free_counter += 1
-            if self.idle_free_counter >= self.config.idle_free_len:
-                self.in_idle_free = False
-                self.idle_free_counter = 0
-        else:
-            if appended:
-                self.idle_counter = 0
-            else:
-                self.idle_counter += 1
-                if self.config.idle_free_phase and self.idle_counter >= self.config.idle_max_steps:
-                    self.in_idle_free = True
-                    self.idle_counter = 0
-                    self.idle_free_counter = 0
 
         if len(self.moving_avg_window) == self.moving_avg_window.maxlen:
             mean_norm = np.mean(self.moving_avg_window)
@@ -199,31 +152,15 @@ class GradNormGuardian:
         else:
             dynamic_threshold_pre_cap = self.config.initial_threshold
 
-        effective_max = self.config.skip_grad_norm_max
-        if self.config.auto_cap_release and self.config.skip_grad_norm_max is not None:
-            if self.cap_release_counter > 0:
-                effective_max = self.config.skip_grad_norm_max * self.config.cap_release_scale
-                dynamic_threshold_pre_cap = effective_max
-                self.cap_release_counter -= 1
-            else:
-                trigger_threshold = self.config.cap_release_trigger_ratio * self.config.skip_grad_norm_max
-                if not math.isnan(dynamic_threshold_pre_cap) and dynamic_threshold_pre_cap >= trigger_threshold:
-                    self.trigger_count += 1
-                    if self.trigger_count >= self.config.cap_release_trigger_steps:
-                        self.cap_release_counter = self.config.cap_release_length
-                        self.trigger_count = 0
-                else:
-                    self.trigger_count = 0
-
         dynamic_threshold = dynamic_threshold_pre_cap
-        if effective_max is not None and dynamic_threshold > effective_max:
-            dynamic_threshold = effective_max
+        if self.config.skip_grad_norm_max is not None and dynamic_threshold > self.config.skip_grad_norm_max:
+            dynamic_threshold = self.config.skip_grad_norm_max
         if len(self.moving_avg_window) < self.moving_avg_window.maxlen:
             dynamic_threshold = dynamic_threshold_pre_cap
 
         if self.config.log_grad_norm:
             scale_val = self.scaler_for_log.get_scale() if self.config.log_grad_scale and self.scaler_for_log else None
-            flag = 2 if self.in_idle_free else (1 if math.isnan(dynamic_threshold) else 0)
+            flag = 1 if math.isnan(dynamic_threshold) else 0
             log_line = f"{epoch},{step},{current_grad_norm},{dynamic_threshold},{loss_val},{flag}"
             if self.config.log_grad_scale:
                 log_line += f",{scale_val}"
@@ -241,10 +178,74 @@ class GradNormGuardian:
         if (is_nan and self.config.skip_nan_immediate) or (is_inf and self.config.skip_inf_immediate):
             return True
 
-        if self.in_idle_free:
-            return False
-
         return current_grad_norm > dynamic_threshold
+
+
+GRAD_NORM_PRESETS = {
+    "stable": {
+        "skip_grad_norm": True,
+        "log_grad_norm": True,
+        "log_grad_cosine": True,
+        "skip_grad_norm_max": 200000.0,
+        "nan_to_window": True,
+        "inf_to_window": True,
+        "skip_nan_immediate": False,
+        "skip_inf_immediate": False,
+    },
+    "gamble": {
+        "skip_grad_norm": True,
+        "log_grad_norm": True,
+        "log_grad_cosine": True,
+        "skip_grad_norm_max": None,
+        "nan_to_window": False,
+        "inf_to_window": False,
+        "skip_nan_immediate": True,
+        "skip_inf_immediate": True,
+    },
+}
+
+
+def resolve_grad_norm_settings(args):
+    grad_norm_mode = getattr(args, "grad_norm_mode", None)
+    if grad_norm_mode is not None:
+        preset = GRAD_NORM_PRESETS[grad_norm_mode]
+        skip_grad_norm = preset["skip_grad_norm"]
+        log_grad_norm = preset["log_grad_norm"]
+        log_grad_cosine = preset["log_grad_cosine"]
+        skip_grad_norm_max = preset["skip_grad_norm_max"]
+        nan_to_window = preset["nan_to_window"]
+        inf_to_window = preset["inf_to_window"]
+        skip_nan_immediate = preset["skip_nan_immediate"]
+        skip_inf_immediate = preset["skip_inf_immediate"]
+
+        # Allow only explicit negation flags to override preset behavior.
+        if getattr(args, "skip_nan_immediate", True) is False:
+            skip_nan_immediate = False
+        if getattr(args, "skip_inf_immediate", True) is False:
+            skip_inf_immediate = False
+    else:
+        skip_grad_norm = getattr(args, "skip_grad_norm", False)
+        log_grad_norm = getattr(args, "grad_norm_log", False)
+        log_grad_cosine = getattr(args, "grad_cosine_log", False)
+        skip_grad_norm_max = getattr(args, "skip_grad_norm_max", None)
+        nan_to_window = getattr(args, "nan_to_window", False)
+        inf_to_window = getattr(args, "inf_to_window", False)
+        skip_nan_immediate = getattr(args, "skip_nan_immediate", True)
+        skip_inf_immediate = getattr(args, "skip_inf_immediate", True)
+
+    log_grad_cosine = log_grad_norm and log_grad_cosine
+
+    return (
+        grad_norm_mode,
+        skip_grad_norm,
+        log_grad_norm,
+        log_grad_cosine,
+        skip_grad_norm_max,
+        nan_to_window,
+        inf_to_window,
+        skip_nan_immediate,
+        skip_inf_immediate,
+    )
 
 
 class NetworkTrainer:
@@ -1756,34 +1757,24 @@ class NetworkTrainer:
         del train_dataset_group
 
         # prepare gradient skipping if enabled (複数 GPUではrankごとに判定がズレる恐れありらしい)
-        skip_grad_norm = getattr(args, "skip_grad_norm", False)
-        log_grad_norm = getattr(args, "grad_norm_log", False)
+        (
+            grad_norm_mode,
+            skip_grad_norm,
+            log_grad_norm,
+            log_grad_cosine,
+            skip_grad_norm_max,
+            nan_to_window,
+            inf_to_window,
+            skip_nan_immediate,
+            skip_inf_immediate,
+        ) = resolve_grad_norm_settings(args)
         scaler_for_log = accelerator.scaler if hasattr(accelerator, "scaler") else None
         log_grad_scale = log_grad_norm and scaler_for_log is not None
-        log_grad_cosine = log_grad_norm and getattr(args, "grad_cosine_log", False)
-        skip_grad_norm_max = getattr(args, "skip_grad_norm_max", None)
-        nan_to_window = getattr(args, "nan_to_window", False)
-        inf_to_window = getattr(args, "inf_to_window", False)
-        skip_nan_immediate = getattr(args, "skip_nan_immediate", True)
-        skip_inf_immediate = getattr(args, "skip_inf_immediate", True)
-        nan_inf_until_step = getattr(args, "nan_inf_until_step", None)
-        auto_cap_release = getattr(args, "auto_cap_release", False)
-        cap_release_trigger_ratio = getattr(args, "cap_release_trigger_ratio", 0.66)
-        cap_release_trigger_steps = getattr(args, "cap_release_trigger_steps", 200)
-        cap_release_length = getattr(args, "cap_release_length", 200)
-        cap_release_scale = getattr(args, "cap_release_scale", 3.0)
-        idle_free_phase = getattr(args, "idle_free_phase", False)
-        idle_max_steps = getattr(args, "idle_max_steps", 4000)
-        idle_free_len = getattr(args, "idle_free_len", 200)
-        nan_inf_switched = False
         logger.info(
-            f"skip_grad_norm: {skip_grad_norm}, grad_norm_log: {log_grad_norm}, "
+            f"grad_norm_mode: {grad_norm_mode}, skip_grad_norm: {skip_grad_norm}, grad_norm_log: {log_grad_norm}, "
             f"skip_grad_norm_max: {skip_grad_norm_max}, nan_to_window: {nan_to_window}, "
             f"inf_to_window: {inf_to_window}, skip_nan_immediate: {skip_nan_immediate}, "
-            f"skip_inf_immediate: {skip_inf_immediate}, nan_inf_until_step: {nan_inf_until_step}, auto_cap_release: {auto_cap_release}, "
-            f"cap_release_trigger_ratio: {cap_release_trigger_ratio}, cap_release_trigger_steps: {cap_release_trigger_steps}, "
-            f"cap_release_length: {cap_release_length}, cap_release_scale: {cap_release_scale}, "
-            f"idle_free_phase: {idle_free_phase}, idle_max_steps: {idle_max_steps}, idle_free_len: {idle_free_len}"
+            f"skip_inf_immediate: {skip_inf_immediate}"
         )
         use_grad_norm = skip_grad_norm or log_grad_norm
         grad_norm_guardian: Optional[GradNormGuardian] = None
@@ -1801,14 +1792,6 @@ class NetworkTrainer:
                 inf_to_window=inf_to_window,
                 skip_nan_immediate=skip_nan_immediate,
                 skip_inf_immediate=skip_inf_immediate,
-                auto_cap_release=auto_cap_release,
-                cap_release_trigger_ratio=cap_release_trigger_ratio,
-                cap_release_trigger_steps=cap_release_trigger_steps,
-                cap_release_length=cap_release_length,
-                cap_release_scale=cap_release_scale,
-                idle_free_phase=idle_free_phase,
-                idle_max_steps=idle_max_steps,
-                idle_free_len=idle_free_len,
             )
             grad_norm_guardian = GradNormGuardian(
                 config=guardian_config,
@@ -2369,28 +2352,6 @@ class NetworkTrainer:
                                             auto_applied,
                                         ]
                                         _write_csv(dq_auto_log_path, header, ",".join(_dq_format_value(v) for v in row))
-                    if (
-                        not nan_inf_switched
-                        and nan_inf_until_step is not None
-                        and global_step >= nan_inf_until_step
-                    ):
-                        nan_to_window = False
-                        inf_to_window = False
-                        skip_nan_immediate = True
-                        skip_inf_immediate = True
-                        if grad_norm_guardian is not None:
-                            grad_norm_guardian.update_nan_inf_behavior(
-                                nan_to_window=nan_to_window,
-                                inf_to_window=inf_to_window,
-                                skip_nan_immediate=skip_nan_immediate,
-                                skip_inf_immediate=skip_inf_immediate,
-                            )
-                        nan_inf_switched = True
-                        accelerator.print(
-                            f"nan_inf switched at step {global_step}: nan_to_window={nan_to_window}, inf_to_window={inf_to_window}, "
-                            f"skip_nan_immediate={skip_nan_immediate}, skip_inf_immediate={skip_inf_immediate}"
-                        )
-
                     self.sample_images(accelerator, args, None, global_step, accelerator.device, vae, tokenizer, text_encoder, unet)
 
                     # 指定ステップごとにモデルを保存


### PR DESCRIPTION
  PR概要

  - --grad_norm_mode {stable,gamble} を追加し、既存の手動設定をプリセット化
  - プリセット指定時は否定フラグのみ上書き可とし、挙動のブレを抑制
  - nan_inf_until_step / auto_cap_release / idle_free_phase と関連ロジックを削除して単純化
  - GradNormGuardian の分岐を削減し、ThreshOff を 0/1 のみに整理
  - READMEと仕様書を更新（不要プリセットの削除、grad系の表整理、リンク追加）

  互換性

  - --grad_norm_mode 未指定時は従来の個別オプションが有効