### PR TITLE
Add effective-rank stats to dq_delta_log

### DIFF
--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -111,8 +111,8 @@
 ### 出力例（summary）
 
 ```
-Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,AbsMax,Range,ScaleMin,ScaleMean,ScaleMax,Qmax,ClipRateRaw,ClipRateEMA,ZeroRate,QuantErrRMSRaw,QuantErrRMSEMA,QuantErrRatioRaw,QuantErrRatioEMA,Numel,AutoApplied,RangeMulBefore,RangeMulAfter,WarmupActive,WarmupRemain,AutoReason,AutoInitMulApplied,AutoInitMulValue,AutoInitClipTarget
-2,3400,unet,delta,8,,3.0,rms,channel,stoch,0.0123,0.0912,0.0369,0.00020,0.00029,0.00041,127,0.0008,0.0007,0.034,0.0015,0.0014,0.12,0.11,12345678,1,3.0,3.21,0,0,clip_high,1,3.0,0.004
+Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,AbsMax,Range,ScaleMin,ScaleMean,ScaleMax,Qmax,ClipRateRaw,ClipRateEMA,ZeroRate,QuantErrRMSRaw,QuantErrRMSEMA,QuantErrRatioRaw,QuantErrRatioEMA,Numel,AutoApplied,RangeMulBefore,RangeMulAfter,WarmupActive,WarmupRemain,AutoReason,AutoInitMulApplied,AutoInitMulValue,AutoInitClipTarget,RankDim,RankSatWMean,RankSatP50,RankSatP95,RankSatMax,RankTop1P95,RankEnergySum
+2,3400,unet,delta,8,,3.0,rms,channel,stoch,0.0123,0.0912,0.0369,0.00020,0.00029,0.00041,127,0.0008,0.0007,0.034,0.0015,0.0014,0.12,0.11,12345678,1,3.0,3.21,0,0,clip_high,1,3.0,0.004,16,0.83,0.81,0.93,0.98,0.89,12.34
 ```
 
 ## ログの見方（初心者向け）
@@ -156,10 +156,18 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | AutoInitMulApplied | 初期化適用 | 1なら初期 range_mul 上書きが行われた。 |
 | AutoInitMulValue | 初期 range_mul | 自動算出された初期値（適用時）。 |
 | AutoInitClipTarget | 初期 clip_target | `(clip_low+clip_high)/2`。 |
+| RankDim | rank次元 | すべて同一なら r を表示、混在時は空欄。 |
+| RankSatWMean | 飽和度の重み付き平均 | エネルギー（更新量）で重み付けした飽和度。 |
+| RankSatP50 | 飽和度の中央値 | 層の典型的な詰まり具合。 |
+| RankSatP95 | 飽和度の95%点 | 一部層の詰まり具合の早期警戒。 |
+| RankSatMax | 飽和度の最大 | 最も詰まっている層。 |
+| RankTop1P95 | top1エネルギーの95%点 | 上位成分の支配度合い。 |
+| RankEnergySum | エネルギー合計 | `||ΔW||_F^2` の総量（スケール含む）。 |
 
 補足（読み解きの目安）:
 - `ClipRate` が低いのに `QuantErrRatio` が高い場合、**レンジが広く刻みが粗い**可能性がある（`range_mul` 高め / `bits` 低め）。
 - `QuantErrRatio` が低いのに `ClipRate` が高い場合、**クリップ歪み**が支配的な可能性がある。
+※ Rank 系は現状 `unet` のみ集計。`te` 行は空欄。
 
 ### logs（`--dq_delta_log`）: per_module
 
@@ -168,7 +176,7 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | Module | LoRAモジュール名 | どの層の統計か。 |
 | Shape | テンソル形状 | 層の規模感の目安。 |
 
-※ per_module は上記 summary の列に `Module/Shape` が追加されます。
+※ per_module は上記 summary の列に `Module/Shape` が追加され、さらに `RankDim/RankSat/RankTop1/RankEnergy` が追加されます（`unet` のみ、`te` は空欄）。
 
 ### auto（`--dq_delta_auto_log_file`）: minimal
 

--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -169,6 +169,7 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 - `QuantErrRatio` が低いのに `ClipRate` が高い場合、**クリップ歪み**が支配的な可能性がある。
 - `RankSat*` は **高いほど rank を使い切っている**ため、値が高止まりするほど **rank 不足の兆候**。低いほど余裕がある。
 - `RankTop1P95` が高いほど **実質 rank1 に偏っている**可能性が高い。
+- `RankEnergySum` は **LoRA 更新量の総量**。大きいほど LoRA の寄与が強い。
 ※ Rank 系は現状 `unet` のみ集計。`te` 行は空欄。
 
 ### logs（`--dq_delta_log`）: per_module

--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -167,6 +167,8 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 補足（読み解きの目安）:
 - `ClipRate` が低いのに `QuantErrRatio` が高い場合、**レンジが広く刻みが粗い**可能性がある（`range_mul` 高め / `bits` 低め）。
 - `QuantErrRatio` が低いのに `ClipRate` が高い場合、**クリップ歪み**が支配的な可能性がある。
+- `RankSat*` は **高いほど rank を使い切っている**ため、値が高止まりするほど **rank 不足の兆候**。低いほど余裕がある。
+- `RankTop1P95` が高いほど **実質 rank1 に偏っている**可能性が高い。
 ※ Rank 系は現状 `unet` のみ集計。`te` 行は空欄。
 
 ### logs（`--dq_delta_log`）: per_module

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -274,6 +274,73 @@ class DQStatsManager:
         }
 
 
+def _compute_lora_effective_rank_stats(lora, eps: float = 1e-12):
+    w_down = getattr(lora, "lora_down", None)
+    w_up = getattr(lora, "lora_up", None)
+    if w_down is None or w_up is None:
+        return None
+    w_down = w_down.weight
+    w_up = w_up.weight
+    if w_down is None or w_up is None:
+        return None
+
+    with torch.no_grad():
+        a = w_down.to(dtype=torch.float32)
+        b = w_up.to(dtype=torch.float32)
+        if a.dim() == 4:
+            a = a.reshape(a.shape[0], -1)
+        if b.dim() == 4:
+            b = b.reshape(b.shape[0], b.shape[1])
+        r = a.shape[0]
+        if r <= 0:
+            return None
+
+        p = b.transpose(0, 1) @ b
+        q = a @ a.transpose(0, 1)
+
+        eye = torch.eye(r, device=q.device, dtype=q.dtype)
+        diag_mean = torch.mean(torch.diag(q)) if r > 0 else torch.tensor(0.0, device=q.device, dtype=q.dtype)
+        jitter = eps * (diag_mean.abs() + 1.0)
+        l, info = torch.linalg.cholesky_ex(q + jitter * eye)
+        if int(info.item()) != 0:
+            eigvals, eigvecs = torch.linalg.eigh(q)
+            eigvals = torch.clamp(eigvals, min=0.0)
+            sqrt_q = eigvecs @ torch.diag(torch.sqrt(eigvals)) @ eigvecs.transpose(0, 1)
+            s = sqrt_q @ p @ sqrt_q
+        else:
+            s = l.transpose(0, 1) @ p @ l
+
+        s = (s + s.transpose(0, 1)) * 0.5
+        eigvals = torch.linalg.eigvalsh(s)
+        eigvals = torch.clamp(eigvals, min=0.0)
+        energy = eigvals.sum()
+        energy_val = float(energy.item())
+        scale = float(getattr(lora, "scale", 1.0))
+        mult = float(getattr(lora, "multiplier", 1.0))
+        energy_val *= (scale * mult) ** 2
+        if energy_val <= eps:
+            return {
+                "module": lora.lora_name,
+                "r": int(r),
+                "sat": 0.0,
+                "top1": 0.0,
+                "energy": energy_val,
+            }
+
+        w = eigvals / (energy + eps)
+        entropy = -(w * torch.log(w + eps)).sum()
+        r_eff = torch.exp(entropy)
+        sat = float(r_eff.item()) / float(r)
+        top1 = float(torch.max(w).item())
+        return {
+            "module": lora.lora_name,
+            "r": int(r),
+            "sat": sat,
+            "top1": top1,
+            "energy": energy_val,
+        }
+
+
 class LoRAModule(torch.nn.Module):
     """
     replaces forward method of the original Linear, instead of replacing the original Linear module.
@@ -1586,6 +1653,62 @@ class LoRANetwork(torch.nn.Module):
         if self.dq_stats_manager is None:
             return None
         return self.dq_stats_manager.export()
+
+    def compute_rank_stats(self, scope: str = "unet", eps: float = 1e-12):
+        if scope != "unet":
+            return None
+        loras = self.unet_loras
+        if not loras:
+            return None
+
+        per_module = []
+        with torch.no_grad():
+            for lora in loras:
+                stats = _compute_lora_effective_rank_stats(lora, eps=eps)
+                if stats is not None:
+                    per_module.append(stats)
+
+        if not per_module:
+            return None
+
+        energy_sum = float(sum(item["energy"] for item in per_module))
+        active = [item for item in per_module if item["energy"] > eps]
+        if active:
+            sat_values = [item["sat"] for item in active]
+            top1_values = [item["top1"] for item in active]
+        else:
+            sat_values = [item["sat"] for item in per_module]
+            top1_values = [item["top1"] for item in per_module]
+
+        def _quantile(values, q):
+            if not values:
+                return None
+            return float(np.quantile(np.asarray(values, dtype=np.float64), q))
+
+        sat_p50 = _quantile(sat_values, 0.5)
+        sat_p95 = _quantile(sat_values, 0.95)
+        sat_max = float(max(sat_values)) if sat_values else None
+        top1_p95 = _quantile(top1_values, 0.95)
+        sat_wmean = None
+        if energy_sum > eps:
+            sat_wmean = float(sum(item["energy"] * item["sat"] for item in per_module) / energy_sum)
+        else:
+            sat_wmean = 0.0
+
+        r_values = {item["r"] for item in per_module}
+        rank_dim = next(iter(r_values)) if len(r_values) == 1 else None
+
+        return {
+            "per_module": per_module,
+            "by_module": {item["module"]: item for item in per_module},
+            "rank_dim": rank_dim,
+            "sat_wmean": sat_wmean,
+            "sat_p50": sat_p50,
+            "sat_p95": sat_p95,
+            "sat_max": sat_max,
+            "top1_p95": top1_p95,
+            "energy_sum": energy_sum,
+        }
 
     def set_multiplier(self, multiplier):
         self.multiplier = multiplier

--- a/train_network.py
+++ b/train_network.py
@@ -867,6 +867,23 @@ class NetworkTrainer:
                 "AutoInitMulValue",
                 "AutoInitClipTarget",
             ]
+            if log_mode == "summary":
+                cols += [
+                    "RankDim",
+                    "RankSatWMean",
+                    "RankSatP50",
+                    "RankSatP95",
+                    "RankSatMax",
+                    "RankTop1P95",
+                    "RankEnergySum",
+                ]
+            else:
+                cols += [
+                    "RankDim",
+                    "RankSat",
+                    "RankTop1",
+                    "RankEnergy",
+                ]
             return ",".join(cols)
 
         def _dq_auto_log_header(full_schema: bool, include_near_zero: bool):
@@ -2471,6 +2488,18 @@ class NetworkTrainer:
                                     include_near_zero = "near_zero_rate" in dq_log_extra
                                     header = _dq_log_header(dq_log_mode, include_near_zero)
                                     log_scopes = ["unet", "te"] if dq_stats["log_scope"] == "both" else [dq_stats["log_scope"]]
+                                    rank_stats = None
+                                    rank_by_module = None
+                                    if "unet" in log_scopes:
+                                        unwrapped = accelerator.unwrap_model(network)
+                                        if hasattr(unwrapped, "compute_rank_stats"):
+                                            try:
+                                                rank_stats = unwrapped.compute_rank_stats(scope="unet")
+                                            except Exception as exc:
+                                                logger.warning("failed to compute rank stats: %s", str(exc))
+                                                rank_stats = None
+                                            if rank_stats is not None:
+                                                rank_by_module = rank_stats.get("by_module")
                                     quant_err_rms_ema = dq_quant_err_rms_ema_state
                                     quant_err_ratio_ema = dq_quant_err_ratio_ema_state
                                     if dq_stats["log_scope"] == "both":
@@ -2572,6 +2601,20 @@ class NetworkTrainer:
                                                     dq_auto_init_value if dq_auto_init_value is not None else "",
                                                     dq_auto_init_clip_target if dq_auto_init_clip_target is not None else "",
                                                 ]
+                                                rank_dim = rank_sat = rank_top1 = rank_energy = None
+                                                if scope == "unet" and rank_by_module is not None:
+                                                    rank_item = rank_by_module.get(item["module"])
+                                                    if rank_item is not None:
+                                                        rank_dim = rank_item.get("r")
+                                                        rank_sat = rank_item.get("sat")
+                                                        rank_top1 = rank_item.get("top1")
+                                                        rank_energy = rank_item.get("energy")
+                                                row += [
+                                                    rank_dim,
+                                                    rank_sat,
+                                                    rank_top1,
+                                                    rank_energy,
+                                                ]
                                                 _write_csv(dq_log_path, header, ",".join(_dq_format_value(v) for v in row))
                                         else:
                                             row = values + [
@@ -2603,6 +2646,24 @@ class NetworkTrainer:
                                                 dq_auto_init_applied,
                                                 dq_auto_init_value if dq_auto_init_value is not None else "",
                                                 dq_auto_init_clip_target if dq_auto_init_clip_target is not None else "",
+                                            ]
+                                            rank_dim = rank_sat_wmean = rank_sat_p50 = rank_sat_p95 = rank_sat_max = rank_top1_p95 = rank_energy_sum = None
+                                            if scope == "unet" and rank_stats is not None:
+                                                rank_dim = rank_stats.get("rank_dim")
+                                                rank_sat_wmean = rank_stats.get("sat_wmean")
+                                                rank_sat_p50 = rank_stats.get("sat_p50")
+                                                rank_sat_p95 = rank_stats.get("sat_p95")
+                                                rank_sat_max = rank_stats.get("sat_max")
+                                                rank_top1_p95 = rank_stats.get("top1_p95")
+                                                rank_energy_sum = rank_stats.get("energy_sum")
+                                            row += [
+                                                rank_dim,
+                                                rank_sat_wmean,
+                                                rank_sat_p50,
+                                                rank_sat_p95,
+                                                rank_sat_max,
+                                                rank_top1_p95,
+                                                rank_energy_sum,
                                             ]
                                             _write_csv(dq_log_path, header, ",".join(_dq_format_value(v) for v in row))
 
@@ -2649,6 +2710,15 @@ class NetworkTrainer:
                                             dq_auto_init_applied,
                                             dq_auto_init_value if dq_auto_init_value is not None else "",
                                             dq_auto_init_clip_target if dq_auto_init_clip_target is not None else "",
+                                        ]
+                                        row += [
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
+                                            "",
                                         ]
                                         _write_csv(dq_auto_log_path, header, ",".join(_dq_format_value(v) for v in row))
                                     else:


### PR DESCRIPTION
  ## 概要
  dq_delta_log に LoRA の effective rank（rank 飽和度）を追加。UNet のみ集計。

  ## 変更点
  - LoRA の A/B から r×r の Gram 行列で rank 統計を算出（SVD 回避）
  - dq_delta_log summary に Rank 系の列を追加
  - per_module に RankDim/RankSat/RankTop1/RankEnergy を追加
  - dq_delta_auto_log（full_schema）列整合のため空欄追加
  - docs 更新

  ## 影響範囲
  - dq_delta_log の CSV 列が増える（既存列の順序は維持）
  - `Scope=te` の行は Rank 系が空欄（UNet のみ集計）

  ## 補足
  - RankEnergySum は LoRA の scale/multiplier を反映した `||ΔW||_F^2` 相当
  - 数値安定性のため Cholesky 失敗時に固有分解へフォールバック