### PR TITLE
Dq delta autotune validation

### DIFF
--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -49,6 +49,11 @@
 - `clip_rate_raw` : 今回計測した clip_rate
 - `clip_rate_ema` : EMA 平滑化した clip_rate（制御に使用）
 - `zero_rate` : 量子化後に 0 になった割合
+- `quant_err_rms_raw` : `RMS(x - x_q)`（フェイク量子化の誤差）
+- `quant_err_rms_ema` : `quant_err_rms_raw` の EMA（係数は `dq_delta_auto_ema`）
+- `quant_err_ratio_raw` : `quant_err_rms_raw / (rms + eps)`（`eps=1e-12`）
+- `quant_err_ratio_ema` : `quant_err_ratio_raw` の EMA（係数は `dq_delta_auto_ema`）
+  - EMA は scope 共通の 1 系列。`log_scope=both` の場合は unet+te 合算で更新。
 - `numel` : 計測対象の要素数（集計値）
 - 任意: `near_zero_rate` : `|x| < 0.5*scale` の割合（0 になりやすい帯域）
 - `auto_applied` : AutoStep で range_mul 更新が適用された場合は 1、それ以外は 0
@@ -65,17 +70,22 @@
 - summary に加え `module_name,shape` を出力
 - 1行 = 1モジュールの計測
 - DDP 時は **main rank のローカル値のみ**を出力（per_module は all-reduce しない）
+- quant_error 系（`quant_err_*`）も summary と同じ列で出力
 
 ### 集計定義（summary）
 
 - `numel_sum` : 計測対象の全要素数
 - `sumsq_sum` : `x^2` の総和（fp32 で集計）
+- `xq_sumsq_sum` : `x_q^2` の総和（fp32 で集計）
+- `xxq_sum` : `x * x_q` の総和（fp32 で集計）
 - `clip_count_sum` : クリップに該当した要素数（`|x| > range_elem` 相当）
 - `zero_count_sum` : 量子化後に 0 になった要素数
 - `rms = sqrt(sumsq_sum / numel_sum)`
 - `absmax = max(|x|)`（全要素の最大値）
 - `clip_rate = clip_count_sum / numel_sum`
 - `zero_rate = zero_count_sum / numel_sum`
+- `quant_err_rms = sqrt((sumsq_sum + xq_sumsq_sum - 2*xxq_sum) / numel_sum)`
+- `quant_err_ratio = quant_err_rms / (rms + eps)`（`eps=1e-12`）
 
 ※ `range_elem` は `granularity=channel` の場合はチャネル別 range をブロードキャストした per-element range を使う。  
 ※ 分散学習時は `numel_sum/sumsq_sum/clip_count_sum/zero_count_sum` を **all-reduce (sum)** してから算出する。  
@@ -93,12 +103,13 @@
   - （任意）`zero_count_sum`
 - **LogStep のみ**で **full stats**（`sumsq_sum/absmax/scale_*` など）を計測する。
   LogStep 以外の AutoStep は最小統計に限定する。
+- `quant_err_*` は full stats の一部として **LogStep のみ**で計算する。
 
 ### 出力例（summary）
 
 ```
-Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,AbsMax,Range,ScaleMin,ScaleMean,ScaleMax,Qmax,ClipRateRaw,ClipRateEMA,ZeroRate,Numel,AutoApplied,RangeMulBefore,RangeMulAfter,WarmupActive,WarmupRemain,AutoReason
-2,3400,unet,delta,8,,3.0,rms,channel,stoch,0.0123,0.0912,0.0369,0.00020,0.00029,0.00041,127,0.0008,0.0007,0.034,12345678,1,3.0,3.21,0,0,clip_high
+Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,AbsMax,Range,ScaleMin,ScaleMean,ScaleMax,Qmax,ClipRateRaw,ClipRateEMA,ZeroRate,QuantErrRMSRaw,QuantErrRMSEMA,QuantErrRatioRaw,QuantErrRatioEMA,Numel,AutoApplied,RangeMulBefore,RangeMulAfter,WarmupActive,WarmupRemain,AutoReason
+2,3400,unet,delta,8,,3.0,rms,channel,stoch,0.0123,0.0912,0.0369,0.00020,0.00029,0.00041,127,0.0008,0.0007,0.034,0.0015,0.0014,0.12,0.11,12345678,1,3.0,3.21,0,0,clip_high
 ```
 
 ## ログの見方（初心者向け）
@@ -127,6 +138,10 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | ClipRateRaw | 生のクリップ率 | 目標帯域に収まるか確認。 |
 | ClipRateEMA | EMA平滑値 | auto判定に使う値。 |
 | ZeroRate | 量子化後0の割合 | 潰れの兆候。 |
+| QuantErrRMSRaw | 量子化誤差のRMS | 「クリップは少ないが刻みが粗い」を検出。 |
+| QuantErrRMSEMA | QuantErrRMS のEMA | ノイズの安定した傾向を見る。 |
+| QuantErrRatioRaw | 誤差RMS/入力RMS | 入力に対する誤差の割合。 |
+| QuantErrRatioEMA | QuantErrRatio のEMA | 比率の安定した傾向を見る。 |
 | NearZeroRate | 0近傍の割合 | `--dq_delta_log_extra near_zero_rate`時のみ。 |
 | Numel | 要素数 | 統計の母数。 |
 | AutoApplied | auto適用 | 1ならrange_mulが変化。 |
@@ -135,6 +150,10 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | WarmupActive | warmup中 | 1なら range_mul は固定。 |
 | WarmupRemain | warmup残り | 0なら warmup終了。 |
 | AutoReason | 判定理由 | `warmup`/`clip_high`/`clip_low`/`in_band`。 |
+
+補足（読み解きの目安）:
+- `ClipRate` が低いのに `QuantErrRatio` が高い場合、**レンジが広く刻みが粗い**可能性がある（`range_mul` 高め / `bits` 低め）。
+- `QuantErrRatio` が低いのに `ClipRate` が高い場合、**クリップ歪み**が支配的な可能性がある。
 
 ### logs（`--dq_delta_log`）: per_module
 
@@ -229,10 +248,10 @@ range_mul = clamp(range_mul, auto_min, auto_max)
 - warmup 回数は EMA 係数から自動決定し、追加パラメータは持たない
 
 ```
-warmup_updates = ceil(1 / (1 - dq_delta_auto_ema))
+warmup_updates = ceil(2 / (1 - dq_delta_auto_ema))
 ```
 
-例: `dq_delta_auto_ema=0.95` -> 20 回、`0.90` -> 10 回、`0.98` -> 50 回
+例: `dq_delta_auto_ema=0.95` -> 40 回、`0.90` -> 20 回、`0.98` -> 100 回
 
 #### 早期終了
 

--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -253,6 +253,8 @@ warmup_updates = ceil(2 / (1 - dq_delta_auto_ema))
 
 例: `dq_delta_auto_ema=0.95` -> 40 回、`0.90` -> 20 回、`0.98` -> 100 回
 
+※ `1/(1-ema)` は **EMA の実効履歴長**の目安であり、warmup 回数とは別概念。
+
 #### 早期終了
 
 - `clip_low <= clip_rate_ema <= clip_high` が **3 回連続**で成立したら warmup を終了

--- a/docs/dq_delta_mechanism-ja.md
+++ b/docs/dq_delta_mechanism-ja.md
@@ -338,7 +338,19 @@ bits 切替時は量子化の性質が変わるので、
     auto を使う場合は `auto_clip_low/high` を少し低めにして過度なクリップを抑える。
     
 補足: `QuantErrRatio` は `RMS(x)` が小さい局面で見かけ上大きく出ることがあるため、**単独では判断せず** `QuantErrRMS` の絶対量と必ず併せて判断する。
+
+読み方の目安2:
+
+-   `ClipRate` が低いのに `QuantErrRatio` が高い場合、次の2系統がありうる：
     
+    1.  **レンジが広く刻みが粗い**（`range_mul` 高め / `bits` 低め）
+        　→ 対策：`range_mul` を下げる、`bits` を上げる（または `bits_sched` を早める）
+        
+    2.  **外れ値が大きく、少数でも誤差エネルギーを支配**（`AbsMax >> Range`）
+        　→ 対策：`range_mul` を上げる（または `clip_high` を下げて早めに拡張させる）、必要なら `bits` を上げる
+        
+-   見分け方：`AbsMax / Range` が極端に大きい場合は (2) の可能性が高い。
+
 
 ### auto\_only ログ（dq\_delta\_auto\_log\_file）
 

--- a/docs/dq_delta_mechanism-ja.md
+++ b/docs/dq_delta_mechanism-ja.md
@@ -32,6 +32,23 @@
     
 -   フェイク量子化（dq\_delta / dq\_quantize\_z）
     
+### dq\_delta オプション一覧（基本）
+
+※ `--dq_delta_log` / `--dq_delta_auto_range_mul` 系は [docs/dq_delta_autotune_spec-ja.md](docs/dq_delta_autotune_spec-ja.md) に記載。
+
+| オプション | 説明 |
+| --- | --- |
+| `--dq_delta_step <float>` | 等間隔の刻み幅を直接指定（step モード）。 |
+| `--dq_delta_bits <int>` | Nビットの等間隔量子化を模擬（推奨: 8）。`stat` と `range_mul` からスケール算出し、`[-Qmax, Qmax]` にクランプ（`Qmax=2^(N-1)-1`）。 |
+| `--dq_delta_mode {det,stoch}` | `det`=最近傍、`stoch`=確率的丸め。 |
+| `--dq_delta_begin <0-1>` | 学習進行率。この割合以降のみ有効化。 |
+| `--dq_delta_scope {unet,te,both}` | 適用対象の限定（U-Netのみ/Text Encoderのみ/両方）。 |
+| `--dq_delta_granularity {tensor,channel}` | 粒度（テンソル全体/チャネル別）。 |
+| `--dq_delta_stat {rms,absmax,none}` | bits/step のスケール基準（per-channel時はチャネルごとに計算）。 |
+| `--dq_delta_range_mul <float>` | bits モード×`stat=rms`時の有効レンジ倍率（range=倍率×RMS、既定3.0）。 |
+| `--dq_delta_bits_sched 'p1:bits1,p2:bits2,...'` | 学習進行率 p でビット数を段階的に切替（例: `0.0:6,0.5:8,0.8:10`）。 |
+| `--dq_quantize_z` | Δ ではなく `z=A(x)` を量子化（`B(Q(z))`）。rank r の z を対象に統計を取るため軽量化。 |
+
 
 ### 量子化モードの前提
 

--- a/docs/dq_delta_mechanism-ja.md
+++ b/docs/dq_delta_mechanism-ja.md
@@ -337,7 +337,7 @@ bits 切替時は量子化の性質が変わるので、
     対処: `--dq_delta_range_mul` を上げる、または `--dq_delta_bits` を上げて刻みを細かくする。  
     auto を使う場合は `auto_clip_low/high` を少し低めにして過度なクリップを抑える。
     
-補足: `QuantErrRatio` は `RMS(x)` が小さい局面で大きく見えることがあるため、`QuantErrRMS` の絶対量と併せて判断する。
+補足: `QuantErrRatio` は `RMS(x)` が小さい局面で見かけ上大きく出ることがあるため、**単独では判断せず** `QuantErrRMS` の絶対量と必ず併せて判断する。
     
 
 ### auto\_only ログ（dq\_delta\_auto\_log\_file）

--- a/docs/dq_delta_mechanism-ja.md
+++ b/docs/dq_delta_mechanism-ja.md
@@ -223,17 +223,17 @@ AutoStep のたびに
 
 EMA の時間定数に基づく自動決定を採用する。
 
--   `warmup_updates = ceil(1 / (1 - auto_ema))`
+-   `warmup_updates = ceil(2 / (1 - auto_ema))`
     
 
 例:
 
--   `auto_ema=0.95` -> `warmup_updates=20`
+-   `auto_ema=0.95` -> `warmup_updates=40`
     
 
 warmup は **AutoStep の回数**で数える。
 
--   `auto_every=50` の場合、20 回 -> 1000 step 相当の時間スケール
+-   `auto_every=50` の場合、40 回 -> 2000 step 相当の時間スケール
     
 
 ### 早期終了（推奨）
@@ -290,6 +290,8 @@ bits 切替時は量子化の性質が変わるので、
     
 -   監視: `ClipRateRaw, ClipRateEMA, ZeroRate`
     
+-   補助: `QuantErrRMSRaw/QuantErrRMSEMA`, `QuantErrRatioRaw/QuantErrRatioEMA`（LogStep のみ）
+    
 -   制御: `AutoApplied, RangeMulBefore, RangeMulAfter`
     
 -   warmup を入れる場合（推奨）:
@@ -300,6 +302,26 @@ bits 切替時は量子化の性質が変わるので、
         
     -   `AutoReason`（warmup / clip\_high / clip\_low / in\_band など）
         
+### “clipだけ見ない” 2指標ログ（実装済み）
+
+-   `QuantErrRMSRaw = RMS(x - x_q)` で量子化誤差を直接観測する
+    
+-   `QuantErrRatioRaw = QuantErrRMSRaw / (RMS(x) + eps)` で相対化（`eps=1e-12`）
+    
+-   LogStep のみ計測し、dq_delta_log が有効な時だけ出力する
+    
+読み方の目安:
+
+-   `ClipRate` が低いのに `QuantErrRatio` が高い → 刻みが粗く「薄まり」方向  
+    対処: `--dq_delta_range_mul` を下げる（例: -0.1、まだ薄いなら -0.2）。`ClipRate` が上がり過ぎたら戻す。  
+    併用案: `--dq_delta_bits` を上げる、または終盤だけ10にする（例: `--dq_delta_bits_sched "0.0:8,0.9:10"`）。
+    
+-   `QuantErrRatio` が低いのに `ClipRate` が高い → クリップ歪みが支配的  
+    対処: `--dq_delta_range_mul` を上げる、または `--dq_delta_bits` を上げて刻みを細かくする。  
+    auto を使う場合は `auto_clip_low/high` を少し低めにして過度なクリップを抑える。
+    
+補足: `QuantErrRatio` は `RMS(x)` が小さい局面で大きく見えることがあるため、`QuantErrRMS` の絶対量と併せて判断する。
+    
 
 ### auto\_only ログ（dq\_delta\_auto\_log\_file）
 
@@ -361,6 +383,8 @@ AutoStep のみを出す CSV。
 
 ただし、bits は **クリップではなく “刻み幅” を変えるノブ**なので、
 clip\_rate が似ていても量子化誤差（刻みの粗さ）は変わり得る点に注意。
+
+QuantErrRatio を見ると差が出やすい。
 
 * * *
 
@@ -452,34 +476,7 @@ bash
 
 ## 既知の課題と改善アイデア（今後の発展）
 
-### 1) “clipだけ見ない” 2指標制御
-
-clip\_rate だけだと、
-
--   クリップが少ないが刻みが粗い（薄まる）
-    
--   クリップが少ないが量子化誤差が大きい
-    
-
-を拾いにくい。
-
-LogStep のみに限定してもよいので、例えば
-
--   `quant_error_rms = RMS(x - dequantize(quantize(x)))`
-    
-
-を追加ログし、
-
--   clip\_rate は帯域内
-    
--   しかし quant\_error\_rms が悪化するなら mul を下げる（刻みを細かく）
-    
-
-のように 2指標で制御すると、「薄まる」方向を抑えやすくなる。
-
-（量子化最適化の文脈では、ACIQ などの「歪みの合計最小」や、PACT/LSQ のような発想に近い）
-
-### 2) ターゲット clip 帯域のスケジュール
+### 1) ターゲット clip 帯域のスケジュール
 
 キャラ用途では「少しクリップ多めが良い」ことがある一方、
 安定性重視用途では「クリップ少なめ」が良いことがある。
@@ -493,7 +490,7 @@ LogStep のみに限定してもよいので、例えば
 
 のように、目的に応じて「狙い帯域」をスケジュールするのも考えられる。
 
-### 3) scope別 range\_mul（UNet と TE を分離）
+### 2) scope別 range\_mul（UNet と TE を分離）
 
 UNet と TE で分布が違う場合があるので、
 
@@ -516,7 +513,7 @@ UNet と TE で分布が違う場合があるので、
     
 -   学習序盤は EMA が立ち上がり途中で誤制御しやすいので、**制御のみ停止するウォームアップ**が有効
     
--   ログ（clip\_rate\_raw/ema、range\_mul、auto\_applied、warmup情報）を残すことで、学習の挙動差を定量的に比較できる
+-   ログ（clip\_rate\_raw/ema、quant\_err、range\_mul、auto\_applied、warmup情報）を残すことで、学習の挙動差を定量的に比較できる
     
 
 * * *

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -73,6 +73,8 @@ class DQStatsAccumulator:
         self.scale_max = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
         self.scale_sum = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
         self.scale_count = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
+        self.xq_sumsq = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
+        self.xxq_sum = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
 
     def add(
         self,
@@ -82,6 +84,8 @@ class DQStatsAccumulator:
         zero_count: Optional[torch.Tensor] = None,
         near_zero_count: Optional[torch.Tensor] = None,
         sumsq: Optional[torch.Tensor] = None,
+        xq_sumsq: Optional[torch.Tensor] = None,
+        xxq_sum: Optional[torch.Tensor] = None,
         absmax: Optional[torch.Tensor] = None,
         scale_min: Optional[torch.Tensor] = None,
         scale_max: Optional[torch.Tensor] = None,
@@ -97,6 +101,10 @@ class DQStatsAccumulator:
         if self.collect_full:
             if sumsq is not None:
                 self.sumsq += sumsq
+            if xq_sumsq is not None:
+                self.xq_sumsq += xq_sumsq
+            if xxq_sum is not None:
+                self.xxq_sum += xxq_sum
             if absmax is not None:
                 self.absmax = torch.maximum(self.absmax, absmax)
             if scale_min is not None:
@@ -201,6 +209,8 @@ class DQStatsManager:
         zero_count: Optional[torch.Tensor],
         near_zero_count: Optional[torch.Tensor],
         sumsq: Optional[torch.Tensor],
+        xq_sumsq: Optional[torch.Tensor],
+        xxq_sum: Optional[torch.Tensor],
         absmax: Optional[torch.Tensor],
         scale_min: Optional[torch.Tensor],
         scale_max: Optional[torch.Tensor],
@@ -216,6 +226,8 @@ class DQStatsManager:
             zero_count=zero_count,
             near_zero_count=near_zero_count,
             sumsq=sumsq,
+            xq_sumsq=xq_sumsq,
+            xxq_sum=xxq_sum,
             absmax=absmax,
             scale_min=scale_min,
             scale_max=scale_max,
@@ -233,6 +245,8 @@ class DQStatsManager:
                     "zero_count": zero_count.detach() if zero_count is not None else None,
                     "near_zero_count": near_zero_count.detach() if near_zero_count is not None else None,
                     "sumsq": sumsq.detach() if sumsq is not None else None,
+                    "xq_sumsq": xq_sumsq.detach() if xq_sumsq is not None else None,
+                    "xxq_sum": xxq_sum.detach() if xxq_sum is not None else None,
                     "absmax": absmax.detach() if absmax is not None else None,
                     "scale_min": scale_min.detach() if scale_min is not None else None,
                     "scale_max": scale_max.detach() if scale_max is not None else None,
@@ -375,8 +389,16 @@ class LoRAModule(torch.nn.Module):
             near_zero_count = None
             if mgr.collect_near_zero and scale is not None:
                 near_zero_count = (x_in.abs() < (0.5 * scale)).to(torch.float32).sum()
-            sumsq = (x_in.to(torch.float32) ** 2).sum() if mgr.collect_full else None
-            absmax = x_in.abs().max() if mgr.collect_full else None
+            sumsq = xq_sumsq = xxq_sum = absmax = None
+            if mgr.collect_full:
+                x_fp32 = x_in.to(torch.float32)
+                x_flat = x_fp32.reshape(-1)
+                sumsq = torch.dot(x_flat, x_flat)
+                q_fp32 = quantized.to(torch.float32)
+                q_flat = q_fp32.reshape(-1)
+                xq_sumsq = torch.dot(q_flat, q_flat)
+                xxq_sum = torch.dot(x_flat, q_flat)
+                absmax = x_in.abs().max()
             scale_min = scale_max = scale_sum = scale_count = None
             if mgr.collect_full and scale is not None:
                 scale_min = scale.min()
@@ -393,6 +415,8 @@ class LoRAModule(torch.nn.Module):
                 zero_count=zero_count,
                 near_zero_count=near_zero_count,
                 sumsq=sumsq,
+                xq_sumsq=xq_sumsq,
+                xxq_sum=xxq_sum,
                 absmax=absmax,
                 scale_min=scale_min,
                 scale_max=scale_max,

--- a/train_network.py
+++ b/train_network.py
@@ -706,7 +706,7 @@ class NetworkTrainer:
         dq_auto_warmup_updates = 0
         if dq_auto_warmup_enabled:
             if 0.0 < dq_auto_ema < 1.0:
-                dq_auto_warmup_updates = int(math.ceil(1.0 / (1.0 - dq_auto_ema)))
+                dq_auto_warmup_updates = int(math.ceil(2.0 / (1.0 - dq_auto_ema)))
             else:
                 dq_auto_warmup_enabled = False
                 logger.warning(
@@ -790,6 +790,10 @@ class NetworkTrainer:
                 "ClipRateRaw",
                 "ClipRateEMA",
                 "ZeroRate",
+                "QuantErrRMSRaw",
+                "QuantErrRMSEMA",
+                "QuantErrRatioRaw",
+                "QuantErrRatioEMA",
             ]
             if include_near_zero:
                 cols.append("NearZeroRate")
@@ -826,6 +830,10 @@ class NetworkTrainer:
                 if collect_full:
                     sum_fields.append(acc.sumsq)
                     sum_refs.append((acc, "sumsq"))
+                    sum_fields.append(acc.xq_sumsq)
+                    sum_refs.append((acc, "xq_sumsq"))
+                    sum_fields.append(acc.xxq_sum)
+                    sum_refs.append((acc, "xxq_sum"))
                     sum_fields.append(acc.scale_sum)
                     sum_refs.append((acc, "scale_sum"))
                     sum_fields.append(acc.scale_count)
@@ -870,6 +878,7 @@ class NetworkTrainer:
             zero_rate = (acc.zero_count / acc.numel).item() if collect_zero and numel > 0 else None
             near_zero_rate = (acc.near_zero_count / acc.numel).item() if collect_near_zero and numel > 0 else None
             rms = absmax = scale_min = scale_max = scale_mean = range_val = None
+            quant_err_rms = quant_err_ratio = None
             if collect_full and numel > 0:
                 rms = math.sqrt((acc.sumsq / acc.numel).item()) if acc.sumsq is not None else None
                 absmax = acc.absmax.item() if acc.absmax is not None else None
@@ -877,6 +886,12 @@ class NetworkTrainer:
                 scale_max = acc.scale_max.item() if acc.scale_max is not None else None
                 if acc.scale_sum is not None and acc.scale_count is not None and acc.scale_count.item() > 0:
                     scale_mean = (acc.scale_sum / acc.scale_count).item()
+                if acc.xq_sumsq is not None and acc.xxq_sum is not None and acc.sumsq is not None:
+                    err_sumsq = acc.sumsq + acc.xq_sumsq - (2.0 * acc.xxq_sum)
+                    err_sumsq = torch.clamp(err_sumsq, min=0.0)
+                    quant_err_rms = math.sqrt((err_sumsq / acc.numel).item())
+                    if rms is not None:
+                        quant_err_ratio = quant_err_rms / (rms + 1e-12)
             if scale_mean is not None and qmax is not None:
                 range_val = scale_mean * qmax
             return {
@@ -884,6 +899,8 @@ class NetworkTrainer:
                 "clip_rate": clip_rate,
                 "zero_rate": zero_rate,
                 "near_zero_rate": near_zero_rate,
+                "quant_err_rms": quant_err_rms,
+                "quant_err_ratio": quant_err_ratio,
                 "rms": rms,
                 "absmax": absmax,
                 "scale_min": scale_min,
@@ -891,6 +908,37 @@ class NetworkTrainer:
                 "scale_mean": scale_mean,
                 "range": range_val,
             }
+
+        def _dq_merge_acc(acc_a, acc_b, collect_full: bool, collect_zero: bool, collect_near_zero: bool):
+            numel = acc_a.numel + acc_b.numel
+            clip = acc_a.clip_count + acc_b.clip_count
+            zero = acc_a.zero_count + acc_b.zero_count if collect_zero else None
+            near_zero = acc_a.near_zero_count + acc_b.near_zero_count if collect_near_zero else None
+            sumsq = absmax = scale_min = scale_max = scale_sum = scale_count = None
+            xq_sumsq = xxq_sum = None
+            if collect_full:
+                sumsq = acc_a.sumsq + acc_b.sumsq
+                xq_sumsq = acc_a.xq_sumsq + acc_b.xq_sumsq
+                xxq_sum = acc_a.xxq_sum + acc_b.xxq_sum
+                absmax = torch.maximum(acc_a.absmax, acc_b.absmax)
+                scale_min = torch.minimum(acc_a.scale_min, acc_b.scale_min)
+                scale_max = torch.maximum(acc_a.scale_max, acc_b.scale_max)
+                scale_sum = acc_a.scale_sum + acc_b.scale_sum
+                scale_count = acc_a.scale_count + acc_b.scale_count
+            temp_acc = type(acc_a)(acc_a.numel.device, collect_full, collect_zero, collect_near_zero)
+            temp_acc.numel = numel
+            temp_acc.clip_count = clip
+            temp_acc.zero_count = zero
+            temp_acc.near_zero_count = near_zero
+            temp_acc.sumsq = sumsq
+            temp_acc.xq_sumsq = xq_sumsq
+            temp_acc.xxq_sum = xxq_sum
+            temp_acc.absmax = absmax
+            temp_acc.scale_min = scale_min
+            temp_acc.scale_max = scale_max
+            temp_acc.scale_sum = scale_sum
+            temp_acc.scale_count = scale_count
+            return temp_acc
 
         cache_latents = args.cache_latents
         use_dreambooth_method = args.in_json is None
@@ -1903,6 +1951,8 @@ class NetworkTrainer:
             global_step = initial_step
 
         dq_auto_ema_state = None
+        dq_quant_err_rms_ema_state = None
+        dq_quant_err_ratio_ema_state = None
         dq_bits_changed_since_auto = False
         dq_auto_warmup_remaining = dq_auto_warmup_updates
         dq_auto_warmup_inband_streak = 0
@@ -2213,40 +2263,13 @@ class NetworkTrainer:
                                             auto_metrics = metrics["te"]
                                         else:
                                             # combine unet + te
-                                            combined = accum_by_scope["unet"]
-                                            other = accum_by_scope["te"]
-                                            numel = combined.numel + other.numel
-                                            clip = combined.clip_count + other.clip_count
-                                            zero = None
-                                            if collect_zero:
-                                                zero = combined.zero_count + other.zero_count
-                                            near_zero = None
-                                            if collect_near_zero:
-                                                near_zero = combined.near_zero_count + other.near_zero_count
-                                            sumsq = None
-                                            absmax = None
-                                            scale_min = None
-                                            scale_max = None
-                                            scale_sum = None
-                                            scale_count = None
-                                            if collect_full:
-                                                sumsq = combined.sumsq + other.sumsq
-                                                absmax = torch.maximum(combined.absmax, other.absmax)
-                                                scale_min = torch.minimum(combined.scale_min, other.scale_min)
-                                                scale_max = torch.maximum(combined.scale_max, other.scale_max)
-                                                scale_sum = combined.scale_sum + other.scale_sum
-                                                scale_count = combined.scale_count + other.scale_count
-                                            temp_acc = type(combined)(combined.numel.device, collect_full, collect_zero, collect_near_zero)
-                                            temp_acc.numel = numel
-                                            temp_acc.clip_count = clip
-                                            temp_acc.zero_count = zero
-                                            temp_acc.near_zero_count = near_zero
-                                            temp_acc.sumsq = sumsq
-                                            temp_acc.absmax = absmax
-                                            temp_acc.scale_min = scale_min
-                                            temp_acc.scale_max = scale_max
-                                            temp_acc.scale_sum = scale_sum
-                                            temp_acc.scale_count = scale_count
+                                            temp_acc = _dq_merge_acc(
+                                                accum_by_scope["unet"],
+                                                accum_by_scope["te"],
+                                                collect_full,
+                                                collect_zero,
+                                                collect_near_zero,
+                                            )
                                             auto_metrics = _dq_compute_metrics(temp_acc, qmax, collect_full, collect_zero, collect_near_zero)
 
                                         clip_rate_raw = auto_metrics["clip_rate"]
@@ -2319,6 +2342,40 @@ class NetworkTrainer:
                                     include_near_zero = "near_zero_rate" in dq_log_extra
                                     header = _dq_log_header(dq_log_mode, include_near_zero)
                                     log_scopes = ["unet", "te"] if dq_stats["log_scope"] == "both" else [dq_stats["log_scope"]]
+                                    quant_err_rms_ema = dq_quant_err_rms_ema_state
+                                    quant_err_ratio_ema = dq_quant_err_ratio_ema_state
+                                    if dq_stats["log_scope"] == "both":
+                                        ema_acc = _dq_merge_acc(
+                                            accum_by_scope["unet"],
+                                            accum_by_scope["te"],
+                                            collect_full,
+                                            collect_zero,
+                                            collect_near_zero,
+                                        )
+                                        ema_metrics = _dq_compute_metrics(ema_acc, qmax, collect_full, collect_zero, collect_near_zero)
+                                    else:
+                                        ema_metrics = metrics[dq_stats["log_scope"]]
+                                    if ema_metrics is not None:
+                                        quant_err_rms_raw = ema_metrics["quant_err_rms"]
+                                        quant_err_ratio_raw = ema_metrics["quant_err_ratio"]
+                                        if quant_err_rms_raw is not None:
+                                            if dq_quant_err_rms_ema_state is None:
+                                                dq_quant_err_rms_ema_state = quant_err_rms_raw
+                                            else:
+                                                dq_quant_err_rms_ema_state = (
+                                                    dq_quant_err_rms_ema_state * dq_auto_ema
+                                                    + (1.0 - dq_auto_ema) * quant_err_rms_raw
+                                                )
+                                        if quant_err_ratio_raw is not None:
+                                            if dq_quant_err_ratio_ema_state is None:
+                                                dq_quant_err_ratio_ema_state = quant_err_ratio_raw
+                                            else:
+                                                dq_quant_err_ratio_ema_state = (
+                                                    dq_quant_err_ratio_ema_state * dq_auto_ema
+                                                    + (1.0 - dq_auto_ema) * quant_err_ratio_raw
+                                                )
+                                        quant_err_rms_ema = dq_quant_err_rms_ema_state
+                                        quant_err_ratio_ema = dq_quant_err_ratio_ema_state
                                     for scope in log_scopes:
                                         m = metrics[scope]
                                         values = [
@@ -2347,6 +2404,13 @@ class NetworkTrainer:
                                                 scale_max = item["scale_max"].item() if item["scale_max"] is not None else None
                                                 scale_mean = (item["scale_sum"] / item["scale_count"]).item() if item["scale_sum"] is not None and item["scale_count"] is not None and item["scale_count"].item() > 0 else None
                                                 range_val = scale_mean * qmax if scale_mean is not None and qmax is not None else None
+                                                quant_err_rms = quant_err_ratio = None
+                                                if item["sumsq"] is not None and item["xq_sumsq"] is not None and item["xxq_sum"] is not None and numel > 0:
+                                                    err_sumsq = item["sumsq"] + item["xq_sumsq"] - (2.0 * item["xxq_sum"])
+                                                    err_sumsq = torch.clamp(err_sumsq, min=0.0)
+                                                    quant_err_rms = math.sqrt((err_sumsq / item["numel"]).item())
+                                                    if rms is not None:
+                                                        quant_err_ratio = quant_err_rms / (rms + 1e-12)
                                                 row = values + [
                                                     item["module"],
                                                     item["shape"],
@@ -2360,6 +2424,10 @@ class NetworkTrainer:
                                                     clip_rate,
                                                     clip_rate_ema if clip_rate_ema is not None else "",
                                                     zero_rate,
+                                                    quant_err_rms,
+                                                    quant_err_rms_ema if quant_err_rms_ema is not None else "",
+                                                    quant_err_ratio,
+                                                    quant_err_ratio_ema if quant_err_ratio_ema is not None else "",
                                                 ]
                                                 if include_near_zero:
                                                     row.append(near_zero_rate)
@@ -2385,6 +2453,10 @@ class NetworkTrainer:
                                                 m["clip_rate"],
                                                 clip_rate_ema if clip_rate_ema is not None else "",
                                                 m["zero_rate"],
+                                                m["quant_err_rms"],
+                                                quant_err_rms_ema if quant_err_rms_ema is not None else "",
+                                                m["quant_err_ratio"],
+                                                quant_err_ratio_ema if quant_err_ratio_ema is not None else "",
                                             ]
                                             if include_near_zero:
                                                 row.append(m["near_zero_rate"])
@@ -2423,6 +2495,10 @@ class NetworkTrainer:
                                             qmax if qmax is not None else "",
                                             clip_rate_raw if clip_rate_raw is not None else "",
                                             clip_rate_ema if clip_rate_ema is not None else "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
                                             "",
                                         ]
                                         if include_near_zero:


### PR DESCRIPTION
 ## 目的
・dq_delta のオートチューン関連に対して、quant_error ログを追加して「薄まり/クリップ歪み」を可視化する
・dq_delta のオートチューンのウォームアップ期間を延長する
・あわせてドキュメントの説明と対処ガイドを整備する

 ## 変更点
 - dq_delta ログに quant_error（RMS/Ratio と EMA）を追加（LogStep のみ）
 - DDP集約・per_module ログにも対応
 - warmup の更新回数を2倍に変更
 - dq_delta のオプション表と読み方/対処ガイドを docs に反映
 