### PR TITLE
DQ delta: clip_rate_low_auto と診断ログ/レポートを追加

### DIFF
--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -185,7 +185,7 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | ActiveClipBand/Low/High | 現在のclip目標帯 | clip_rate_low_autoのescape前後の目標帯を追う。 |
 | ClipRateLowAutoState | clip_rate_low_auto 状態 | clip_rate_low_auto以外は空欄。 |
 | ClipRateLowAutoDecision | clip_rate_low_auto判断 | `observe`/`keep_low`/`bad_count`/`escape_to_mid`/`mid_lock`/`frozen`。 |
-| ClipRateLowAutoReason | clip_rate_low_auto判断理由 | `min_steps`/`low_bad`/`bad_streak_met`/`escaped_once`/`freeze_progress`/`insufficient_qerr_stats`。 |
+| ClipRateLowAutoReason | clip_rate_low_auto判断理由 | `min_progress`/`low_bad`/`bad_streak_met`/`escaped_once`/`freeze_progress`/`insufficient_qerr_stats`。 |
 | ClipRateLowAutoBad/ClipRateLowAutoBadStreak | bad判定と連続回数 | `mid` に逃がした根拠を追う。 |
 補足（読み解きの目安）:
 - `ClipRate` が低いのに `QuantErrRatio` が高い場合、**レンジが広く刻みが粗い**可能性がある（`range_mul` 高め / `bits` 低め）。
@@ -245,7 +245,7 @@ LogStep 以外の列は空欄（NA）で、追加統計は計算しません。
 - `--dq_delta_auto_warmup_updates <int>` : warmup 回数の上書き（0=内部デフォルト）
 - `--dq_delta_auto_log_file <path>` : 省略時は `--output_dir/dq_delta_auto+<output_name>.txt`（auto イベントのみ記録）
 - `--dq_delta_auto_log_format {minimal,full_schema}` : auto ログの列形式（デフォルト minimal）
-- `--dq_delta_clip_rate_low_auto_min_steps <int>` : `clip_rate_low_auto` の観測期間（デフォルト 6000 optimizer step）
+- `--dq_delta_clip_rate_low_auto_min_progress <float>` : `clip_rate_low_auto` の判定開始進捗（デフォルト 0.25）
 - `--dq_delta_clip_rate_low_auto_bad_streak <int>` : `clip_rate_low_auto` が `mid` へ逃がすまでのbad連続回数（デフォルト 3）
 - `--dq_delta_clip_rate_low_auto_freeze_progress <float>` : この学習進捗以降は `clip_rate_low_auto` のband切替を凍結（デフォルト 0.55）
 - `--dq_delta_clip_rate_low_auto_qerr_ratio <float>` : `clip_rate_low_auto` bad判定の `QuantErrRatioEMA` 閾値（デフォルト 0.25）
@@ -282,7 +282,7 @@ low_bad =
   and QErrPerClip >= dq_delta_clip_rate_low_auto_qerr_per_clip
 ```
 
-既定値は `QuantErrRatioEMA >= 0.25` かつ `QErrPerClip >= 130`。`dq_delta_clip_rate_low_auto_min_steps` 経過後に `low_bad` が `dq_delta_clip_rate_low_auto_bad_streak` 回連続したら、目標bandを `clip_rate_mid`（0.002〜0.004）へ切り替える。一度 `mid` に逃げた後は `low` へ戻さない。`dq_delta_clip_rate_low_auto_freeze_progress` 以降は新規のband切替を行わない。
+既定値は `QuantErrRatioEMA >= 0.25` かつ `QErrPerClip >= 130`。`dq_delta_clip_rate_low_auto_min_progress` 経過後に `low_bad` が `dq_delta_clip_rate_low_auto_bad_streak` 回連続したら、目標bandを `clip_rate_mid`（0.002〜0.004）へ切り替える。一度 `mid` に逃げた後は `low` へ戻さない。`dq_delta_clip_rate_low_auto_freeze_progress` 以降は新規のband切替を行わない。
 
 `QErrPerClip` は clip_rate_low_auto 以外でも診断列として出力される。これは preset 比較時に、clip率に対して量子化誤差が重くなっていないかを見るため。
 

--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -295,6 +295,12 @@ low_bad =
 
 既定値は `QuantErrRatioEMA >= 0.25` かつ `QErrPerClip >= 130`。`dq_delta_clip_rate_low_auto_min_progress` 経過後に `low_bad` が `dq_delta_clip_rate_low_auto_bad_streak` 回連続したら、目標bandを `clip_rate_mid`（0.002〜0.004）へ切り替える。一度 `mid` に逃げた後は `low` へ戻さない。`dq_delta_clip_rate_low_auto_freeze_progress` 以降は新規のband切替を行わない。
 
+#### 既定閾値の前提
+
+`clip_rate_low_auto` の既定閾値（`QuantErrRatioEMA=0.25`, `QErrPerClip=130`）は、主に `--dq_quantize_z` を使わない delta 量子化、`--dq_delta_mode stoch`、`8bit/channel/rms` のログを基準にした経験的な値。
+
+`--dq_quantize_z` や `--dq_delta_mode det` を使う場合、`ZeroRate` や `QErrPerClip` の分布が変わるため、同じ閾値は保守的な警告として扱う。特に z 量子化では `QErrPerClip` が高めに出ることがあり、`clip_rate_low_auto` が `mid` へ逃がす挙動は安全側に働く可能性がある。
+
 `QErrPerClip` は clip_rate_low_auto 以外でも診断列として出力される。これは preset 比較時に、clip率に対して量子化誤差が重くなっていないかを見るため。
 
 ### 発動条件（重要）

--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -167,6 +167,12 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | ClipRateLowAutoState | clip_rate_low_auto 状態 | `observe`/`keep_low`/`escape_to_mid`/`mid_lock`/`frozen`。clip_rate_low_auto以外は空欄。 |
 | ClipRateLowAutoBad | clip_rate_low_auto bad判定 | `QuantErrRatioEMA>=0.25` かつ `QErrPerClip>=130` の時 1。clip_rate_low_auto以外は空欄。 |
 | ClipRateLowAutoBadStreak | bad連続回数 | 既定では3回連続で `mid` へ逃がす。clip_rate_low_auto以外は空欄。 |
+| TrainProgress | 学習進捗 | `global_step / max_train_steps`。min/freeze境界を後から確認するための列。 |
+| ClipRateLowAutoMinProgress | low_auto判定開始進捗 | `--dq_delta_clip_rate_low_auto_min_progress` の値。clip_rate_low_auto以外は空欄。 |
+| ClipRateLowAutoFreezeProgress | low_auto切替凍結進捗 | `--dq_delta_clip_rate_low_auto_freeze_progress` の値。clip_rate_low_auto以外は空欄。 |
+| ClipRateLowAutoThresholdQErrRatio | low_auto QuantErrRatio閾値 | `--dq_delta_clip_rate_low_auto_qerr_ratio` の値。clip_rate_low_auto以外は空欄。 |
+| ClipRateLowAutoThresholdQErrPerClip | low_auto QErrPerClip閾値 | `--dq_delta_clip_rate_low_auto_qerr_per_clip` の値。clip_rate_low_auto以外は空欄。 |
+| ClipRateLowAutoPhase | low_auto判定フェーズ | `warmup`/`pre_min_progress`/`active`/`frozen`/`escaped`。clip_rate_low_auto以外は空欄。 |
 | ClipErrRMS | clip誤差RMS | `--dq_delta_log_error_parts`時のみ。range外でclampされた成分。 |
 | RoundErrRMS | round誤差RMS | `--dq_delta_log_error_parts`時のみ。range内で量子化丸めされた成分。 |
 | ClipErrRatio/RoundErrRatio | 各誤差RMS/RMS | clip/round どちらが重いかを見る。 |
@@ -187,6 +193,11 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | ClipRateLowAutoDecision | clip_rate_low_auto判断 | `observe`/`keep_low`/`bad_count`/`escape_to_mid`/`mid_lock`/`frozen`。 |
 | ClipRateLowAutoReason | clip_rate_low_auto判断理由 | `min_progress`/`low_bad`/`bad_streak_met`/`escaped_once`/`freeze_progress`/`insufficient_qerr_stats`。 |
 | ClipRateLowAutoBad/ClipRateLowAutoBadStreak | bad判定と連続回数 | `mid` に逃がした根拠を追う。 |
+| TrainProgress | 学習進捗 | `global_step / max_train_steps`。 |
+| ClipRateLowAutoMinProgress/ClipRateLowAutoFreezeProgress | low_auto進捗閾値 | min/freeze境界をログ単体から復元する。 |
+| ClipRateLowAutoThresholdQErrRatio/ClipRateLowAutoThresholdQErrPerClip | low_auto bad判定閾値 | CLIで指定した閾値をログ単体から復元する。 |
+| ClipRateLowAutoPhase | low_auto判定フェーズ | `warmup`/`pre_min_progress`/`active`/`frozen`/`escaped`。 |
+| ClipRateLowAutoCanEscape | low_auto切替可能状態 | min_progress以降、freeze_progress前、未escapeなら1。minimal autoログのみ。 |
 補足（読み解きの目安）:
 - `ClipRate` が低いのに `QuantErrRatio` が高い場合、**レンジが広く刻みが粗い**可能性がある（`range_mul` 高め / `bits` 低め）。
 - `QuantErrRatio` が低いのに `ClipRate` が高い場合、**クリップ歪み**が支配的な可能性がある。

--- a/docs/dq_delta_autotune_spec-ja.md
+++ b/docs/dq_delta_autotune_spec-ja.md
@@ -25,6 +25,7 @@
 - `--dq_delta_log_mode {summary,per_module}` : 出力粒度（デフォルト summary）
 - `--dq_delta_log_file <path>` : 省略時は `--output_dir/dq_delta_logs+<output_name>.txt`
 - `--dq_delta_log_extra {near_zero_rate}` : 追加ログ項目（デフォルト無効）
+- `--dq_delta_log_error_parts` : `QuantErr` を clip 成分と round 成分に分解した診断列を追加（デフォルト無効）
 
 ### 計測ポイント
 
@@ -54,6 +55,12 @@
 - `quant_err_ratio_raw` : `quant_err_rms_raw / (rms + eps)`（`eps=1e-12`）
 - `quant_err_ratio_ema` : `quant_err_ratio_raw` の EMA（係数は `dq_delta_auto_ema`）
   - EMA は scope 共通の 1 系列。`log_scope=both` の場合は unet+te 合算で更新。
+- `qerr_per_clip` : `quant_err_ratio_ema / max(clip_rate_ema, dq_delta_qerr_per_clip_floor)`。clip率に対して量子化誤差が重いかを見る診断値。
+- `qerr_per_clip_clip_floor` : `qerr_per_clip` の分母に使う clip率下限（デフォルト 0.001）。clip率が極端に低い時の過敏な比率上昇を抑える。
+- `active_clip_band` : 現在の目標clip帯（`default` / `low` / `mid` / `high` / `high_narrow` / `custom`）。
+- `active_clip_low,active_clip_high` : その時点でauto制御が使っている目標clip帯。`clip_rate_low_auto` では途中で `low` から `mid` に変わる。
+- `clip_rate_low_auto_state,clip_rate_low_auto_bad,clip_rate_low_auto_bad_streak` : `clip_rate_low_auto` 用の状態とbad判定。`clip_rate_low_auto` 以外では空欄。
+- 任意: `clip_err_rms,round_err_rms,clip_err_ratio,round_err_ratio,clip_share,round_share` : `--dq_delta_log_error_parts` 指定時のみ。`QuantErr` を clip 由来と round 由来に分けて確認する診断列。
 - `numel` : 計測対象の要素数（集計値）
 - 任意: `near_zero_rate` : `|x| < 0.5*scale` の割合（0 になりやすい帯域）
 - `auto_applied` : AutoStep で range_mul 更新が適用された場合は 1、それ以外は 0
@@ -89,6 +96,11 @@
 - `zero_rate = zero_count_sum / numel_sum`
 - `quant_err_rms = sqrt((sumsq_sum + xq_sumsq_sum - 2*xxq_sum) / numel_sum)`
 - `quant_err_ratio = quant_err_rms / (rms + eps)`（`eps=1e-12`）
+- `qerr_per_clip = quant_err_ratio_ema / max(clip_rate_ema, dq_delta_qerr_per_clip_floor)`
+- `clip_err_rms = sqrt(sum((x - x_clamped)^2) / numel_sum)`（`--dq_delta_log_error_parts` 時）
+- `round_err_rms = sqrt(sum((x_clamped - x_q)^2) / numel_sum)`（`--dq_delta_log_error_parts` 時）
+- `clip_err_ratio = clip_err_rms / (rms + eps)`、`round_err_ratio = round_err_rms / (rms + eps)`
+- `clip_share = clip_err_sumsq / max(total_err_sumsq, eps)`、`round_share = round_err_sumsq / max(total_err_sumsq, eps)`
 
 ※ `range_elem` は `granularity=channel` の場合はチャネル別 range をブロードキャストした per-element range を使う。  
 ※ 分散学習時は `numel_sum/sumsq_sum/clip_count_sum/zero_count_sum` を **all-reduce (sum)** してから算出する。  
@@ -100,19 +112,21 @@
 
 ### Auto 用統計（低負荷）
 
-- auto の判定に必要なのは **clip_rate** のみなので、`dq_delta_log` が無効な場合は以下に限定する。
+- 通常autoの判定に必要なのは **clip_rate** のみなので、`dq_delta_log` が無効な場合は以下に限定する。
   - `numel_sum`
   - `clip_count_sum`
   - （任意）`zero_count_sum`
 - **LogStep のみ**で **full stats**（`sumsq_sum/absmax/scale_*` など）を計測する。
   LogStep 以外の AutoStep は最小統計に限定する。
 - `quant_err_*` は full stats の一部として **LogStep のみ**で計算する。
+- 例外として `--dq_delta_auto_preset clip_rate_low_auto` では、AutoStep の判定に `QuantErrRatioEMA` / `QErrPerClip` を使うため、AutoStep でも full stats を計測する。
+- `--dq_delta_log_error_parts` の clip/round 分解は **LogStep のみ**で計測し、`clip_rate_low_auto` の第一版判定には使わない。
 
 ### 出力例（summary）
 
 ```
-Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,AbsMax,Range,ScaleMin,ScaleMean,ScaleMax,Qmax,ClipRateRaw,ClipRateEMA,ZeroRate,QuantErrRMSRaw,QuantErrRMSEMA,QuantErrRatioRaw,QuantErrRatioEMA,Numel,AutoApplied,RangeMulBefore,RangeMulAfter,WarmupActive,WarmupRemain,AutoReason,AutoInitMulApplied,AutoInitMulValue,AutoInitClipTarget
-2,3400,unet,delta,8,,3.0,rms,channel,stoch,0.0123,0.0912,0.0369,0.00020,0.00029,0.00041,127,0.0008,0.0007,0.034,0.0015,0.0014,0.12,0.11,12345678,1,3.0,3.21,0,0,clip_high,1,3.0,0.004
+Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,AbsMax,Range,ScaleMin,ScaleMean,ScaleMax,Qmax,ClipRateRaw,ClipRateEMA,ZeroRate,QuantErrRMSRaw,QuantErrRMSEMA,QuantErrRatioRaw,QuantErrRatioEMA,QErrPerClip,QErrPerClipClipFloor,ActiveClipBand,ActiveClipLow,ActiveClipHigh,ClipRateLowAutoState,ClipRateLowAutoBad,ClipRateLowAutoBadStreak,Numel,AutoApplied,RangeMulBefore,RangeMulAfter,WarmupActive,WarmupRemain,AutoReason,AutoInitMulApplied,AutoInitMulValue,AutoInitClipTarget
+2,3400,unet,delta,8,,3.0,rms,channel,stoch,0.0123,0.0912,0.0369,0.00020,0.00029,0.00041,127,0.0008,0.0007,0.034,0.0015,0.0014,0.12,0.11,157,0.001,low,0.0005,0.0022,keep_low,0,0,12345678,1,3.0,3.21,0,0,clip_high,1,3.0,0.004
 ```
 
 ## ログの見方（初心者向け）
@@ -146,6 +160,17 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | QuantErrRatioRaw | 誤差RMS/入力RMS | 入力に対する誤差の割合。 |
 | QuantErrRatioEMA | QuantErrRatio のEMA | 比率の安定した傾向を見る。 |
 | NearZeroRate | 0近傍の割合 | `--dq_delta_log_extra near_zero_rate`時のみ。 |
+| QErrPerClip | QuantErrRatioEMA / max(ClipRateEMA, floor) | clip率に対して誤差が重いかを見る。`clip_rate_low` が合わない時の早期兆候として使う。 |
+| QErrPerClipClipFloor | QErrPerClip の分母下限 | 比率が低clipで過敏に跳ねるのを抑えるための値。既定 0.001。 |
+| ActiveClipBand | 現在の目標clip帯 | `clip_rate_low_auto` では `low` から `mid` へ切り替わる。通常presetでも比較用に出力。 |
+| ActiveClipLow/High | 現在のclip帯下限/上限 | autoがどの帯を狙っているか確認する。 |
+| ClipRateLowAutoState | clip_rate_low_auto 状態 | `observe`/`keep_low`/`escape_to_mid`/`mid_lock`/`frozen`。clip_rate_low_auto以外は空欄。 |
+| ClipRateLowAutoBad | clip_rate_low_auto bad判定 | `QuantErrRatioEMA>=0.25` かつ `QErrPerClip>=130` の時 1。clip_rate_low_auto以外は空欄。 |
+| ClipRateLowAutoBadStreak | bad連続回数 | 既定では3回連続で `mid` へ逃がす。clip_rate_low_auto以外は空欄。 |
+| ClipErrRMS | clip誤差RMS | `--dq_delta_log_error_parts`時のみ。range外でclampされた成分。 |
+| RoundErrRMS | round誤差RMS | `--dq_delta_log_error_parts`時のみ。range内で量子化丸めされた成分。 |
+| ClipErrRatio/RoundErrRatio | 各誤差RMS/RMS | clip/round どちらが重いかを見る。 |
+| ClipShare/RoundShare | 全QuantErr中のclip/round寄与 | lowを守るためにround誤差が支配的になっていないか確認する。 |
 | Numel | 要素数 | 統計の母数。 |
 | AutoApplied | auto適用 | 1ならrange_mulが変化。 |
 | RangeMulBefore | 変更前 | auto適用時の前値。 |
@@ -156,6 +181,12 @@ Epoch,TrainStep,Scope,Target,Bits,DQStepSize,RangeMul,Stat,Granularity,Mode,RMS,
 | AutoInitMulApplied | 初期化適用 | 1なら初期 range_mul 上書きが行われた。 |
 | AutoInitMulValue | 初期 range_mul | 自動算出された初期値（適用時）。 |
 | AutoInitClipTarget | 初期 clip_target | `(clip_low+clip_high)/2`。 |
+| QErrPerClip | QuantErrRatioEMA / max(ClipRateEMA, floor) | full statsがあるAutoStepで記録。通常autoでは空欄になることがある。 |
+| ActiveClipBand/Low/High | 現在のclip目標帯 | clip_rate_low_autoのescape前後の目標帯を追う。 |
+| ClipRateLowAutoState | clip_rate_low_auto 状態 | clip_rate_low_auto以外は空欄。 |
+| ClipRateLowAutoDecision | clip_rate_low_auto判断 | `observe`/`keep_low`/`bad_count`/`escape_to_mid`/`mid_lock`/`frozen`。 |
+| ClipRateLowAutoReason | clip_rate_low_auto判断理由 | `min_steps`/`low_bad`/`bad_streak_met`/`escaped_once`/`freeze_progress`/`insufficient_qerr_stats`。 |
+| ClipRateLowAutoBad/ClipRateLowAutoBadStreak | bad判定と連続回数 | `mid` に逃がした根拠を追う。 |
 補足（読み解きの目安）:
 - `ClipRate` が低いのに `QuantErrRatio` が高い場合、**レンジが広く刻みが粗い**可能性がある（`range_mul` 高め / `bits` 低め）。
 - `QuantErrRatio` が低いのに `ClipRate` が高い場合、**クリップ歪み**が支配的な可能性がある。
@@ -199,7 +230,7 @@ LogStep 以外の列は空欄（NA）で、追加統計は計算しません。
 ### 有効化オプション
 
 - `--dq_delta_auto_range_mul` : range_mul の自動調整を有効化（デフォルト無効）
-- `--dq_delta_auto_preset {default,clip_rate_high,clip_rate_high_narrow,clip_rate_mid,clip_rate_low}` : auto range_mul のプリセット（指定時は clip_low/high のみ上書き）
+- `--dq_delta_auto_preset {default,clip_rate_high,clip_rate_high_narrow,clip_rate_mid,clip_rate_low,clip_rate_low_auto}` : auto range_mul のプリセット（指定時は clip_low/high のみ上書き。`clip_rate_low_auto` は途中でbandを切替）
 - `--dq_delta_auto_every <int>` : 調整間隔（optimizer step 単位、デフォルト 50）
 - `--dq_delta_auto_clip_low <float>` : clip_rate 下限（デフォルト 0.0005 = 0.05%）
 - `--dq_delta_auto_clip_high <float>` : clip_rate 上限（デフォルト 0.003 = 0.3%）
@@ -214,6 +245,12 @@ LogStep 以外の列は空欄（NA）で、追加統計は計算しません。
 - `--dq_delta_auto_warmup_updates <int>` : warmup 回数の上書き（0=内部デフォルト）
 - `--dq_delta_auto_log_file <path>` : 省略時は `--output_dir/dq_delta_auto+<output_name>.txt`（auto イベントのみ記録）
 - `--dq_delta_auto_log_format {minimal,full_schema}` : auto ログの列形式（デフォルト minimal）
+- `--dq_delta_clip_rate_low_auto_min_steps <int>` : `clip_rate_low_auto` の観測期間（デフォルト 6000 optimizer step）
+- `--dq_delta_clip_rate_low_auto_bad_streak <int>` : `clip_rate_low_auto` が `mid` へ逃がすまでのbad連続回数（デフォルト 3）
+- `--dq_delta_clip_rate_low_auto_freeze_progress <float>` : この学習進捗以降は `clip_rate_low_auto` のband切替を凍結（デフォルト 0.55）
+- `--dq_delta_clip_rate_low_auto_qerr_ratio <float>` : `clip_rate_low_auto` bad判定の `QuantErrRatioEMA` 閾値（デフォルト 0.25）
+- `--dq_delta_clip_rate_low_auto_qerr_per_clip <float>` : `clip_rate_low_auto` bad判定の `QErrPerClip` 閾値（デフォルト 130）
+- `--dq_delta_qerr_per_clip_floor <float>` : `QErrPerClip` 計算時の `ClipRateEMA` 下限（デフォルト 0.001）
 
 ### auto プリセット一覧
 
@@ -227,6 +264,27 @@ LogStep 以外の列は空欄（NA）で、追加統計は計算しません。
 | `clip_rate_high_narrow` | 0.0038 | 0.0048 | args | args | キャラクター学習向け2。狭い範囲を狙う。 |
 | `clip_rate_mid` | 0.002 | 0.004 | args | args | 中間帯の clip_rate を狙う。 |
 | `clip_rate_low` | 0.0005 | 0.0022 | args | args | defaultより安定方向に振る。 |
+| `clip_rate_low_auto` | 開始時 0.0005 | 開始時 0.0022 | args | args | low帯で開始し、low維持コストが高いと判断したら `clip_rate_mid` 帯へ一方向に逃がす。 |
+
+### `clip_rate_low_auto` プリセット
+
+`clip_rate_low` は低clipを狙うため、外れ値の影響を抑えられるデータでは有効なことがある。一方で、データによっては low帯を維持するために有効レンジを広げる必要があり、8bit量子化の刻みが粗くなって `QuantErr` が増えることがある。
+
+`clip_rate_low_auto` はこの「lowを維持するコストが高い」ケースを本番ラン中に検出し、low帯から中間帯へ逃がす保険として用意する。highへは自動で移動せず、第一版では `low -> mid` の一方向のみ。
+
+判定はシンプルに以下を使う。
+
+```
+QErrPerClip = QuantErrRatioEMA / max(ClipRateEMA, dq_delta_qerr_per_clip_floor)
+
+low_bad =
+  QuantErrRatioEMA >= dq_delta_clip_rate_low_auto_qerr_ratio
+  and QErrPerClip >= dq_delta_clip_rate_low_auto_qerr_per_clip
+```
+
+既定値は `QuantErrRatioEMA >= 0.25` かつ `QErrPerClip >= 130`。`dq_delta_clip_rate_low_auto_min_steps` 経過後に `low_bad` が `dq_delta_clip_rate_low_auto_bad_streak` 回連続したら、目標bandを `clip_rate_mid`（0.002〜0.004）へ切り替える。一度 `mid` に逃げた後は `low` へ戻さない。`dq_delta_clip_rate_low_auto_freeze_progress` 以降は新規のband切替を行わない。
+
+`QErrPerClip` は clip_rate_low_auto 以外でも診断列として出力される。これは preset 比較時に、clip率に対して量子化誤差が重くなっていないかを見るため。
 
 ### 発動条件（重要）
 

--- a/docs/dq_delta_mechanism-ja.md
+++ b/docs/dq_delta_mechanism-ja.md
@@ -162,6 +162,8 @@ bits モードでは概ね
 
 `clip_rate` を目標レンジに保つように `range_mul` を自動調整する。
 
+`--dq_delta_auto_preset clip_rate_low_auto` では、最初は `clip_rate_low` と同じ低clip帯を狙う。学習中に `QuantErrRatioEMA >= 0.25` かつ `QErrPerClip >= 130` が連続し、lowを維持するコストが高いと判断した場合は、目標clip帯を `clip_rate_mid` へ一方向に切り替える。これは低clipが合うデータではlowを維持し、低clipが合わないデータでは誤差が深くなる前に中間帯へ逃がすための保険である。
+
 ### 基本ロジック（AutoStep ごと）
 
 AutoStep のたびに
@@ -187,11 +189,19 @@ AutoStep のたびに
 -   `clip_rate_ema > clip_high` -> `range_mul *= mul_up`（レンジ拡大、クリップ減）
     
 -   `clip_rate_ema < clip_low` -> `range_mul *= mul_down`（レンジ縮小、クリップ増）
-    
+
 -   `--dq_delta_auto_use_raw` 指定時は `clip_rate_raw` も同時に判定
-    
+
 -   その後 `range_mul` を `[auto_min, auto_max]` にクランプ
-    
+
+補助診断:
+
+-   `QErrPerClip = QuantErrRatioEMA / max(ClipRateEMA, 0.001)`
+
+-   clip率に対して量子化誤差が重いかを見る指標。`clip_rate_low_auto` の判定にも使う。
+
+-   `--dq_delta_log_error_parts` を指定すると、`QuantErr` を `ClipErr` と `RoundErr` に分解してログに出す。第一版では判定には使わず、後から「clip由来かround由来か」を確認するための診断列として扱う。
+
 
 ### bits スケジュールとの関係
 

--- a/docs/make_lora_diagnostic_report-ja.md
+++ b/docs/make_lora_diagnostic_report-ja.md
@@ -122,6 +122,14 @@ JSONは時系列配列（`x`, `rows`, `series[*].y` など）が非常に長く�
 - `ClipRateRaw`, `ClipRateEMA`
 - `QuantErrRatioRaw`, `QuantErrRatioEMA`
 - `QuantErrRMSRaw`, `QuantErrRMSEMA`
+- `QErrPerClip`, `QErrPerClipClipFloor`
+- `ActiveClipBand`, `ActiveClipLow`, `ActiveClipHigh`
+- `ClipRateLowAutoState`, `ClipRateLowAutoBad`, `ClipRateLowAutoBadStreak`
+- `TrainProgress`
+- `ClipRateLowAutoMinProgress`, `ClipRateLowAutoFreezeProgress`
+- `ClipRateLowAutoThresholdQErrRatio`, `ClipRateLowAutoThresholdQErrPerClip`
+- `ClipRateLowAutoPhase`
+- `ClipErrRMS`, `RoundErrRMS`, `ClipErrRatio`, `RoundErrRatio`, `ClipShare`, `RoundShare`
 - `ZeroRate`, `AbsMax`, `Range`
 - `AutoReason`
 
@@ -136,6 +144,14 @@ JSONは時系列配列（`x`, `rows`, `series[*].y` など）が非常に長く�
 - `RangeMulBefore`, `RangeMulAfter`
 - `AutoApplied`, `WarmupActive`, `AutoReason`
 - `AutoInitClipTarget`
+- `QErrPerClip`, `QErrPerClipClipFloor`
+- `ActiveClipBand`, `ActiveClipLow`, `ActiveClipHigh`
+- `ClipRateLowAutoState`, `ClipRateLowAutoDecision`, `ClipRateLowAutoReason`
+- `ClipRateLowAutoBad`, `ClipRateLowAutoBadStreak`
+- `TrainProgress`
+- `ClipRateLowAutoMinProgress`, `ClipRateLowAutoFreezeProgress`
+- `ClipRateLowAutoThresholdQErrRatio`, `ClipRateLowAutoThresholdQErrPerClip`
+- `ClipRateLowAutoPhase`, `ClipRateLowAutoCanEscape`
 
 `dq.summary` の主なキー:
 
@@ -149,6 +165,18 @@ JSONは時系列配列（`x`, `rows`, `series[*].y` など）が非常に長く�
 - `final_clip_rate_ema`
 - `final_quant_err_ratio_ema`
 - `final_quant_err_rms_ema`
+- `final_qerr_per_clip`, `max_qerr_per_clip`, `tail_mean_qerr_per_clip`
+- `qerr_per_clip_threshold`
+- `run_qerr_ratio_threshold`, `run_qerr_per_clip_threshold`
+- `low_band_seen`, `low_auto_bad_count`, `low_auto_bad_ratio`, `low_auto_max_bad_streak`
+- `low_auto_escaped`, `low_auto_frozen_bad_count`
+- `low_auto_state_counts`, `low_auto_decision_counts`, `low_auto_reason_counts`
+- `low_auto_phase_counts`
+- `low_auto_min_progress`, `low_auto_freeze_progress`
+- `low_auto_min_progress_step`, `low_auto_freeze_progress_step`
+- `active_clip_band_final`, `active_clip_band_counts`
+- `clip_share_tail_mean`, `round_share_tail_mean`
+- `clip_err_ratio_tail_mean`, `round_err_ratio_tail_mean`
 - `final_zero_rate`
 
 ### `rank` セクション
@@ -270,6 +298,10 @@ JSONは時系列配列（`x`, `rows`, `series[*].y` など）が非常に長く�
 - `start_density`, `end_density`, `delta_density`
 
 ### `diagnostics` セクション
+
+DQ logsに `ActiveClipBand=low` または `ClipRateLowAuto*` 列がある場合のみ、`clip_rate_low適性` の診断を追加します。
+`QErrPerClip` は固定診断基準 `130` を主基準として評価します。ログに `ClipRateLowAutoThresholdQErrPerClip` がある場合は、run指定閾値も補足表示します。
+
 | JSONパス | 情報源 | 内容の概説 |
 |---|---|---|
 | `diagnostics.score` | `grad.summary` / `dq.summary` / `lora.diagnostic` から派生 | 100点満点の総合スコア |
@@ -286,6 +318,10 @@ JSONは時系列配列（`x`, `rows`, `series[*].y` など）が非常に長く�
 - `note`
 
 ### `charts` セクション
+
+DQ logsに該当列がある場合は、`QErrPerClip`（run指定閾値の水平線つき。130と異なる場合は固定130も表示）、`clip_rate_low_auto Bad / Streak`、`ClipErrRatio / RoundErrRatio`、`ClipShare / RoundShare` のグラフを追加します。
+`TrainProgress` と low_auto progress閾値がある場合は、min_progress / freeze_progress の位置をDQグラフの縦線マーカーに追加します。
+
 | JSONパス | 情報源 | 内容の概説 |
 |---|---|---|
 | `charts.grad[]` | `grad` から派生 | Grad系チャート定義 |

--- a/docs/sdxl_lora_recommended_settings-ja.md
+++ b/docs/sdxl_lora_recommended_settings-ja.md
@@ -90,7 +90,7 @@
 | `--dq_delta_bits_sched`（独自） | `0.0:8,0.9:10` | 進行率で bits を切替 | 終盤で刻みを細かくする 効果があるか不明　途中でbit数を増やすのと破綻しやすくなる可能性もありそう |
 | `--dq_delta_log`（独自） | 有効 | dq_delta の統計ログを出力 | クリップ率等の確認用 |
 | `--dq_delta_auto_range_mul`（独自） | 有効 | clip_rate を見て range_mul を自動調整 | 過/不足クリップを自動補正 データセットによっては初期値から変わらないこともある |
-| `--dq_delta_auto_preset`（独自） | clip_rate_high | auto 調整のプリセット | clip_low/high を高め側に 選択により味付けが変わる |
+| `--dq_delta_auto_preset`（独自） | clip_rate_high | auto 調整のプリセット | clip_low/high を選択。`clip_rate_low_auto` はlow帯で開始し、`QErrPerClip` が高い状態が続くとmid帯へ逃がす |
 | `--dq_delta_auto_init_range_mul_from_band`（独自） | 有効 | clip 帯中心から range_mul 初期値を算出 | `stat=rms` 前提 適正なrange_mulからスタートすることで安定させる |
 | `--dq_delta_auto_use_raw`（独自） | 有効 | auto 判定に ema だけでなくraw も併用 | range_mulの変化をなだらかにする |
 
@@ -99,6 +99,7 @@
 - 量子化はしないのが一番無難
 - 最初から量子化有で学習するとディティールが弱くなりやすいが、うまく行けば柔軟性が増す
 - まず量子化無で学習し、`--network_weights` でその重みを読み込んで量子化ありで追加学習するのもよい
+- `clip_rate_low` が合うデータもあるが、lowを維持するための量子化誤差が重くなる場合は `--dq_delta_auto_preset clip_rate_low_auto` でmid帯へ自動退避させる選択肢がある
 
 ## データセット設定例（dataset_config.toml）
 ```

--- a/networks/lora.py
+++ b/networks/lora.py
@@ -58,11 +58,19 @@ def _fake_quantize_levels_with_q(
 
 
 class DQStatsAccumulator:
-    def __init__(self, device, collect_full: bool, collect_zero: bool, collect_near_zero: bool):
+    def __init__(
+        self,
+        device,
+        collect_full: bool,
+        collect_zero: bool,
+        collect_near_zero: bool,
+        collect_error_parts: bool = False,
+    ):
         self.device = device
         self.collect_full = collect_full
         self.collect_zero = collect_zero
         self.collect_near_zero = collect_near_zero
+        self.collect_error_parts = collect_error_parts
         self.numel = torch.zeros(1, device=device, dtype=torch.float32)
         self.clip_count = torch.zeros(1, device=device, dtype=torch.float32)
         self.zero_count = torch.zeros(1, device=device, dtype=torch.float32) if collect_zero else None
@@ -75,6 +83,8 @@ class DQStatsAccumulator:
         self.scale_count = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
         self.xq_sumsq = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
         self.xxq_sum = torch.zeros(1, device=device, dtype=torch.float32) if collect_full else None
+        self.clip_err_sumsq = torch.zeros(1, device=device, dtype=torch.float32) if collect_error_parts else None
+        self.round_err_sumsq = torch.zeros(1, device=device, dtype=torch.float32) if collect_error_parts else None
 
     def add(
         self,
@@ -91,6 +101,8 @@ class DQStatsAccumulator:
         scale_max: Optional[torch.Tensor] = None,
         scale_sum: Optional[torch.Tensor] = None,
         scale_count: Optional[torch.Tensor] = None,
+        clip_err_sumsq: Optional[torch.Tensor] = None,
+        round_err_sumsq: Optional[torch.Tensor] = None,
     ):
         self.numel += numel
         self.clip_count += clip_count
@@ -115,6 +127,11 @@ class DQStatsAccumulator:
                 self.scale_sum += scale_sum
             if scale_count is not None:
                 self.scale_count += scale_count
+        if self.collect_error_parts:
+            if clip_err_sumsq is not None:
+                self.clip_err_sumsq += clip_err_sumsq
+            if round_err_sumsq is not None:
+                self.round_err_sumsq += round_err_sumsq
 
 
 class DQStatsManager:
@@ -124,6 +141,7 @@ class DQStatsManager:
         self.collect_full = False
         self.collect_zero = False
         self.collect_near_zero = False
+        self.collect_error_parts = False
         self.log_mode = "summary"
         self.log_scope = "both"
         self.auto_scope = "both"
@@ -135,8 +153,12 @@ class DQStatsManager:
 
     def _reset(self, device):
         self.accum = {
-            "unet": DQStatsAccumulator(device, self.collect_full, self.collect_zero, self.collect_near_zero),
-            "te": DQStatsAccumulator(device, self.collect_full, self.collect_zero, self.collect_near_zero),
+            "unet": DQStatsAccumulator(
+                device, self.collect_full, self.collect_zero, self.collect_near_zero, self.collect_error_parts
+            ),
+            "te": DQStatsAccumulator(
+                device, self.collect_full, self.collect_zero, self.collect_near_zero, self.collect_error_parts
+            ),
         }
         self.per_module = []
 
@@ -150,6 +172,7 @@ class DQStatsManager:
         collect_full: bool,
         collect_zero: bool,
         collect_near_zero: bool,
+        collect_error_parts: bool,
         log_mode: str,
         log_scope: str,
         auto_scope: str,
@@ -163,6 +186,7 @@ class DQStatsManager:
             self.collect_full = collect_full
             self.collect_zero = collect_zero
             self.collect_near_zero = collect_near_zero
+            self.collect_error_parts = collect_error_parts
             self.log_mode = log_mode
             self.log_scope = log_scope
             self.auto_scope = auto_scope
@@ -176,6 +200,7 @@ class DQStatsManager:
             self.collect_full = collect_full
             self.collect_zero = collect_zero
             self.collect_near_zero = collect_near_zero
+            self.collect_error_parts = collect_error_parts
             self.log_mode = log_mode
             self.log_scope = log_scope
             self.auto_scope = auto_scope
@@ -216,6 +241,8 @@ class DQStatsManager:
         scale_max: Optional[torch.Tensor],
         scale_sum: Optional[torch.Tensor],
         scale_count: Optional[torch.Tensor],
+        clip_err_sumsq: Optional[torch.Tensor],
+        round_err_sumsq: Optional[torch.Tensor],
     ):
         if not self._scope_enabled(scope):
             return
@@ -233,6 +260,8 @@ class DQStatsManager:
             scale_max=scale_max,
             scale_sum=scale_sum,
             scale_count=scale_count,
+            clip_err_sumsq=clip_err_sumsq,
+            round_err_sumsq=round_err_sumsq,
         )
         if self.do_log and self.log_mode == "per_module" and (self.log_scope == "both" or self.log_scope == scope):
             self.per_module.append(
@@ -252,6 +281,8 @@ class DQStatsManager:
                     "scale_max": scale_max.detach() if scale_max is not None else None,
                     "scale_sum": scale_sum.detach() if scale_sum is not None else None,
                     "scale_count": scale_count.detach() if scale_count is not None else None,
+                    "clip_err_sumsq": clip_err_sumsq.detach() if clip_err_sumsq is not None else None,
+                    "round_err_sumsq": round_err_sumsq.detach() if round_err_sumsq is not None else None,
                 }
             )
 
@@ -269,6 +300,7 @@ class DQStatsManager:
             "collect_full": self.collect_full,
             "collect_zero": self.collect_zero,
             "collect_near_zero": self.collect_near_zero,
+            "collect_error_parts": self.collect_error_parts,
             "accum": self.accum,
             "per_module": self.per_module,
         }
@@ -457,6 +489,7 @@ class LoRAModule(torch.nn.Module):
             if mgr.collect_near_zero and scale is not None:
                 near_zero_count = (x_in.abs() < (0.5 * scale)).to(torch.float32).sum()
             sumsq = xq_sumsq = xxq_sum = absmax = None
+            clip_err_sumsq = round_err_sumsq = None
             if mgr.collect_full:
                 x_fp32 = x_in.to(torch.float32)
                 x_flat = x_fp32.reshape(-1)
@@ -466,6 +499,14 @@ class LoRAModule(torch.nn.Module):
                 xq_sumsq = torch.dot(q_flat, q_flat)
                 xxq_sum = torch.dot(x_flat, q_flat)
                 absmax = x_in.abs().max()
+                if mgr.collect_error_parts and q_clamp is not None and scale is not None:
+                    x_clamped = q_clamp.to(torch.float32) * scale.to(device=device, dtype=torch.float32)
+                    clip_err = x_fp32 - x_clamped
+                    round_err = x_clamped - q_fp32
+                    clip_err_flat = clip_err.reshape(-1)
+                    round_err_flat = round_err.reshape(-1)
+                    clip_err_sumsq = torch.dot(clip_err_flat, clip_err_flat)
+                    round_err_sumsq = torch.dot(round_err_flat, round_err_flat)
             scale_min = scale_max = scale_sum = scale_count = None
             if mgr.collect_full and scale is not None:
                 scale_min = scale.min()
@@ -489,6 +530,8 @@ class LoRAModule(torch.nn.Module):
                 scale_max=scale_max,
                 scale_sum=scale_sum,
                 scale_count=scale_count,
+                clip_err_sumsq=clip_err_sumsq,
+                round_err_sumsq=round_err_sumsq,
             )
 
     def forward(self, x):
@@ -1623,6 +1666,7 @@ class LoRANetwork(torch.nn.Module):
         collect_full: bool,
         collect_zero: bool,
         collect_near_zero: bool,
+        collect_error_parts: bool = False,
         log_mode: str,
         log_scope: str,
         auto_scope: str,
@@ -1638,6 +1682,7 @@ class LoRANetwork(torch.nn.Module):
             collect_full=collect_full,
             collect_zero=collect_zero,
             collect_near_zero=collect_near_zero,
+            collect_error_parts=collect_error_parts,
             log_mode=log_mode,
             log_scope=log_scope,
             auto_scope=auto_scope,

--- a/tools/make_lora_diagnostic_report.py
+++ b/tools/make_lora_diagnostic_report.py
@@ -21,6 +21,7 @@ ColorPalette = [
 ]
 
 DEFAULT_LORA_EPOCH_TREND_MAX_SERIES = 18
+DQ_LOW_QERR_PER_CLIP_THRESHOLD = 130.0
 
 
 def module_label(module: str) -> str:
@@ -376,6 +377,26 @@ def parse_dq_logs(
                 "QuantErrRatioEMA": safe_float(row.get("QuantErrRatioEMA")),
                 "QuantErrRMSRaw": safe_float(row.get("QuantErrRMSRaw")),
                 "QuantErrRMSEMA": safe_float(row.get("QuantErrRMSEMA")),
+                "QErrPerClip": safe_float(row.get("QErrPerClip")),
+                "QErrPerClipClipFloor": safe_float(row.get("QErrPerClipClipFloor")),
+                "ActiveClipBand": (row.get("ActiveClipBand") or "").strip(),
+                "ActiveClipLow": safe_float(row.get("ActiveClipLow")),
+                "ActiveClipHigh": safe_float(row.get("ActiveClipHigh")),
+                "ClipRateLowAutoState": (row.get("ClipRateLowAutoState") or "").strip(),
+                "ClipRateLowAutoBad": safe_int(row.get("ClipRateLowAutoBad")),
+                "ClipRateLowAutoBadStreak": safe_int(row.get("ClipRateLowAutoBadStreak")),
+                "TrainProgress": safe_float(row.get("TrainProgress")),
+                "ClipRateLowAutoMinProgress": safe_float(row.get("ClipRateLowAutoMinProgress")),
+                "ClipRateLowAutoFreezeProgress": safe_float(row.get("ClipRateLowAutoFreezeProgress")),
+                "ClipRateLowAutoThresholdQErrRatio": safe_float(row.get("ClipRateLowAutoThresholdQErrRatio")),
+                "ClipRateLowAutoThresholdQErrPerClip": safe_float(row.get("ClipRateLowAutoThresholdQErrPerClip")),
+                "ClipRateLowAutoPhase": (row.get("ClipRateLowAutoPhase") or "").strip(),
+                "ClipErrRMS": safe_float(row.get("ClipErrRMS")),
+                "RoundErrRMS": safe_float(row.get("RoundErrRMS")),
+                "ClipErrRatio": safe_float(row.get("ClipErrRatio")),
+                "RoundErrRatio": safe_float(row.get("RoundErrRatio")),
+                "ClipShare": safe_float(row.get("ClipShare")),
+                "RoundShare": safe_float(row.get("RoundShare")),
                 "ZeroRate": safe_float(row.get("ZeroRate")),
                 "AbsMax": safe_float(row.get("AbsMax")),
                 "Range": safe_float(row.get("Range")),
@@ -403,6 +424,23 @@ def parse_dq_logs(
                     "WarmupActive": safe_int(row.get("WarmupActive")),
                     "AutoReason": (row.get("AutoReason") or "").strip(),
                     "AutoInitClipTarget": safe_float(row.get("AutoInitClipTarget")),
+                    "QErrPerClip": safe_float(row.get("QErrPerClip")),
+                    "QErrPerClipClipFloor": safe_float(row.get("QErrPerClipClipFloor")),
+                    "ActiveClipBand": (row.get("ActiveClipBand") or "").strip(),
+                    "ActiveClipLow": safe_float(row.get("ActiveClipLow")),
+                    "ActiveClipHigh": safe_float(row.get("ActiveClipHigh")),
+                    "ClipRateLowAutoState": (row.get("ClipRateLowAutoState") or "").strip(),
+                    "ClipRateLowAutoDecision": (row.get("ClipRateLowAutoDecision") or "").strip(),
+                    "ClipRateLowAutoReason": (row.get("ClipRateLowAutoReason") or "").strip(),
+                    "ClipRateLowAutoBad": safe_int(row.get("ClipRateLowAutoBad")),
+                    "ClipRateLowAutoBadStreak": safe_int(row.get("ClipRateLowAutoBadStreak")),
+                    "TrainProgress": safe_float(row.get("TrainProgress")),
+                    "ClipRateLowAutoMinProgress": safe_float(row.get("ClipRateLowAutoMinProgress")),
+                    "ClipRateLowAutoFreezeProgress": safe_float(row.get("ClipRateLowAutoFreezeProgress")),
+                    "ClipRateLowAutoThresholdQErrRatio": safe_float(row.get("ClipRateLowAutoThresholdQErrRatio")),
+                    "ClipRateLowAutoThresholdQErrPerClip": safe_float(row.get("ClipRateLowAutoThresholdQErrPerClip")),
+                    "ClipRateLowAutoPhase": (row.get("ClipRateLowAutoPhase") or "").strip(),
+                    "ClipRateLowAutoCanEscape": safe_int(row.get("ClipRateLowAutoCanEscape")),
                 }
             )
         auto_rows.sort(key=lambda item: item["TrainStep"])
@@ -458,6 +496,80 @@ def parse_dq_logs(
             variance = sum((x - tail_mean) ** 2 for x in tail) / len(tail)
             clip_ema_cv = math.sqrt(variance) / tail_mean
 
+    low_diag_source = auto_rows if auto_rows else parsed_rows
+    qerr_per_clip_values = [item["QErrPerClip"] for item in low_diag_source if item.get("QErrPerClip") is not None]
+    qerr_tail_mean = mean_tail(qerr_per_clip_values, 0.25, True) if qerr_per_clip_values else None
+    qerr_max = max(qerr_per_clip_values) if qerr_per_clip_values else None
+    final_qerr_per_clip = qerr_per_clip_values[-1] if qerr_per_clip_values else None
+    low_auto_bad_values = [
+        item["ClipRateLowAutoBad"] for item in low_diag_source if item.get("ClipRateLowAutoBad") is not None
+    ]
+    low_auto_bad_count = sum(1 for value in low_auto_bad_values if value == 1)
+    low_auto_bad_ratio = safe_ratio(float(low_auto_bad_count), float(len(low_auto_bad_values))) if low_auto_bad_values else None
+    low_auto_streak_values = [
+        item["ClipRateLowAutoBadStreak"]
+        for item in low_diag_source
+        if item.get("ClipRateLowAutoBadStreak") is not None
+    ]
+    low_auto_states = [str(item.get("ClipRateLowAutoState") or "") for item in low_diag_source]
+    low_auto_decisions = [str(item.get("ClipRateLowAutoDecision") or "") for item in low_diag_source]
+    low_auto_reasons = [str(item.get("ClipRateLowAutoReason") or "") for item in low_diag_source]
+    low_auto_phases = [str(item.get("ClipRateLowAutoPhase") or "") for item in low_diag_source]
+    low_auto_escaped = any(value in ("escape_to_mid", "mid_lock") for value in low_auto_states + low_auto_decisions)
+    low_auto_frozen_bad_count = sum(
+        1
+        for item in low_diag_source
+        if item.get("ClipRateLowAutoBad") == 1
+        and (
+            item.get("ClipRateLowAutoState") == "frozen"
+            or item.get("ClipRateLowAutoReason") == "freeze_progress"
+        )
+    )
+    active_bands = [str(item.get("ActiveClipBand") or "") for item in low_diag_source if item.get("ActiveClipBand")]
+    active_band_counts = dict(Counter(active_bands))
+    active_clip_band_final = active_bands[-1] if active_bands else None
+    low_band_seen = any(band == "low" for band in active_bands) or bool(low_auto_bad_values)
+    run_qerr_ratio_thresholds = [
+        item["ClipRateLowAutoThresholdQErrRatio"]
+        for item in low_diag_source
+        if item.get("ClipRateLowAutoThresholdQErrRatio") is not None
+    ]
+    run_qerr_per_clip_thresholds = [
+        item["ClipRateLowAutoThresholdQErrPerClip"]
+        for item in low_diag_source
+        if item.get("ClipRateLowAutoThresholdQErrPerClip") is not None
+    ]
+    min_progress_values = [
+        item["ClipRateLowAutoMinProgress"]
+        for item in low_diag_source
+        if item.get("ClipRateLowAutoMinProgress") is not None
+    ]
+    freeze_progress_values = [
+        item["ClipRateLowAutoFreezeProgress"]
+        for item in low_diag_source
+        if item.get("ClipRateLowAutoFreezeProgress") is not None
+    ]
+    progress_rows = [item for item in low_diag_source if item.get("TrainProgress") is not None]
+    min_progress_value = min_progress_values[-1] if min_progress_values else None
+    freeze_progress_value = freeze_progress_values[-1] if freeze_progress_values else None
+    min_progress_step = None
+    freeze_progress_step = None
+    if min_progress_value is not None:
+        for item in progress_rows:
+            if item.get("TrainProgress") is not None and item["TrainProgress"] >= min_progress_value:
+                min_progress_step = item.get("TrainStep")
+                break
+    if freeze_progress_value is not None:
+        for item in progress_rows:
+            if item.get("TrainProgress") is not None and item["TrainProgress"] >= freeze_progress_value:
+                freeze_progress_step = item.get("TrainStep")
+                break
+
+    clip_share_values = [item["ClipShare"] for item in parsed_rows if item.get("ClipShare") is not None]
+    round_share_values = [item["RoundShare"] for item in parsed_rows if item.get("RoundShare") is not None]
+    clip_err_ratio_values = [item["ClipErrRatio"] for item in parsed_rows if item.get("ClipErrRatio") is not None]
+    round_err_ratio_values = [item["RoundErrRatio"] for item in parsed_rows if item.get("RoundErrRatio") is not None]
+
     summary = {
         "rows": len(parsed_rows),
         "auto_rows": len(auto_rows),
@@ -471,6 +583,32 @@ def parse_dq_logs(
         "final_clip_rate_ema": latest.get("ClipRateEMA"),
         "final_quant_err_ratio_ema": latest.get("QuantErrRatioEMA"),
         "final_quant_err_rms_ema": latest.get("QuantErrRMSEMA"),
+        "final_qerr_per_clip": final_qerr_per_clip,
+        "max_qerr_per_clip": qerr_max,
+        "tail_mean_qerr_per_clip": qerr_tail_mean,
+        "qerr_per_clip_threshold": DQ_LOW_QERR_PER_CLIP_THRESHOLD,
+        "run_qerr_ratio_threshold": run_qerr_ratio_thresholds[-1] if run_qerr_ratio_thresholds else None,
+        "run_qerr_per_clip_threshold": run_qerr_per_clip_thresholds[-1] if run_qerr_per_clip_thresholds else None,
+        "low_band_seen": low_band_seen,
+        "low_auto_bad_count": low_auto_bad_count if low_auto_bad_values else None,
+        "low_auto_bad_ratio": low_auto_bad_ratio,
+        "low_auto_max_bad_streak": max(low_auto_streak_values) if low_auto_streak_values else None,
+        "low_auto_escaped": low_auto_escaped if low_auto_bad_values or low_auto_states or low_auto_decisions else None,
+        "low_auto_frozen_bad_count": low_auto_frozen_bad_count if low_auto_bad_values else None,
+        "low_auto_state_counts": dict(Counter(value for value in low_auto_states if value)),
+        "low_auto_decision_counts": dict(Counter(value for value in low_auto_decisions if value)),
+        "low_auto_reason_counts": dict(Counter(value for value in low_auto_reasons if value)),
+        "low_auto_phase_counts": dict(Counter(value for value in low_auto_phases if value)),
+        "low_auto_min_progress": min_progress_value,
+        "low_auto_freeze_progress": freeze_progress_value,
+        "low_auto_min_progress_step": min_progress_step,
+        "low_auto_freeze_progress_step": freeze_progress_step,
+        "active_clip_band_final": active_clip_band_final,
+        "active_clip_band_counts": active_band_counts,
+        "clip_share_tail_mean": mean_tail(clip_share_values, 0.25, True) if clip_share_values else None,
+        "round_share_tail_mean": mean_tail(round_share_values, 0.25, True) if round_share_values else None,
+        "clip_err_ratio_tail_mean": mean_tail(clip_err_ratio_values, 0.25, True) if clip_err_ratio_values else None,
+        "round_err_ratio_tail_mean": mean_tail(round_err_ratio_values, 0.25, True) if round_err_ratio_values else None,
         "final_zero_rate": latest.get("ZeroRate"),
     }
 
@@ -1274,6 +1412,57 @@ def build_diagnostics(
             }
         )
 
+        if dq_summary.get("low_band_seen"):
+            qerr_per_clip_tail = dq_summary.get("tail_mean_qerr_per_clip")
+            qerr_per_clip_max = dq_summary.get("max_qerr_per_clip")
+            max_bad_streak = dq_summary.get("low_auto_max_bad_streak")
+            frozen_bad_count = dq_summary.get("low_auto_frozen_bad_count")
+            escaped = dq_summary.get("low_auto_escaped")
+            bad_count = dq_summary.get("low_auto_bad_count")
+            run_qerr_threshold = dq_summary.get("run_qerr_per_clip_threshold")
+            run_threshold_note = ""
+            if run_qerr_threshold is not None and abs(run_qerr_threshold - DQ_LOW_QERR_PER_CLIP_THRESHOLD) > 1e-9:
+                run_threshold_note = f" run指定閾値は{run_qerr_threshold:g}。"
+            if escaped or (frozen_bad_count is not None and frozen_bad_count > 0):
+                status = "bad"
+                note = "要改善 (low帯では誤差負荷が高い可能性。clip_rate_midまたはclip_rate_highでの再実行を推奨)"
+            elif qerr_per_clip_tail is not None and qerr_per_clip_tail >= DQ_LOW_QERR_PER_CLIP_THRESHOLD:
+                status = "bad"
+                note = "要改善 (QErrPerClipが固定診断閾値130以上で継続)"
+            elif (
+                (qerr_per_clip_max is not None and qerr_per_clip_max >= DQ_LOW_QERR_PER_CLIP_THRESHOLD)
+                or (max_bad_streak is not None and max_bad_streak >= 2)
+                or (bad_count is not None and bad_count > 0)
+            ):
+                status = "warn"
+                note = "注意 (low帯で一時的に誤差負荷が高い。mid/highとの比較候補)"
+            elif qerr_per_clip_tail is None:
+                status = "info"
+                note = "データ不足 (QErrPerClip列が無いためlow適性は判定不可)"
+            else:
+                status = "good"
+                note = "良好 (low clip帯でもQErrPerClipは安定)"
+            checks.append(
+                {
+                    "section": "DQ",
+                    "name": "clip_rate_low適性",
+                    "value": fmt_float(qerr_per_clip_tail, 2),
+                    "status": status,
+                    "note": note + run_threshold_note,
+                }
+            )
+
+            if frozen_bad_count is not None and frozen_bad_count > 0:
+                checks.append(
+                    {
+                        "section": "DQ",
+                        "name": "low_auto凍結後bad",
+                        "value": str(frozen_bad_count),
+                        "status": "warn",
+                        "note": "freeze_progress後にbadが出ています。この実行ではmidへ逃げませんが、次回はlow以外の比較を推奨します。",
+                    }
+                )
+
     if rank_data:
         rank_summary = rank_data.get("summary", {})
         rank_sat_p95 = rank_summary.get("final_rank_sat_p95")
@@ -1441,14 +1630,32 @@ def build_chart_payload(
 
     if dq_data:
         rows = dq_data.get("rows", [])
+        auto_rows = dq_data.get("auto_rows", [])
         x = [item.get("TrainStep") for item in rows]
-        markers = dq_data.get("markers", [])
+        markers = list(dq_data.get("markers", []))
+        dq_summary = dq_data.get("summary", {})
+        if dq_summary.get("low_auto_min_progress_step") is not None:
+            markers.append({"x": dq_summary.get("low_auto_min_progress_step"), "label": "min_progress"})
+        if dq_summary.get("low_auto_freeze_progress_step") is not None:
+            markers.append({"x": dq_summary.get("low_auto_freeze_progress_step"), "label": "freeze_progress"})
 
         def series_for(keys: List[Tuple[str, str, str]]) -> List[Dict[str, Any]]:
             output = []
             for field, label, color in keys:
                 output.append({"name": label, "color": color, "y": [item.get(field) for item in rows]})
             return output
+
+        def series_for_source(source_rows: List[Dict[str, Any]], keys: List[Tuple[str, str, str]]) -> List[Dict[str, Any]]:
+            output = []
+            for field, label, color in keys:
+                output.append({"name": label, "color": color, "y": [item.get(field) for item in source_rows]})
+            return output
+
+        def has_series_value(field: str) -> bool:
+            return any(item.get(field) is not None for item in rows)
+
+        def has_source_series_value(source_rows: List[Dict[str, Any]], field: str) -> bool:
+            return any(item.get(field) is not None for item in source_rows)
 
         payload["dq"] = [
             {
@@ -1483,7 +1690,12 @@ def build_chart_payload(
                 "y_tick_step": 0.001,
                 "y_tick_precision": 3,
                 "series": series_for(
-                    [("ClipRateRaw", "ClipRateRaw", ColorPalette[2]), ("ClipRateEMA", "ClipRateEMA", ColorPalette[0])]
+                    [
+                        ("ClipRateRaw", "ClipRateRaw", ColorPalette[2]),
+                        ("ClipRateEMA", "ClipRateEMA", ColorPalette[0]),
+                        ("ActiveClipLow", "ActiveClipLow", "#64748b"),
+                        ("ActiveClipHigh", "ActiveClipHigh", "#334155"),
+                    ]
                 ),
             },
             {
@@ -1554,6 +1766,112 @@ def build_chart_payload(
                 "series": series_for([("Range", "Range", ColorPalette[5])]),
             },
         ]
+
+        qerr_chart_rows = rows if has_series_value("QErrPerClip") else auto_rows
+        qerr_chart_x = [item.get("TrainStep") for item in qerr_chart_rows]
+        if has_source_series_value(qerr_chart_rows, "QErrPerClip"):
+            run_qerr_threshold = dq_summary.get("run_qerr_per_clip_threshold") or DQ_LOW_QERR_PER_CLIP_THRESHOLD
+            qerr_threshold_series = [
+                {
+                    "name": f"Run threshold {run_qerr_threshold:g}",
+                    "color": ColorPalette[2],
+                    "y": [run_qerr_threshold if step is not None else None for step in qerr_chart_x],
+                }
+            ]
+            if abs(run_qerr_threshold - DQ_LOW_QERR_PER_CLIP_THRESHOLD) > 1e-9:
+                qerr_threshold_series.append(
+                    {
+                        "name": "Fixed reference 130",
+                        "color": "#94a3b8",
+                        "y": [DQ_LOW_QERR_PER_CLIP_THRESHOLD if step is not None else None for step in qerr_chart_x],
+                    }
+                )
+            payload["dq"].append(
+                {
+                    "id": "dq_qerr_per_clip",
+                    "title": "QErrPerClip",
+                    "subtitle": "QErrPerClip = QuantErrRatioEMA / max(ClipRateEMA, floor).",
+                    "x_label": "TrainStep",
+                    "markers": markers,
+                    "x": qerr_chart_x,
+                    "y_min_fixed": 0.0,
+                    "y_max_ceil": max(run_qerr_threshold, DQ_LOW_QERR_PER_CLIP_THRESHOLD),
+                    "y_tick_step": 25.0,
+                    "y_tick_precision": 0,
+                    "series": series_for_source(qerr_chart_rows, [("QErrPerClip", "QErrPerClip", ColorPalette[0])])
+                    + qerr_threshold_series,
+                }
+            )
+
+        low_auto_chart_rows = (
+            rows
+            if has_series_value("ClipRateLowAutoBad") or has_series_value("ClipRateLowAutoBadStreak")
+            else auto_rows
+        )
+        low_auto_chart_x = [item.get("TrainStep") for item in low_auto_chart_rows]
+        if has_source_series_value(low_auto_chart_rows, "ClipRateLowAutoBad") or has_source_series_value(
+            low_auto_chart_rows, "ClipRateLowAutoBadStreak"
+        ):
+            payload["dq"].append(
+                {
+                    "id": "dq_low_auto_bad",
+                    "title": "clip_rate_low_auto Bad / Streak",
+                    "x_label": "TrainStep",
+                    "markers": markers,
+                    "x": low_auto_chart_x,
+                    "y_min_fixed": 0.0,
+                    "y_tick_step": 1.0,
+                    "y_tick_integer": True,
+                    "series": series_for_source(
+                        low_auto_chart_rows,
+                        [
+                            ("ClipRateLowAutoBad", "Bad", ColorPalette[2]),
+                            ("ClipRateLowAutoBadStreak", "BadStreak", ColorPalette[4]),
+                        ]
+                    ),
+                }
+            )
+
+        if has_series_value("ClipErrRatio") or has_series_value("RoundErrRatio"):
+            payload["dq"].append(
+                {
+                    "id": "dq_error_part_ratio",
+                    "title": "ClipErrRatio / RoundErrRatio",
+                    "x_label": "TrainStep",
+                    "markers": markers,
+                    "x": x,
+                    "y_min_fixed": 0.0,
+                    "y_tick_step": 0.05,
+                    "y_tick_precision": 2,
+                    "series": series_for(
+                        [
+                            ("ClipErrRatio", "ClipErrRatio", ColorPalette[2]),
+                            ("RoundErrRatio", "RoundErrRatio", ColorPalette[0]),
+                        ]
+                    ),
+                }
+            )
+
+        if has_series_value("ClipShare") or has_series_value("RoundShare"):
+            payload["dq"].append(
+                {
+                    "id": "dq_error_part_share",
+                    "title": "ClipShare / RoundShare",
+                    "x_label": "TrainStep",
+                    "markers": markers,
+                    "x": x,
+                    "y_min_fixed": 0.0,
+                    "y_max_fixed": 1.0,
+                    "y_tick_step": 0.1,
+                    "y_tick_precision": 1,
+                    "series": series_for(
+                        [
+                            ("ClipShare", "ClipShare", ColorPalette[2]),
+                            ("RoundShare", "RoundShare", ColorPalette[0]),
+                        ]
+                    ),
+                }
+            )
 
     if rank_data:
         rows = rank_data.get("rows", [])

--- a/tools/make_lora_diagnostic_report.py
+++ b/tools/make_lora_diagnostic_report.py
@@ -496,7 +496,8 @@ def parse_dq_logs(
             variance = sum((x - tail_mean) ** 2 for x in tail) / len(tail)
             clip_ema_cv = math.sqrt(variance) / tail_mean
 
-    low_diag_source = auto_rows if auto_rows else parsed_rows
+    auto_has_qerr_per_clip = any(item.get("QErrPerClip") is not None for item in auto_rows)
+    low_diag_source = auto_rows if auto_has_qerr_per_clip else parsed_rows
     qerr_per_clip_values = [item["QErrPerClip"] for item in low_diag_source if item.get("QErrPerClip") is not None]
     qerr_tail_mean = mean_tail(qerr_per_clip_values, 0.25, True) if qerr_per_clip_values else None
     qerr_max = max(qerr_per_clip_values) if qerr_per_clip_values else None

--- a/train_network.py
+++ b/train_network.py
@@ -1204,6 +1204,12 @@ class NetworkTrainer:
                 "ClipRateLowAutoState",
                 "ClipRateLowAutoBad",
                 "ClipRateLowAutoBadStreak",
+                "TrainProgress",
+                "ClipRateLowAutoMinProgress",
+                "ClipRateLowAutoFreezeProgress",
+                "ClipRateLowAutoThresholdQErrRatio",
+                "ClipRateLowAutoThresholdQErrPerClip",
+                "ClipRateLowAutoPhase",
             ]
             if dq_log_error_parts:
                 cols += [
@@ -1267,7 +1273,10 @@ class NetworkTrainer:
                 "TrainStep,Scope,Target,Bits,ClipRateRaw,ClipRateEMA,RangeMulBefore,RangeMulAfter,AutoApplied,"
                 "WarmupActive,WarmupRemain,AutoReason,AutoInitMulApplied,AutoInitMulValue,AutoInitClipTarget,"
                 "QErrPerClip,QErrPerClipClipFloor,ActiveClipBand,ActiveClipLow,ActiveClipHigh,"
-                "ClipRateLowAutoState,ClipRateLowAutoDecision,ClipRateLowAutoReason,ClipRateLowAutoBad,ClipRateLowAutoBadStreak"
+                "ClipRateLowAutoState,ClipRateLowAutoDecision,ClipRateLowAutoReason,ClipRateLowAutoBad,ClipRateLowAutoBadStreak,"
+                "TrainProgress,ClipRateLowAutoMinProgress,ClipRateLowAutoFreezeProgress,"
+                "ClipRateLowAutoThresholdQErrRatio,ClipRateLowAutoThresholdQErrPerClip,"
+                "ClipRateLowAutoPhase,ClipRateLowAutoCanEscape"
             )
 
         def _dq_qerr_per_clip(quant_err_ratio, clip_rate):
@@ -3079,6 +3088,8 @@ class NetworkTrainer:
         dq_low_auto_reason = ""
         dq_low_auto_bad = ""
         dq_low_auto_qerr_per_clip = None
+        dq_low_auto_phase = "pre_min_progress" if dq_low_auto_enabled else ""
+        dq_low_auto_can_escape = 0 if dq_low_auto_enabled else ""
         dq_bits_changed_since_auto = False
         dq_auto_warmup_reset_updates = dq_auto_warmup_updates
         dq_auto_warmup_remaining = dq_auto_warmup_reset_updates
@@ -3107,6 +3118,20 @@ class NetworkTrainer:
                 row[col_idx["ActiveClipLow"]] = dq_auto_active_clip_low
             if "ActiveClipHigh" in col_idx:
                 row[col_idx["ActiveClipHigh"]] = dq_auto_active_clip_high
+            if "TrainProgress" in col_idx:
+                row[col_idx["TrainProgress"]] = 0
+            if "ClipRateLowAutoMinProgress" in col_idx:
+                row[col_idx["ClipRateLowAutoMinProgress"]] = dq_low_auto_min_progress
+            if "ClipRateLowAutoFreezeProgress" in col_idx:
+                row[col_idx["ClipRateLowAutoFreezeProgress"]] = dq_low_auto_freeze_progress
+            if "ClipRateLowAutoThresholdQErrRatio" in col_idx:
+                row[col_idx["ClipRateLowAutoThresholdQErrRatio"]] = dq_low_auto_qerr_ratio_threshold
+            if "ClipRateLowAutoThresholdQErrPerClip" in col_idx:
+                row[col_idx["ClipRateLowAutoThresholdQErrPerClip"]] = dq_low_auto_qerr_per_clip_threshold
+            if "ClipRateLowAutoPhase" in col_idx:
+                row[col_idx["ClipRateLowAutoPhase"]] = "pre_min_progress" if dq_low_auto_enabled else ""
+            if "ClipRateLowAutoCanEscape" in col_idx:
+                row[col_idx["ClipRateLowAutoCanEscape"]] = 0 if dq_low_auto_enabled else ""
             _write_csv(dq_auto_log_path, header, ",".join(_dq_format_value(v) for v in row))
 
         def _dq_bits_for_progress(progress_frac: float, default_bits: Optional[int]):
@@ -3461,6 +3486,8 @@ class NetworkTrainer:
                                 low_auto_bad = ""
                                 low_auto_bad_streak = dq_low_auto_bad_streak
                                 low_auto_qerr_per_clip = None
+                                low_auto_phase = dq_low_auto_phase
+                                low_auto_can_escape = dq_low_auto_can_escape
 
                                 if dq_stats["do_auto"]:
                                     auto_scope = dq_stats["auto_scope"]
@@ -3532,6 +3559,8 @@ class NetworkTrainer:
                                                     low_auto_state = "observe"
                                                     low_auto_decision = "observe"
                                                     low_auto_reason = "warmup"
+                                                    low_auto_phase = "warmup"
+                                                    low_auto_can_escape = 0
                                             else:
                                                 if dq_low_auto_enabled:
                                                     low_auto_frozen = progress_frac >= dq_low_auto_freeze_progress
@@ -3545,20 +3574,28 @@ class NetworkTrainer:
                                                         and low_auto_qerr_per_clip >= dq_low_auto_qerr_per_clip_threshold
                                                     )
                                                     low_auto_bad = 1 if low_auto_is_bad else (0 if low_auto_stats_ready else "")
+                                                    low_auto_can_escape = 1 if (
+                                                        progress_frac >= dq_low_auto_min_progress
+                                                        and not low_auto_frozen
+                                                        and not dq_low_auto_escaped
+                                                    ) else 0
                                                     if progress_frac < dq_low_auto_min_progress:
                                                         dq_low_auto_state = "observe"
                                                         low_auto_decision = "observe"
                                                         low_auto_reason = "min_progress"
+                                                        low_auto_phase = "pre_min_progress"
                                                         dq_low_auto_bad_streak = 0
                                                     elif dq_low_auto_escaped:
                                                         dq_low_auto_state = "mid_lock"
                                                         low_auto_decision = "mid_lock"
                                                         low_auto_reason = "escaped_once"
+                                                        low_auto_phase = "escaped"
                                                         dq_low_auto_bad_streak = 0
                                                     elif low_auto_frozen:
                                                         dq_low_auto_state = "frozen"
                                                         low_auto_decision = "frozen"
                                                         low_auto_reason = "freeze_progress"
+                                                        low_auto_phase = "frozen"
                                                         if low_auto_is_bad:
                                                             dq_low_auto_bad_streak += 1
                                                         else:
@@ -3567,8 +3604,10 @@ class NetworkTrainer:
                                                         dq_low_auto_state = "observe"
                                                         low_auto_decision = "observe"
                                                         low_auto_reason = "insufficient_qerr_stats"
+                                                        low_auto_phase = "active"
                                                         dq_low_auto_bad_streak = 0
                                                     else:
+                                                        low_auto_phase = "active"
                                                         if low_auto_is_bad:
                                                             dq_low_auto_bad_streak += 1
                                                             low_auto_decision = "bad_count"
@@ -3584,8 +3623,12 @@ class NetworkTrainer:
                                                             dq_low_auto_state = "escape_to_mid"
                                                             low_auto_decision = "escape_to_mid"
                                                             low_auto_reason = "bad_streak_met"
+                                                            low_auto_phase = "escaped"
+                                                            low_auto_can_escape = 0
                                                 low_auto_state = dq_low_auto_state
                                                 low_auto_bad_streak = dq_low_auto_bad_streak
+                                                dq_low_auto_phase = low_auto_phase
+                                                dq_low_auto_can_escape = low_auto_can_escape
 
                                                 if dq_auto_use_raw:
                                                     clip_high_hit = (
@@ -3755,6 +3798,12 @@ class NetworkTrainer:
                                                     low_auto_state if dq_low_auto_enabled else "",
                                                     low_auto_bad if dq_low_auto_enabled else "",
                                                     low_auto_bad_streak if dq_low_auto_enabled else "",
+                                                    progress_frac,
+                                                    dq_low_auto_min_progress if dq_low_auto_enabled else "",
+                                                    dq_low_auto_freeze_progress if dq_low_auto_enabled else "",
+                                                    dq_low_auto_qerr_ratio_threshold if dq_low_auto_enabled else "",
+                                                    dq_low_auto_qerr_per_clip_threshold if dq_low_auto_enabled else "",
+                                                    low_auto_phase if dq_low_auto_enabled else "",
                                                 ]
                                                 if dq_log_error_parts:
                                                     row += [
@@ -3807,6 +3856,12 @@ class NetworkTrainer:
                                                 low_auto_state if dq_low_auto_enabled else "",
                                                 low_auto_bad if dq_low_auto_enabled else "",
                                                 low_auto_bad_streak if dq_low_auto_enabled else "",
+                                                progress_frac,
+                                                dq_low_auto_min_progress if dq_low_auto_enabled else "",
+                                                dq_low_auto_freeze_progress if dq_low_auto_enabled else "",
+                                                dq_low_auto_qerr_ratio_threshold if dq_low_auto_enabled else "",
+                                                dq_low_auto_qerr_per_clip_threshold if dq_low_auto_enabled else "",
+                                                low_auto_phase if dq_low_auto_enabled else "",
                                             ]
                                             if dq_log_error_parts:
                                                 row += [
@@ -3876,6 +3931,12 @@ class NetworkTrainer:
                                             low_auto_state if dq_low_auto_enabled else "",
                                             low_auto_bad if dq_low_auto_enabled else "",
                                             low_auto_bad_streak if dq_low_auto_enabled else "",
+                                            progress_frac,
+                                            dq_low_auto_min_progress if dq_low_auto_enabled else "",
+                                            dq_low_auto_freeze_progress if dq_low_auto_enabled else "",
+                                            dq_low_auto_qerr_ratio_threshold if dq_low_auto_enabled else "",
+                                            dq_low_auto_qerr_per_clip_threshold if dq_low_auto_enabled else "",
+                                            low_auto_phase if dq_low_auto_enabled else "",
                                         ]
                                         if dq_log_error_parts:
                                             row += ["", "", "", "", "", ""]
@@ -3919,6 +3980,13 @@ class NetworkTrainer:
                                             low_auto_reason if dq_low_auto_enabled else "",
                                             low_auto_bad if dq_low_auto_enabled else "",
                                             low_auto_bad_streak if dq_low_auto_enabled else "",
+                                            progress_frac,
+                                            dq_low_auto_min_progress if dq_low_auto_enabled else "",
+                                            dq_low_auto_freeze_progress if dq_low_auto_enabled else "",
+                                            dq_low_auto_qerr_ratio_threshold if dq_low_auto_enabled else "",
+                                            dq_low_auto_qerr_per_clip_threshold if dq_low_auto_enabled else "",
+                                            low_auto_phase if dq_low_auto_enabled else "",
+                                            low_auto_can_escape if dq_low_auto_enabled else "",
                                         ]
                                         _write_csv(dq_auto_log_path, header, ",".join(_dq_format_value(v) for v in row))
                     if rank_log_enabled and accelerator.is_main_process and rank_log_path and (not skip_step_flag):

--- a/train_network.py
+++ b/train_network.py
@@ -1048,7 +1048,7 @@ class NetworkTrainer:
         dq_auto_use_raw = bool(getattr(args, "dq_delta_auto_use_raw", False))
         dq_qerr_per_clip_floor = max(1e-12, float(getattr(args, "dq_delta_qerr_per_clip_floor", 0.001)))
         dq_log_error_parts = bool(getattr(args, "dq_delta_log_error_parts", False))
-        dq_low_auto_min_steps = max(0, int(getattr(args, "dq_delta_clip_rate_low_auto_min_steps", 6000)))
+        dq_low_auto_min_progress = max(0.0, min(1.0, float(getattr(args, "dq_delta_clip_rate_low_auto_min_progress", 0.25))))
         dq_low_auto_bad_streak_threshold = max(1, int(getattr(args, "dq_delta_clip_rate_low_auto_bad_streak", 3)))
         dq_low_auto_freeze_progress = float(getattr(args, "dq_delta_clip_rate_low_auto_freeze_progress", 0.55))
         dq_low_auto_qerr_ratio_threshold = float(getattr(args, "dq_delta_clip_rate_low_auto_qerr_ratio", 0.25))
@@ -3534,13 +3534,23 @@ class NetworkTrainer:
                                                     low_auto_reason = "warmup"
                                             else:
                                                 if dq_low_auto_enabled:
-                                                    low_auto_elapsed = (
-                                                        step_idx - dq_low_auto_start_step
-                                                        if dq_low_auto_start_step is not None
-                                                        else 0
-                                                    )
                                                     low_auto_frozen = progress_frac >= dq_low_auto_freeze_progress
-                                                    if dq_low_auto_escaped:
+                                                    low_auto_stats_ready = (
+                                                        dq_low_auto_quant_err_ratio_ema_state is not None
+                                                        and low_auto_qerr_per_clip is not None
+                                                    )
+                                                    low_auto_is_bad = (
+                                                        low_auto_stats_ready
+                                                        and dq_low_auto_quant_err_ratio_ema_state >= dq_low_auto_qerr_ratio_threshold
+                                                        and low_auto_qerr_per_clip >= dq_low_auto_qerr_per_clip_threshold
+                                                    )
+                                                    low_auto_bad = 1 if low_auto_is_bad else (0 if low_auto_stats_ready else "")
+                                                    if progress_frac < dq_low_auto_min_progress:
+                                                        dq_low_auto_state = "observe"
+                                                        low_auto_decision = "observe"
+                                                        low_auto_reason = "min_progress"
+                                                        dq_low_auto_bad_streak = 0
+                                                    elif dq_low_auto_escaped:
                                                         dq_low_auto_state = "mid_lock"
                                                         low_auto_decision = "mid_lock"
                                                         low_auto_reason = "escaped_once"
@@ -3549,23 +3559,16 @@ class NetworkTrainer:
                                                         dq_low_auto_state = "frozen"
                                                         low_auto_decision = "frozen"
                                                         low_auto_reason = "freeze_progress"
-                                                        dq_low_auto_bad_streak = 0
-                                                    elif low_auto_elapsed < dq_low_auto_min_steps:
-                                                        dq_low_auto_state = "observe"
-                                                        low_auto_decision = "observe"
-                                                        low_auto_reason = "min_steps"
-                                                        dq_low_auto_bad_streak = 0
-                                                    elif dq_low_auto_quant_err_ratio_ema_state is None or low_auto_qerr_per_clip is None:
+                                                        if low_auto_is_bad:
+                                                            dq_low_auto_bad_streak += 1
+                                                        else:
+                                                            dq_low_auto_bad_streak = 0
+                                                    elif not low_auto_stats_ready:
                                                         dq_low_auto_state = "observe"
                                                         low_auto_decision = "observe"
                                                         low_auto_reason = "insufficient_qerr_stats"
                                                         dq_low_auto_bad_streak = 0
                                                     else:
-                                                        low_auto_is_bad = (
-                                                            dq_low_auto_quant_err_ratio_ema_state >= dq_low_auto_qerr_ratio_threshold
-                                                            and low_auto_qerr_per_clip >= dq_low_auto_qerr_per_clip_threshold
-                                                        )
-                                                        low_auto_bad = 1 if low_auto_is_bad else 0
                                                         if low_auto_is_bad:
                                                             dq_low_auto_bad_streak += 1
                                                             low_auto_decision = "bad_count"
@@ -4769,10 +4772,10 @@ def setup_parser() -> argparse.ArgumentParser:
         help="Auto log format / auto ログ形式（minimal/full_schema）",
     )
     parser.add_argument(
-        "--dq_delta_clip_rate_low_auto_min_steps",
-        type=int,
-        default=6000,
-        help="clip_rate_low_auto observation steps before escape checks / clip_rate_low_auto の判定開始までの観測step数",
+        "--dq_delta_clip_rate_low_auto_min_progress",
+        type=float,
+        default=0.25,
+        help="Training progress before clip_rate_low_auto escape checks / clip_rate_low_auto の判定開始までの学習進捗",
     )
     parser.add_argument(
         "--dq_delta_clip_rate_low_auto_bad_streak",

--- a/train_network.py
+++ b/train_network.py
@@ -329,6 +329,18 @@ DQ_DELTA_AUTO_PRESETS = {
         "clip_low": 0.0005,
         "clip_high": 0.0022,
     },
+    "clip_rate_low_auto": {
+        "clip_low": 0.0005,
+        "clip_high": 0.0022,
+    },
+}
+
+DQ_DELTA_AUTO_BANDS = {
+    "default": (0.0005, 0.003),
+    "high": (0.003, 0.005),
+    "high_narrow": (0.0038, 0.0048),
+    "mid": (0.002, 0.004),
+    "low": (0.0005, 0.0022),
 }
 
 
@@ -1010,6 +1022,16 @@ class NetworkTrainer:
             dq_auto_mul_up,
             dq_auto_mul_down,
         ) = resolve_dq_delta_auto_settings(args)
+        dq_low_auto_enabled = dq_auto_enabled and dq_auto_preset == "clip_rate_low_auto"
+        dq_auto_active_band = "low" if dq_auto_preset in ("clip_rate_low", "clip_rate_low_auto") else (
+            "mid" if dq_auto_preset == "clip_rate_mid" else (
+                "high_narrow" if dq_auto_preset == "clip_rate_high_narrow" else (
+                    "high" if dq_auto_preset == "clip_rate_high" else ("default" if dq_auto_preset == "default" else "custom")
+                )
+            )
+        )
+        dq_auto_active_clip_low = dq_auto_clip_low
+        dq_auto_active_clip_high = dq_auto_clip_high
         if dq_auto_preset is not None:
             logger.info(
                 "dq_delta_auto_preset: %s (clip_low=%s, clip_high=%s, mul_up=%s, mul_down=%s)",
@@ -1024,6 +1046,13 @@ class NetworkTrainer:
         dq_auto_max = float(getattr(args, "dq_delta_auto_max", 6.0))
         dq_auto_ema = float(getattr(args, "dq_delta_auto_ema", 0.95))
         dq_auto_use_raw = bool(getattr(args, "dq_delta_auto_use_raw", False))
+        dq_qerr_per_clip_floor = max(1e-12, float(getattr(args, "dq_delta_qerr_per_clip_floor", 0.001)))
+        dq_log_error_parts = bool(getattr(args, "dq_delta_log_error_parts", False))
+        dq_low_auto_min_steps = max(0, int(getattr(args, "dq_delta_clip_rate_low_auto_min_steps", 6000)))
+        dq_low_auto_bad_streak_threshold = max(1, int(getattr(args, "dq_delta_clip_rate_low_auto_bad_streak", 3)))
+        dq_low_auto_freeze_progress = float(getattr(args, "dq_delta_clip_rate_low_auto_freeze_progress", 0.55))
+        dq_low_auto_qerr_ratio_threshold = float(getattr(args, "dq_delta_clip_rate_low_auto_qerr_ratio", 0.25))
+        dq_low_auto_qerr_per_clip_threshold = float(getattr(args, "dq_delta_clip_rate_low_auto_qerr_per_clip", 130.0))
         dq_auto_warmup_enabled = dq_auto_enabled and bool(getattr(args, "dq_delta_auto_warmup", True))
         dq_auto_warmup_updates_override = int(getattr(args, "dq_delta_auto_warmup_updates", 0))
         dq_auto_warmup_updates = 0
@@ -1047,7 +1076,7 @@ class NetworkTrainer:
                     "dq_delta_auto_init_range_mul_from_band is enabled but dq_delta_stat is not rms; init will be skipped."
                 )
             else:
-                clip_target = (dq_auto_clip_low + dq_auto_clip_high) / 2.0
+                clip_target = (dq_auto_active_clip_low + dq_auto_active_clip_high) / 2.0
                 p = 1.0 - (clip_target / 2.0)
                 try:
                     range_mul_init = math.sqrt(2.0) * torch.erfinv(torch.tensor(2.0 * p - 1.0)).item()
@@ -1167,6 +1196,25 @@ class NetworkTrainer:
             if include_near_zero:
                 cols.append("NearZeroRate")
             cols += [
+                "QErrPerClip",
+                "QErrPerClipClipFloor",
+                "ActiveClipBand",
+                "ActiveClipLow",
+                "ActiveClipHigh",
+                "ClipRateLowAutoState",
+                "ClipRateLowAutoBad",
+                "ClipRateLowAutoBadStreak",
+            ]
+            if dq_log_error_parts:
+                cols += [
+                    "ClipErrRMS",
+                    "RoundErrRMS",
+                    "ClipErrRatio",
+                    "RoundErrRatio",
+                    "ClipShare",
+                    "RoundShare",
+                ]
+            cols += [
                 "Numel",
                 "AutoApplied",
                 "RangeMulBefore",
@@ -1217,8 +1265,15 @@ class NetworkTrainer:
                 return _dq_log_header("summary", include_near_zero)
             return (
                 "TrainStep,Scope,Target,Bits,ClipRateRaw,ClipRateEMA,RangeMulBefore,RangeMulAfter,AutoApplied,"
-                "WarmupActive,WarmupRemain,AutoReason,AutoInitMulApplied,AutoInitMulValue,AutoInitClipTarget"
+                "WarmupActive,WarmupRemain,AutoReason,AutoInitMulApplied,AutoInitMulValue,AutoInitClipTarget,"
+                "QErrPerClip,QErrPerClipClipFloor,ActiveClipBand,ActiveClipLow,ActiveClipHigh,"
+                "ClipRateLowAutoState,ClipRateLowAutoDecision,ClipRateLowAutoReason,ClipRateLowAutoBad,ClipRateLowAutoBadStreak"
             )
+
+        def _dq_qerr_per_clip(quant_err_ratio, clip_rate):
+            if quant_err_ratio is None or clip_rate is None:
+                return None
+            return quant_err_ratio / max(clip_rate, dq_qerr_per_clip_floor)
 
         def _dq_reduce_stats(accum_by_scope, collect_full: bool, collect_zero: bool, collect_near_zero: bool):
             if accelerator.num_processes <= 1 or not dist.is_available() or not dist.is_initialized():
@@ -1250,6 +1305,12 @@ class NetworkTrainer:
                     sum_refs.append((acc, "scale_sum"))
                     sum_fields.append(acc.scale_count)
                     sum_refs.append((acc, "scale_count"))
+                    if getattr(acc, "clip_err_sumsq", None) is not None:
+                        sum_fields.append(acc.clip_err_sumsq)
+                        sum_refs.append((acc, "clip_err_sumsq"))
+                    if getattr(acc, "round_err_sumsq", None) is not None:
+                        sum_fields.append(acc.round_err_sumsq)
+                        sum_refs.append((acc, "round_err_sumsq"))
 
             if sum_fields:
                 sum_vec = torch.stack(sum_fields)
@@ -1291,6 +1352,8 @@ class NetworkTrainer:
             near_zero_rate = (acc.near_zero_count / acc.numel).item() if collect_near_zero and numel > 0 else None
             rms = absmax = scale_min = scale_max = scale_mean = range_val = None
             quant_err_rms = quant_err_ratio = None
+            clip_err_rms = round_err_rms = clip_err_ratio = round_err_ratio = clip_share = round_share = None
+            total_err_sumsq = None
             if collect_full and numel > 0:
                 rms = math.sqrt((acc.sumsq / acc.numel).item()) if acc.sumsq is not None else None
                 absmax = acc.absmax.item() if acc.absmax is not None else None
@@ -1301,9 +1364,23 @@ class NetworkTrainer:
                 if acc.xq_sumsq is not None and acc.xxq_sum is not None and acc.sumsq is not None:
                     err_sumsq = acc.sumsq + acc.xq_sumsq - (2.0 * acc.xxq_sum)
                     err_sumsq = torch.clamp(err_sumsq, min=0.0)
+                    total_err_sumsq = err_sumsq
                     quant_err_rms = math.sqrt((err_sumsq / acc.numel).item())
                     if rms is not None:
                         quant_err_ratio = quant_err_rms / (rms + 1e-12)
+                if getattr(acc, "clip_err_sumsq", None) is not None and acc.clip_err_sumsq is not None:
+                    clip_err_rms = math.sqrt((torch.clamp(acc.clip_err_sumsq, min=0.0) / acc.numel).item())
+                    if rms is not None:
+                        clip_err_ratio = clip_err_rms / (rms + 1e-12)
+                if getattr(acc, "round_err_sumsq", None) is not None and acc.round_err_sumsq is not None:
+                    round_err_rms = math.sqrt((torch.clamp(acc.round_err_sumsq, min=0.0) / acc.numel).item())
+                    if rms is not None:
+                        round_err_ratio = round_err_rms / (rms + 1e-12)
+                if total_err_sumsq is not None and total_err_sumsq.item() > 0:
+                    if getattr(acc, "clip_err_sumsq", None) is not None and acc.clip_err_sumsq is not None:
+                        clip_share = (torch.clamp(acc.clip_err_sumsq, min=0.0) / (total_err_sumsq + 1e-12)).item()
+                    if getattr(acc, "round_err_sumsq", None) is not None and acc.round_err_sumsq is not None:
+                        round_share = (torch.clamp(acc.round_err_sumsq, min=0.0) / (total_err_sumsq + 1e-12)).item()
             if scale_mean is not None and qmax is not None:
                 range_val = scale_mean * qmax
             return {
@@ -1319,6 +1396,12 @@ class NetworkTrainer:
                 "scale_max": scale_max,
                 "scale_mean": scale_mean,
                 "range": range_val,
+                "clip_err_rms": clip_err_rms,
+                "round_err_rms": round_err_rms,
+                "clip_err_ratio": clip_err_ratio,
+                "round_err_ratio": round_err_ratio,
+                "clip_share": clip_share,
+                "round_share": round_share,
             }
 
         def _dq_merge_acc(acc_a, acc_b, collect_full: bool, collect_zero: bool, collect_near_zero: bool):
@@ -1328,6 +1411,7 @@ class NetworkTrainer:
             near_zero = acc_a.near_zero_count + acc_b.near_zero_count if collect_near_zero else None
             sumsq = absmax = scale_min = scale_max = scale_sum = scale_count = None
             xq_sumsq = xxq_sum = None
+            clip_err_sumsq = round_err_sumsq = None
             if collect_full:
                 sumsq = acc_a.sumsq + acc_b.sumsq
                 xq_sumsq = acc_a.xq_sumsq + acc_b.xq_sumsq
@@ -1337,7 +1421,21 @@ class NetworkTrainer:
                 scale_max = torch.maximum(acc_a.scale_max, acc_b.scale_max)
                 scale_sum = acc_a.scale_sum + acc_b.scale_sum
                 scale_count = acc_a.scale_count + acc_b.scale_count
-            temp_acc = type(acc_a)(acc_a.numel.device, collect_full, collect_zero, collect_near_zero)
+                if getattr(acc_a, "clip_err_sumsq", None) is not None and getattr(acc_b, "clip_err_sumsq", None) is not None:
+                    clip_err_sumsq = acc_a.clip_err_sumsq + acc_b.clip_err_sumsq
+                if getattr(acc_a, "round_err_sumsq", None) is not None and getattr(acc_b, "round_err_sumsq", None) is not None:
+                    round_err_sumsq = acc_a.round_err_sumsq + acc_b.round_err_sumsq
+            acc_cls = type(acc_a)
+            if "collect_error_parts" in inspect.signature(acc_cls).parameters:
+                temp_acc = acc_cls(
+                    acc_a.numel.device,
+                    collect_full,
+                    collect_zero,
+                    collect_near_zero,
+                    getattr(acc_a, "collect_error_parts", False) or getattr(acc_b, "collect_error_parts", False),
+                )
+            else:
+                temp_acc = acc_cls(acc_a.numel.device, collect_full, collect_zero, collect_near_zero)
             temp_acc.numel = numel
             temp_acc.clip_count = clip
             temp_acc.zero_count = zero
@@ -1350,6 +1448,8 @@ class NetworkTrainer:
             temp_acc.scale_max = scale_max
             temp_acc.scale_sum = scale_sum
             temp_acc.scale_count = scale_count
+            temp_acc.clip_err_sumsq = clip_err_sumsq
+            temp_acc.round_err_sumsq = round_err_sumsq
             return temp_acc
 
         cache_latents = args.cache_latents
@@ -2970,6 +3070,15 @@ class NetworkTrainer:
         dq_auto_ema_state = None
         dq_quant_err_rms_ema_state = None
         dq_quant_err_ratio_ema_state = None
+        dq_low_auto_quant_err_ratio_ema_state = None
+        dq_low_auto_start_step = None
+        dq_low_auto_bad_streak = 0
+        dq_low_auto_escaped = False
+        dq_low_auto_state = "observe" if dq_low_auto_enabled else ""
+        dq_low_auto_decision = ""
+        dq_low_auto_reason = ""
+        dq_low_auto_bad = ""
+        dq_low_auto_qerr_per_clip = None
         dq_bits_changed_since_auto = False
         dq_auto_warmup_reset_updates = dq_auto_warmup_updates
         dq_auto_warmup_remaining = dq_auto_warmup_reset_updates
@@ -2990,6 +3099,14 @@ class NetworkTrainer:
                 row[col_idx["AutoInitClipTarget"]] = (
                     dq_auto_init_clip_target if dq_auto_init_clip_target is not None else ""
                 )
+            if "QErrPerClipClipFloor" in col_idx:
+                row[col_idx["QErrPerClipClipFloor"]] = dq_qerr_per_clip_floor
+            if "ActiveClipBand" in col_idx:
+                row[col_idx["ActiveClipBand"]] = dq_auto_active_band
+            if "ActiveClipLow" in col_idx:
+                row[col_idx["ActiveClipLow"]] = dq_auto_active_clip_low
+            if "ActiveClipHigh" in col_idx:
+                row[col_idx["ActiveClipHigh"]] = dq_auto_active_clip_high
             _write_csv(dq_auto_log_path, header, ",".join(_dq_format_value(v) for v in row))
 
         def _dq_bits_for_progress(progress_frac: float, default_bits: Optional[int]):
@@ -3121,12 +3238,13 @@ class NetworkTrainer:
                                 (getattr(args, "dq_delta_bits", None) is not None and args.dq_delta_bits) or bool(dq_bits_sched)
                             ) and (args.dq_delta_stat == "rms")
                             do_auto = auto_eligible and (step_idx % dq_auto_every == 0)
-                            collect_full = bool(do_log)
+                            collect_full = bool(do_log or (do_auto and dq_low_auto_enabled))
                             collect_zero = bool(do_log)
                             collect_near_zero = bool(do_log and ("near_zero_rate" in dq_log_extra))
+                            collect_error_parts = bool(do_log and dq_log_error_parts)
                             target = "z" if getattr(args, "dq_quantize_z", False) else "delta"
 
-                            accelerator.unwrap_model(network).set_dq_stats_state(
+                            dq_stats_kwargs = dict(
                                 step_idx=step_idx,
                                 device=accelerator.device,
                                 do_log=do_log,
@@ -3139,6 +3257,15 @@ class NetworkTrainer:
                                 auto_scope=getattr(args, "dq_delta_scope", "both"),
                                 target=target,
                             )
+                            dq_stats_state_fn = accelerator.unwrap_model(network).set_dq_stats_state
+                            supports_error_parts = "collect_error_parts" in inspect.signature(dq_stats_state_fn).parameters
+                            if supports_error_parts:
+                                dq_stats_state_fn(
+                                    **dq_stats_kwargs,
+                                    collect_error_parts=collect_error_parts,
+                                )
+                            else:
+                                dq_stats_state_fn(**dq_stats_kwargs)
 
                     self._apply_te_freeze_if_ready(optimizer, accelerator.unwrap_model(network), global_step)
 
@@ -3328,6 +3455,12 @@ class NetworkTrainer:
                                     auto_reason = "in_band"
                                 else:
                                     auto_reason = ""
+                                low_auto_state = dq_low_auto_state
+                                low_auto_decision = ""
+                                low_auto_reason = ""
+                                low_auto_bad = ""
+                                low_auto_bad_streak = dq_low_auto_bad_streak
+                                low_auto_qerr_per_clip = None
 
                                 if dq_stats["do_auto"]:
                                     auto_scope = dq_stats["auto_scope"]
@@ -3351,6 +3484,7 @@ class NetworkTrainer:
                                         if clip_rate_raw is not None:
                                             if dq_bits_changed_since_auto:
                                                 dq_auto_ema_state = clip_rate_raw
+                                                dq_low_auto_quant_err_ratio_ema_state = None
                                                 dq_bits_changed_since_auto = False
                                                 if dq_auto_warmup_enabled:
                                                     dq_auto_warmup_remaining = dq_auto_warmup_reset_updates
@@ -3366,9 +3500,27 @@ class NetworkTrainer:
                                                 range_mul_before = getattr(args, "dq_delta_range_mul", 3.0)
                                             range_mul_after = range_mul_before
 
+                                            if dq_low_auto_enabled and dq_low_auto_start_step is None:
+                                                dq_low_auto_start_step = step_idx
+
+                                            if dq_low_auto_enabled:
+                                                qerr_ratio_raw_for_low_auto = auto_metrics.get("quant_err_ratio")
+                                                if qerr_ratio_raw_for_low_auto is not None:
+                                                    if dq_low_auto_quant_err_ratio_ema_state is None:
+                                                        dq_low_auto_quant_err_ratio_ema_state = qerr_ratio_raw_for_low_auto
+                                                    else:
+                                                        dq_low_auto_quant_err_ratio_ema_state = (
+                                                            dq_low_auto_quant_err_ratio_ema_state * dq_auto_ema
+                                                            + (1.0 - dq_auto_ema) * qerr_ratio_raw_for_low_auto
+                                                        )
+                                                low_auto_qerr_per_clip = _dq_qerr_per_clip(
+                                                    dq_low_auto_quant_err_ratio_ema_state,
+                                                    clip_rate_ema,
+                                                )
+
                                             warmup_step_active = dq_auto_warmup_enabled and dq_auto_warmup_remaining > 0
                                             if warmup_step_active:
-                                                if dq_auto_clip_low <= clip_rate_ema <= dq_auto_clip_high:
+                                                if dq_auto_active_clip_low <= clip_rate_ema <= dq_auto_active_clip_high:
                                                     dq_auto_warmup_inband_streak += 1
                                                 else:
                                                     dq_auto_warmup_inband_streak = 0
@@ -3376,21 +3528,76 @@ class NetworkTrainer:
                                                 if dq_auto_warmup_inband_streak >= 3:
                                                     dq_auto_warmup_remaining = 0
                                                 auto_reason = "warmup"
+                                                if dq_low_auto_enabled:
+                                                    low_auto_state = "observe"
+                                                    low_auto_decision = "observe"
+                                                    low_auto_reason = "warmup"
                                             else:
+                                                if dq_low_auto_enabled:
+                                                    low_auto_elapsed = (
+                                                        step_idx - dq_low_auto_start_step
+                                                        if dq_low_auto_start_step is not None
+                                                        else 0
+                                                    )
+                                                    low_auto_frozen = progress_frac >= dq_low_auto_freeze_progress
+                                                    if dq_low_auto_escaped:
+                                                        dq_low_auto_state = "mid_lock"
+                                                        low_auto_decision = "mid_lock"
+                                                        low_auto_reason = "escaped_once"
+                                                        dq_low_auto_bad_streak = 0
+                                                    elif low_auto_frozen:
+                                                        dq_low_auto_state = "frozen"
+                                                        low_auto_decision = "frozen"
+                                                        low_auto_reason = "freeze_progress"
+                                                        dq_low_auto_bad_streak = 0
+                                                    elif low_auto_elapsed < dq_low_auto_min_steps:
+                                                        dq_low_auto_state = "observe"
+                                                        low_auto_decision = "observe"
+                                                        low_auto_reason = "min_steps"
+                                                        dq_low_auto_bad_streak = 0
+                                                    elif dq_low_auto_quant_err_ratio_ema_state is None or low_auto_qerr_per_clip is None:
+                                                        dq_low_auto_state = "observe"
+                                                        low_auto_decision = "observe"
+                                                        low_auto_reason = "insufficient_qerr_stats"
+                                                        dq_low_auto_bad_streak = 0
+                                                    else:
+                                                        low_auto_is_bad = (
+                                                            dq_low_auto_quant_err_ratio_ema_state >= dq_low_auto_qerr_ratio_threshold
+                                                            and low_auto_qerr_per_clip >= dq_low_auto_qerr_per_clip_threshold
+                                                        )
+                                                        low_auto_bad = 1 if low_auto_is_bad else 0
+                                                        if low_auto_is_bad:
+                                                            dq_low_auto_bad_streak += 1
+                                                            low_auto_decision = "bad_count"
+                                                            low_auto_reason = "low_bad"
+                                                        else:
+                                                            dq_low_auto_bad_streak = 0
+                                                            low_auto_decision = "keep_low"
+                                                            low_auto_reason = "in_band"
+                                                        if dq_low_auto_bad_streak >= dq_low_auto_bad_streak_threshold:
+                                                            dq_low_auto_escaped = True
+                                                            dq_auto_active_band = "mid"
+                                                            dq_auto_active_clip_low, dq_auto_active_clip_high = DQ_DELTA_AUTO_BANDS["mid"]
+                                                            dq_low_auto_state = "escape_to_mid"
+                                                            low_auto_decision = "escape_to_mid"
+                                                            low_auto_reason = "bad_streak_met"
+                                                low_auto_state = dq_low_auto_state
+                                                low_auto_bad_streak = dq_low_auto_bad_streak
+
                                                 if dq_auto_use_raw:
                                                     clip_high_hit = (
                                                         clip_rate_raw is not None
-                                                        and clip_rate_ema > dq_auto_clip_high
-                                                        and clip_rate_raw > dq_auto_clip_high
+                                                        and clip_rate_ema > dq_auto_active_clip_high
+                                                        and clip_rate_raw > dq_auto_active_clip_high
                                                     )
                                                     clip_low_hit = (
                                                         clip_rate_raw is not None
-                                                        and clip_rate_ema < dq_auto_clip_low
-                                                        and clip_rate_raw < dq_auto_clip_low
+                                                        and clip_rate_ema < dq_auto_active_clip_low
+                                                        and clip_rate_raw < dq_auto_active_clip_low
                                                     )
                                                 else:
-                                                    clip_high_hit = clip_rate_ema > dq_auto_clip_high
-                                                    clip_low_hit = clip_rate_ema < dq_auto_clip_low
+                                                    clip_high_hit = clip_rate_ema > dq_auto_active_clip_high
+                                                    clip_low_hit = clip_rate_ema < dq_auto_active_clip_low
                                                 if clip_high_hit:
                                                     range_mul_after = range_mul_before * dq_auto_mul_up
                                                     auto_reason = "clip_high"
@@ -3405,6 +3612,8 @@ class NetworkTrainer:
 
                                             warmup_active = 1 if warmup_step_active else 0
                                             warmup_remain = dq_auto_warmup_remaining if dq_auto_warmup_enabled else 0
+                                            low_auto_state = dq_low_auto_state
+                                            low_auto_bad_streak = dq_low_auto_bad_streak
 
                                     if dist.is_available() and dist.is_initialized():
                                         range_tensor = torch.tensor(
@@ -3494,12 +3703,26 @@ class NetworkTrainer:
                                                 scale_mean = (item["scale_sum"] / item["scale_count"]).item() if item["scale_sum"] is not None and item["scale_count"] is not None and item["scale_count"].item() > 0 else None
                                                 range_val = scale_mean * qmax if scale_mean is not None and qmax is not None else None
                                                 quant_err_rms = quant_err_ratio = None
+                                                clip_err_rms = round_err_rms = clip_err_ratio = round_err_ratio = clip_share = round_share = None
                                                 if item["sumsq"] is not None and item["xq_sumsq"] is not None and item["xxq_sum"] is not None and numel > 0:
                                                     err_sumsq = item["sumsq"] + item["xq_sumsq"] - (2.0 * item["xxq_sum"])
                                                     err_sumsq = torch.clamp(err_sumsq, min=0.0)
                                                     quant_err_rms = math.sqrt((err_sumsq / item["numel"]).item())
                                                     if rms is not None:
                                                         quant_err_ratio = quant_err_rms / (rms + 1e-12)
+                                                    if item.get("clip_err_sumsq") is not None:
+                                                        clip_err_rms = math.sqrt((torch.clamp(item["clip_err_sumsq"], min=0.0) / item["numel"]).item())
+                                                        if rms is not None:
+                                                            clip_err_ratio = clip_err_rms / (rms + 1e-12)
+                                                        if err_sumsq.item() > 0:
+                                                            clip_share = (torch.clamp(item["clip_err_sumsq"], min=0.0) / (err_sumsq + 1e-12)).item()
+                                                    if item.get("round_err_sumsq") is not None:
+                                                        round_err_rms = math.sqrt((torch.clamp(item["round_err_sumsq"], min=0.0) / item["numel"]).item())
+                                                        if rms is not None:
+                                                            round_err_ratio = round_err_rms / (rms + 1e-12)
+                                                        if err_sumsq.item() > 0:
+                                                            round_share = (torch.clamp(item["round_err_sumsq"], min=0.0) / (err_sumsq + 1e-12)).item()
+                                                qerr_per_clip = _dq_qerr_per_clip(quant_err_ratio, clip_rate)
                                                 row = values + [
                                                     item["module"],
                                                     item["shape"],
@@ -3520,6 +3743,25 @@ class NetworkTrainer:
                                                 ]
                                                 if include_near_zero:
                                                     row.append(near_zero_rate)
+                                                row += [
+                                                    qerr_per_clip if qerr_per_clip is not None else "",
+                                                    dq_qerr_per_clip_floor,
+                                                    dq_auto_active_band,
+                                                    dq_auto_active_clip_low,
+                                                    dq_auto_active_clip_high,
+                                                    low_auto_state if dq_low_auto_enabled else "",
+                                                    low_auto_bad if dq_low_auto_enabled else "",
+                                                    low_auto_bad_streak if dq_low_auto_enabled else "",
+                                                ]
+                                                if dq_log_error_parts:
+                                                    row += [
+                                                        clip_err_rms if clip_err_rms is not None else "",
+                                                        round_err_rms if round_err_rms is not None else "",
+                                                        clip_err_ratio if clip_err_ratio is not None else "",
+                                                        round_err_ratio if round_err_ratio is not None else "",
+                                                        clip_share if clip_share is not None else "",
+                                                        round_share if round_share is not None else "",
+                                                    ]
                                                 row += [
                                                     numel,
                                                     auto_applied,
@@ -3552,6 +3794,26 @@ class NetworkTrainer:
                                             ]
                                             if include_near_zero:
                                                 row.append(m["near_zero_rate"])
+                                            qerr_per_clip = _dq_qerr_per_clip(quant_err_ratio_ema, clip_rate_ema)
+                                            row += [
+                                                qerr_per_clip if qerr_per_clip is not None else "",
+                                                dq_qerr_per_clip_floor,
+                                                dq_auto_active_band,
+                                                dq_auto_active_clip_low,
+                                                dq_auto_active_clip_high,
+                                                low_auto_state if dq_low_auto_enabled else "",
+                                                low_auto_bad if dq_low_auto_enabled else "",
+                                                low_auto_bad_streak if dq_low_auto_enabled else "",
+                                            ]
+                                            if dq_log_error_parts:
+                                                row += [
+                                                    m["clip_err_rms"] if m["clip_err_rms"] is not None else "",
+                                                    m["round_err_rms"] if m["round_err_rms"] is not None else "",
+                                                    m["clip_err_ratio"] if m["clip_err_ratio"] is not None else "",
+                                                    m["round_err_ratio"] if m["round_err_ratio"] is not None else "",
+                                                    m["clip_share"] if m["clip_share"] is not None else "",
+                                                    m["round_share"] if m["round_share"] is not None else "",
+                                                ]
                                             row += [
                                                 m["numel"],
                                                 auto_applied,
@@ -3598,6 +3860,22 @@ class NetworkTrainer:
                                         ]
                                         if include_near_zero:
                                             row.append("")
+                                        auto_qerr_per_clip = _dq_qerr_per_clip(
+                                            dq_low_auto_quant_err_ratio_ema_state if dq_low_auto_enabled else None,
+                                            clip_rate_ema,
+                                        )
+                                        row += [
+                                            auto_qerr_per_clip if auto_qerr_per_clip is not None else "",
+                                            dq_qerr_per_clip_floor,
+                                            dq_auto_active_band,
+                                            dq_auto_active_clip_low,
+                                            dq_auto_active_clip_high,
+                                            low_auto_state if dq_low_auto_enabled else "",
+                                            low_auto_bad if dq_low_auto_enabled else "",
+                                            low_auto_bad_streak if dq_low_auto_enabled else "",
+                                        ]
+                                        if dq_log_error_parts:
+                                            row += ["", "", "", "", "", ""]
                                         row += [
                                             "",
                                             auto_applied,
@@ -3628,6 +3906,16 @@ class NetworkTrainer:
                                             dq_auto_init_applied,
                                             dq_auto_init_value if dq_auto_init_value is not None else "",
                                             dq_auto_init_clip_target if dq_auto_init_clip_target is not None else "",
+                                            low_auto_qerr_per_clip if low_auto_qerr_per_clip is not None else "",
+                                            dq_qerr_per_clip_floor,
+                                            dq_auto_active_band,
+                                            dq_auto_active_clip_low,
+                                            dq_auto_active_clip_high,
+                                            low_auto_state if dq_low_auto_enabled else "",
+                                            low_auto_decision if dq_low_auto_enabled else "",
+                                            low_auto_reason if dq_low_auto_enabled else "",
+                                            low_auto_bad if dq_low_auto_enabled else "",
+                                            low_auto_bad_streak if dq_low_auto_enabled else "",
                                         ]
                                         _write_csv(dq_auto_log_path, header, ",".join(_dq_format_value(v) for v in row))
                     if rank_log_enabled and accelerator.is_main_process and rank_log_path and (not skip_step_flag):
@@ -4391,7 +4679,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "--dq_delta_auto_preset",
         type=str,
         default=None,
-        choices=["default", "clip_rate_high", "clip_rate_high_narrow", "clip_rate_mid", "clip_rate_low"],
+        choices=["default", "clip_rate_high", "clip_rate_high_narrow", "clip_rate_mid", "clip_rate_low", "clip_rate_low_auto"],
         help=(
             "Preset for auto range_mul tuning (overrides clip_low/high only) / "
             "auto range_mul 調整プリセット（clip_low/high のみ上書き）"
@@ -4479,6 +4767,47 @@ def setup_parser() -> argparse.ArgumentParser:
         default="minimal",
         choices=["minimal", "full_schema"],
         help="Auto log format / auto ログ形式（minimal/full_schema）",
+    )
+    parser.add_argument(
+        "--dq_delta_clip_rate_low_auto_min_steps",
+        type=int,
+        default=6000,
+        help="clip_rate_low_auto observation steps before escape checks / clip_rate_low_auto の判定開始までの観測step数",
+    )
+    parser.add_argument(
+        "--dq_delta_clip_rate_low_auto_bad_streak",
+        type=int,
+        default=3,
+        help="Consecutive clip_rate_low_auto bad checks before escaping to mid / clip_rate_low_auto がmidへ逃がすまでの連続bad回数",
+    )
+    parser.add_argument(
+        "--dq_delta_clip_rate_low_auto_freeze_progress",
+        type=float,
+        default=0.55,
+        help="Training progress after which clip_rate_low_auto band switching is frozen / clip_rate_low_auto のband切替を凍結する学習進捗",
+    )
+    parser.add_argument(
+        "--dq_delta_clip_rate_low_auto_qerr_ratio",
+        type=float,
+        default=0.25,
+        help="clip_rate_low_auto QuantErrRatioEMA threshold / clip_rate_low_auto の QuantErrRatioEMA 閾値",
+    )
+    parser.add_argument(
+        "--dq_delta_clip_rate_low_auto_qerr_per_clip",
+        type=float,
+        default=130.0,
+        help="clip_rate_low_auto QErrPerClip threshold / clip_rate_low_auto の QErrPerClip 閾値",
+    )
+    parser.add_argument(
+        "--dq_delta_qerr_per_clip_floor",
+        type=float,
+        default=0.001,
+        help="ClipRate floor for QErrPerClip diagnostics / QErrPerClip 診断で使う ClipRate 下限",
+    )
+    parser.add_argument(
+        "--dq_delta_log_error_parts",
+        action="store_true",
+        help="Log clip/round components of dq_delta quantization error / dq_delta量子化誤差のclip/round成分をログ出力",
     )
     # ema_* options removed
     # LoRA rounding options


### PR DESCRIPTION
## 概要

DQ delta の auto preset に `clip_rate_low_auto` を追加しました。

`clip_rate_low` はデータによって有効な場合がある一方、low 帯を維持するコストが高くなり、QuantErr が大きく増えるケースがありました。  
そのため、学習中に low が合わない兆候を検出した場合だけ `clip_rate_mid` 相当の帯へ逃がす保険として `clip_rate_low_auto` を追加しています。

## 主な変更

- `--dq_delta_auto_preset clip_rate_low_auto` を追加
- `QErrPerClip = QuantErrRatioEMA / max(ClipRateEMA, floor)` を追加
- `QuantErrRatioEMA` と `QErrPerClip` を使って low 不適合を判定
- 判定開始/凍結を step 数ではなく学習進捗率で指定するように変更
  - `--dq_delta_clip_rate_low_auto_min_progress`
  - `--dq_delta_clip_rate_low_auto_freeze_progress`
- dq_delta ログと dq_delta_auto ログに診断用の列を追加
- diagnostic report に low_auto 判定、QErrPerClip グラフ、進捗マーカーを追加
- clip/round 誤差分解ログを任意オプションとして追加
- 仕様ドキュメントを更新

## low_auto の判定

既定では以下を満たした状態が連続した場合に bad とみなします。

- `QuantErrRatioEMA >= 0.25`
- `QErrPerClip >= 130`

`bad_streak` 回連続した場合、`clip_rate_low` 相当の帯から `clip_rate_mid` 相当の帯へ一方向に切り替えます。  
一度 mid へ逃がした後は low へ戻しません。

## ログ/診断

low_auto の判断をあとから追えるよう、以下の情報をログに追加しています。

- 現在の進捗率
- low_auto の判定フェーズ
- bad 判定
- bad streak
- 使用中の QErrRatio / QErrPerClip 閾値
- 現在の active clip band
- QErrPerClip

diagnostic report では、`clip_rate_low` または `clip_rate_low_auto` のログに対して low が合っていたかどうかを診断します。

## 注意点

`clip_rate_low_auto` の既定閾値は、主に `--dq_quantize_z` を使わない delta 量子化、`--dq_delta_mode stoch`、`8bit/channel/rms` のログを基準にした経験的な値です。

`--dq_quantize_z` や `--dq_delta_mode det` を使う場合は `ZeroRate` や `QErrPerClip` の分布が変わるため、同じ閾値は保守的な警告として扱います。

## テスト

- 既存ログに対する diagnostic report の読み込み互換を確認
- `clip_rate_low_auto` のテストランで low 維持ケースを確認
- `--dq_quantize_z --dq_delta_mode det` のテストランで、QErrPerClip 上昇時に mid へ escape することを確認