### PR TITLE
AdamW8bitのCUDA同期を集約してLoRA学習を高速化

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -109,11 +109,14 @@ accelerate configの質問には以下のように答えてください。（bf1
 
 新しいリリースがあった場合、以下のコマンドで更新できます。
 
+重要：以前の手順に従ってPyTorch 2.1.2 / torchvision 0.16.2で作成した仮想環境は、`requirements.txt`だけで更新しないでください。`bitsandbytes==0.48.2`にはPyTorch 2.3以降が必要です。PyTorchとtorchvisionを互換性のある組み合わせで更新するため、新しい仮想環境を作成し、現在の[Windows環境でのインストール](#windows環境でのインストール)手順を実行してください。以下の更新コマンドは、動作確認済みのPyTorch 2.9.1 / torchvision 0.24.1環境へ移行済みの場合に使用します。
+
 ```powershell
 cd sd-scripts
 git pull
 .\venv\Scripts\activate
-pip install --use-pep517 --upgrade -r requirements.txt
+python -m pip install --use-pep517 --upgrade -r requirements.txt
+python -m pip check
 ```
 
 コマンドが成功すれば新しいバージョンが使用できます。

--- a/README-ja.md
+++ b/README-ja.md
@@ -31,12 +31,12 @@ GUIやPowerShellスクリプトなど、より使いやすくする機能が[bma
 
 ## Windowsでの動作に必要なプログラム
 
-Python 3.10.6およびGitが必要です。
+Python 3.10.x（64bit）およびGitが必要です。
 
-- Python 3.10.6: https://www.python.org/ftp/python/3.10.6/python-3.10.6-amd64.exe
+- Python 3.10.x: https://www.python.org/downloads/windows/
 - git: https://git-scm.com/download/win
 
-Python 3.10.x、3.11.x、3.12.xでも恐らく動作しますが、3.10.6でテストしています。
+このフォークではPython 3.10で動作確認しています。
 
 PowerShellを使う場合、venvを使えるようにするためには以下の手順でセキュリティ設定を変更してください。
 （venvに限らずスクリプトの実行が可能になりますので注意してください。）
@@ -47,33 +47,48 @@ PowerShellを使う場合、venvを使えるようにするためには以下の
 
 ## Windows環境でのインストール
 
-スクリプトはPyTorch 2.1.2でテストしています。PyTorch 2.2以降でも恐らく動作します。
+このフォークでは、Windows環境のPyTorch 2.9.1、torchvision 0.24.1、CUDA 13.0、bitsandbytes 0.48.2、およびSDPAの組み合わせを動作確認済みの基準環境としています。RTX 50シリーズでは、この構成を推奨します。
+
+bitsandbytes 0.48.2が対応するPyTorchの範囲は`2.3 <= PyTorch < 3.0`です。PyTorch 2.9.1以外も利用できますが、このフォークでの動作確認範囲外です。
 
 （なお、python -m venv～の行で「python」とだけ表示された場合、py -m venv～のようにpythonをpyに変更してください。）
 
 PowerShellを使う場合、通常の（管理者ではない）PowerShellを開き以下を順に実行します。
 
 ```powershell
-git clone https://github.com/kohya-ss/sd-scripts.git
+git clone https://github.com/maruo555/sd-scripts.git
 cd sd-scripts
 
 python -m venv venv
 .\venv\Scripts\activate
 
-pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu118
-pip install --upgrade -r requirements.txt
-pip install xformers==0.0.23.post1 --index-url https://download.pytorch.org/whl/cu118
+python -m pip install --upgrade pip
+python -m pip install "numpy<2"
+python -m pip install torch==2.9.1 torchvision==0.24.1 --index-url https://download.pytorch.org/whl/cu130
+python -m pip install --upgrade -r requirements.txt
 
 accelerate config
 ```
 
 コマンドプロンプトでも同一です。
 
-注：`bitsandbytes==0.44.0`、`prodigyopt==1.0`、`lion-pytorch==0.0.6` は `requirements.txt` に含まれるようになりました。他のバージョンを使う場合は適宜インストールしてください。
+`numpy<2`を先にインストールする順序には意味があります。後続パッケージが要求するNumPyの条件を満たしているため、通常は`requirements.txt`のインストール時にNumPy 2へ置き換えられません。新しい仮想環境で上記の順に実行することを推奨します。
 
-この例では PyTorch および xfomers は2.1.2／CUDA 11.8版をインストールします。CUDA 12.1版やPyTorch 1.12.1を使う場合は適宜書き換えください。たとえば CUDA 12.1版の場合は `pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121` および `pip install xformers==0.0.23.post1 --index-url https://download.pytorch.org/whl/cu121` としてください。
+注：`bitsandbytes`は本家の当時の`0.44.0`から、このフォークでは`0.48.2`へ更新しています。`requirements.txt`からインストールされるため、通常は別途インストールする必要はありません。`prodigyopt==1.0`、`lion-pytorch==0.0.6`もrequirements.txtに含まれています。
 
-PyTorch 2.2以降を用いる場合は、`torch==2.1.2` と `torchvision==0.16.2` 、および `xformers==0.0.23.post1` を適宜変更してください。
+上記の例はPyTorch 2.9.1およびCUDA 13.0用です。異なるCUDA版を使う場合は、[PyTorch公式のインストール手順](https://pytorch.org/get-started/locally/)で対応するコマンドを確認してください。bitsandbytesを使う場合は、前述の対応PyTorch範囲にも注意してください。
+
+### Attention実装について
+
+RTX 50シリーズのWindows環境では、xformersを追加せず、学習オプションに`--sdpa`を指定する構成を動作確認済みの基準としています。
+
+RTX 40シリーズなど、利用環境に対応するxformersのwheelが提供されている場合は、xformersを選ぶこともできます。上記のPyTorch 2.9.1 / CUDA 13.0構成では、必要に応じて次のようにインストールできます。
+
+```powershell
+python -m pip install xformers==0.0.33.post2 --index-url https://download.pytorch.org/whl/cu130
+```
+
+xformersを使う場合は`--xformers`、SDPAを使う場合は`--sdpa`を指定してください。両方を同時に指定する必要はありません。GPU、PyTorch、CUDAの組み合わせによって速度や互換性が異なるため、環境ごとに確認してください。
 
 accelerate configの質問には以下のように答えてください。（bf16で学習する場合、最後の質問にはbf16と答えてください。）
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ accelerate config
 
 If `python -m venv` shows only `python`, change `python` to `py`.
 
-Note: Now `bitsandbytes==0.44.0`, `prodigyopt==1.0` and `lion-pytorch==0.0.6` are included in the requirements.txt. If you'd like to use the another version, please install it manually.
+Note: The original version used `bitsandbytes==0.44.0` (`0.48.2` in this fork). The latest upstream no longer pins the bitsandbytes version, while this fork pins the GPU-tested `0.48.2` in requirements.txt. `prodigyopt==1.0` and `lion-pytorch==0.0.6` are also included. If you'd like to use another version, please install it manually.
 
 This installation is for CUDA 11.8. If you use a different version of CUDA, please install the appropriate version of PyTorch and xformers. For example, if you use CUDA 12, please install `pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121` and `pip install xformers==0.0.23.post1 --index-url https://download.pytorch.org/whl/cu121`.
 
@@ -209,7 +209,7 @@ The majority of scripts is licensed under ASL 2.0 (including codes from Diffuser
 
 [Memory Efficient Attention Pytorch](https://github.com/lucidrains/memory-efficient-attention-pytorch): MIT
 
-[bitsandbytes](https://github.com/TimDettmers/bitsandbytes): MIT
+[bitsandbytes](https://github.com/TimDettmers/bitsandbytes): MIT ([license](third_party/bitsandbytes-LICENSE.txt))
 
 [BLIP](https://github.com/salesforce/BLIP): BSD-3-Clause
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 | オプション | 既定値 | 主な効果 | 実装箇所／備考 |
 |------------|:------:|----------|----------------|
+| `--optimizer_type AdamW8bitFast` | 無効 | **LoRA向けAdamW8bit同期集約版**。bitsandbytesと同じ更新・stateを維持し、parameterごとのCUDA同期をstep末尾の1回へまとめる。 | 実験用。単GPU・non-paged CUDAで自動高速化し、非対応条件はstock AdamW8bitへfallback。fork不要。詳細: [docs/adamw8bit_fast-ja.md](docs/adamw8bit_fast-ja.md) |
 | `--downscale_freq_shift` | `0.0` | **時間埋め込みの周波数ダウンスケール**を 1.0 (従来値) に戻す。キャラクター LoRA で *identity* が定着しやすい傾向。 | `library/sdxl_original_unet.py`<br>本家 PR #1187 で 1.0→0.0 に変更された挙動を選択式に復活。|
 | `--te_mlp_fc_only` | 全層 | Text Encoder の学習対象を **MLP (全結合) 層だけ**に限定。キーワードベースのキャラ LoRA で“語彙を固めつつ柔軟性を保つ”目的。 | 本家 PR #1964 以前の挙動を再現。|
 | `--fp16_safe_norms` | `False` | 縮約系（LayerNorm/GroupNorm/Softmax）だけ **fp32 で演算**し、重みと他演算は fp16 のまま。fp16 + 小バッチ（例: `batch_size=1`）で学習安定性を向上。 | `library/sdxl_original_unet.py` にラッパ実装。<br>注意: Softmax の fp32 化は通常のAttention経路のみ（`--xformers`/`--sdpa` 使用時は各実装に依存）。Normは全経路でfp32化。|

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 
 ---
 
-## 以下、公式のまま
+## 以下は公式READMEをベースにしています（セットアップ手順など一部を本フォーク向けに更新）
 <!--- ここまで自分の追記 --->
 
 
@@ -95,7 +95,9 @@ This repository contains the scripts for:
 
 The file does not contain requirements for PyTorch. Because the version of PyTorch depends on the environment, it is not included in the file. Please install PyTorch first according to the environment. See installation instructions below.
 
-The scripts are tested with Pytorch 2.1.2. PyTorch 2.2 or later will work. Please install the appropriate version of PyTorch and xformers.
+This fork is tested on Windows with PyTorch 2.9.1, torchvision 0.24.1 and CUDA 13.0. The verified RTX 50-series setup uses PyTorch SDPA and does not require xformers. Other PyTorch versions may work, but have not been verified with this fork.
+
+`bitsandbytes==0.48.2` requires PyTorch 2.3 or later. The installation steps below pin a mutually compatible, tested package set instead of installing whichever PyTorch version happens to be latest.
 
 ## Links to usage documentation
 
@@ -135,26 +137,39 @@ Give unrestricted script access to powershell so venv can work:
 Open a regular Powershell terminal and type the following inside:
 
 ```powershell
-git clone https://github.com/kohya-ss/sd-scripts.git
+git clone https://github.com/maruo555/sd-scripts.git
 cd sd-scripts
 
 python -m venv venv
 .\venv\Scripts\activate
 
-pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu118
-pip install --upgrade -r requirements.txt
-pip install xformers==0.0.23.post1 --index-url https://download.pytorch.org/whl/cu118
+python -m pip install --upgrade pip
+python -m pip install "numpy<2"
+python -m pip install torch==2.9.1 torchvision==0.24.1 --index-url https://download.pytorch.org/whl/cu130
+python -m pip install --upgrade -r requirements.txt
 
 accelerate config
 ```
 
 If `python -m venv` shows only `python`, change `python` to `py`.
 
-Note: The original version used `bitsandbytes==0.44.0` (`0.48.2` in this fork). The latest upstream no longer pins the bitsandbytes version, while this fork pins the GPU-tested `0.48.2` in requirements.txt. `prodigyopt==1.0` and `lion-pytorch==0.0.6` are also included. If you'd like to use another version, please install it manually.
+The installation order is intentional. Installing `numpy<2` first keeps the older binary dependencies in this fork on the NumPy 1.x ABI. A clean installation from this branch kept NumPy 1.26.4 when `requirements.txt` was installed and completed with no broken requirements.
 
-This installation is for CUDA 11.8. If you use a different version of CUDA, please install the appropriate version of PyTorch and xformers. For example, if you use CUDA 12, please install `pip install torch==2.1.2 torchvision==0.16.2 --index-url https://download.pytorch.org/whl/cu121` and `pip install xformers==0.0.23.post1 --index-url https://download.pytorch.org/whl/cu121`.
+Note: The original version used `bitsandbytes==0.44.0` (`0.48.2` in this fork). The latest upstream no longer pins the bitsandbytes version, while this fork pins the GPU-tested `0.48.2` in requirements.txt. Installing bitsandbytes separately is not required. `prodigyopt==1.0` and `lion-pytorch==0.0.6` are also included. If you'd like to use another version, please install it manually and rerun the optimizer regression tests.
 
-If you use PyTorch 2.2 or later, please change `torch==2.1.2` and `torchvision==0.16.2` and `xformers==0.0.23.post1` to the appropriate version.
+This installation targets the tested CUDA 13.0 environment. If you use a different CUDA build, install a matching PyTorch and torchvision pair from the [official PyTorch installation guide](https://pytorch.org/get-started/locally/). Keep PyTorch at 2.3 or later, but below 3.0, for compatibility with bitsandbytes 0.48.2.
+
+### Attention implementation: SDPA or xformers
+
+For RTX 50-series GPUs on Windows, this fork's verified and recommended baseline omits xformers and uses PyTorch SDPA. Specify `--sdpa` in the training command.
+
+For RTX 40-series and other supported GPUs, SDPA remains available. xformers is optional; if you prefer it with the pinned PyTorch 2.9.1 setup, install the matching build:
+
+```powershell
+python -m pip install xformers==0.0.33.post2 --index-url https://download.pytorch.org/whl/cu130
+```
+
+Specify `--xformers` instead of `--sdpa` when using xformers. Do not specify both options. The faster implementation depends on the GPU and workload, so compare them under the same training settings when possible.
 
 <!-- 
 cp .\bitsandbytes_windows\*.dll .\venv\Lib\site-packages\bitsandbytes\

--- a/README.md
+++ b/README.md
@@ -199,18 +199,21 @@ Note: Some user reports ``ValueError: fp16 mixed precision requires a GPU`` is o
 
 When a new release comes out you can upgrade your repo with the following command:
 
+Important: If your virtual environment was created with the previous PyTorch 2.1.2 / torchvision 0.16.2 instructions, do not upgrade it by installing only `requirements.txt`. `bitsandbytes==0.48.2` requires PyTorch 2.3 or later. Create a new virtual environment and follow the current [Windows Installation](#windows-installation) steps so that PyTorch and torchvision are upgraded as a compatible pair. The commands below are for an environment that has already been migrated to the tested PyTorch 2.9.1 / torchvision 0.24.1 setup.
+
 ```powershell
 cd sd-scripts
 git pull
 .\venv\Scripts\activate
-pip install --use-pep517 --upgrade -r requirements.txt
+python -m pip install --use-pep517 --upgrade -r requirements.txt
+python -m pip check
 ```
 
 Once the commands have completed successfully you should be ready to use the new version.
 
 ### Upgrade PyTorch
 
-If you want to upgrade PyTorch, you can upgrade it with `pip install` command in [Windows Installation](#windows-installation) section. `xformers` is also required to be upgraded when PyTorch is upgraded.
+When changing PyTorch versions, install a compatible PyTorch and torchvision pair together. xformers is not required when using SDPA. If you use xformers, update it to a build compatible with the selected PyTorch and CUDA versions.
 
 ## Credits
 

--- a/docs/adamw8bit_fast-ja.md
+++ b/docs/adamw8bit_fast-ja.md
@@ -1,0 +1,100 @@
+# AdamW8bitFast: LoRA向け同期集約版
+
+## 概要
+
+`AdamW8bitFast`は、bitsandbytesの`AdamW8bit`と同じparameter更新・optimizer stateを使いながら、CUDA同期回数だけを削減する実験用optimizerです。
+
+bitsandbytesのforkや、venv内の`site-packages`の書き換えは不要です。このリポジトリ内の [library/adamw8bit_fast.py](../library/adamw8bit_fast.py) が`bnb.optim.AdamW8bit`を継承します。
+
+使用方法:
+
+```text
+--optimizer_type AdamW8bitFast
+```
+
+`fused=True`はPyTorchの`torch.optim.AdamW`用であり、AdamW8bitFastには指定しません。学習率、`betas`、`eps`、`weight_decay`、`min_8bit_size`など、AdamW8bitが受け取る`--optimizer_args`はそのまま渡されます。
+
+## 何を変えるか
+
+通常のbitsandbytes optimizerは、概ね次の順序で処理します。
+
+```text
+parameter 1を更新 → GPU全体を同期
+parameter 2を更新 → GPU全体を同期
+...
+parameter Nを更新 → GPU全体を同期
+```
+
+AdamW8bitFastは次のようにします。
+
+```text
+parameter 1を更新
+parameter 2を更新
+...
+parameter Nを更新
+GPU全体を1回だけ同期
+```
+
+同一CUDA streamへ投入したkernelは投入順に実行されます。最後の同期は残すため、非同期CUDAエラーも`step()`が戻る前に検出されます。
+
+変更しないもの:
+
+- AdamW8bitの更新式
+- 8bit / FP32 optimizer stateの選択
+- `min_8bit_size`の判定
+- parameterとparameter groupの更新順序
+- 学習率、weight decay、betas、eps
+- state dict、LR scheduler、zero_gradの形式
+
+## 高速経路の条件
+
+次をすべて満たすと同期集約経路を使います。
+
+- non-paged AdamW8bit
+- 通常の`torch.nn.Parameter`とdense strided gradient
+- parameterとgradientが同じ1台のCUDA device上
+- 分散world sizeが1
+- optimizer closureを使わない
+
+CPU、paged optimizer、複数GPU、DTensorなどのTensor subclass、sparse gradient、複数device、closure使用時は、bitsandbytes標準の`step()`へ戻ります。
+
+## RTX 5080での実測
+
+検証環境:
+
+```text
+PyTorch       2.9.1+cu130
+bitsandbytes  0.48.2
+GPU           NVIDIA GeForce RTX 5080
+LoRA tensors  1,620
+LoRA elements 12,646,400
+Parameter dtype FP32
+```
+
+代表的なLoRA checkpointのtensor形状で、warmup 3回後に20回測定した結果です。
+
+| optimizer | step中央値 | optimizer周辺の定常割当 |
+|---|---:|---:|
+| AdamW8bit | 85.34ms | 125.107MiB |
+| AdamW8bitFast | 32.98ms | 125.107MiB |
+
+optimizer stepは約2.59倍、約52.35ms/step短縮しました。単純換算では8,400 stepで約440秒（約7分20秒）ですが、実学習時間はデータ処理、forward/backward、保存、ログ、量子化処理にも左右されます。
+
+再測定コマンド:
+
+```powershell
+python tools/benchmark_adamw8bit_fast.py "path\to\lora_checkpoint.safetensors"
+```
+
+benchmarkはcheckpointのtensor名とshapeだけを読み、重み値は使用・変更しません。
+
+通常のmixed-precision学習ではLoRA parameterとgradientがFP32のため、benchmarkも既定でFP32を使います。`--full_fp16`相当を調べる場合は`--dtype float16`を追加します。
+
+## 検証状況と注意点
+
+- FP32とFP16の両方について、複数learning-rate group、8bit/FP32 state混在、途中の`grad=None`を含む7 stepで、stock AdamW8bitと全parameter・全optimizer stateのbit完全一致を確認済みです。
+- CUDA同期が1 stepにつき1回になることをテストしています。
+- 実GPUテストはbitsandbytes 0.48.2で行い、`requirements.txt`記載の0.44.0についても継承するmethod・attributeと標準`step()`の構造が同じことを公式wheelで確認しています。
+- まだ8,400 stepの長時間学習では未検証です。
+- bitsandbytesの内部メソッドを継承しているため、bitsandbytes更新時は回帰テストとbenchmarkを再実行してください。
+- 最初の学習試験では既存のAdamW8bit runを上書きせず、別のoutput nameを使用してください。

--- a/docs/adamw8bit_fast-ja.md
+++ b/docs/adamw8bit_fast-ja.md
@@ -51,12 +51,25 @@ GPU全体を1回だけ同期
 次をすべて満たすと同期集約経路を使います。
 
 - non-paged AdamW8bit
-- 通常の`torch.nn.Parameter`とdense strided gradient
-- parameterとgradientが同じ1台のCUDA device上
+- `percentile_clipping=100`（既定値）かつ`max_unorm=0`
+- そのstepで`grad is not None`の更新対象が、通常の`torch.nn.Parameter`とdense strided gradient
+- 更新対象のparameterとgradientが同じ1台のCUDA device上
 - 分散world sizeが1
 - optimizer closureを使わない
 
 CPU、paged optimizer、複数GPU、DTensorなどのTensor subclass、sparse gradient、複数device、closure使用時は、bitsandbytes標準の`step()`へ戻ります。
+
+最初にgradientを更新するstepで、実際に選ばれた経路とbitsandbytesのversionを一度だけログへ出します。
+
+```text
+AdamW8bitFast: fast path enabled on cuda:0 (bitsandbytes 0.48.2)
+```
+
+標準経路へ戻る場合は、理由を含むwarningを一度だけ出します。途中で条件が変わり、高速経路から標準経路へ移った場合も同様です。
+
+```text
+AdamW8bitFast: using stock AdamW8bit step (reason: parameter is on cpu, bitsandbytes 0.48.2)
+```
 
 ## RTX 5080での実測
 
@@ -93,8 +106,11 @@ benchmarkはcheckpointのtensor名とshapeだけを読み、重み値は使用�
 ## 検証状況と注意点
 
 - FP32とFP16の両方について、複数learning-rate group、8bit/FP32 state混在、途中の`grad=None`を含む7 stepで、stock AdamW8bitと全parameter・全optimizer stateのbit完全一致を確認済みです。
+- `block_wise=False`でもstock AdamW8bitとのbit完全一致を確認しています。`percentile_clipping < 100`と`max_unorm > 0`は安全のため標準経路へ戻します。
+- stock AdamW8bitからAdamW8bitFast、および逆方向のstate dict読み込み後も、次のstepで全parameter・全optimizer stateが一致することを確認しています。
 - CUDA同期が1 stepにつき1回になることをテストしています。
-- 実GPUテストはbitsandbytes 0.48.2で行い、`requirements.txt`記載の0.44.0についても継承するmethod・attributeと標準`step()`の構造が同じことを公式wheelで確認しています。
+- 実GPUテストは`requirements.txt`と同じbitsandbytes 0.48.2で行っています。
 - まだ8,400 stepの長時間学習では未検証です。
 - bitsandbytesの内部メソッドを継承しているため、bitsandbytes更新時は回帰テストとbenchmarkを再実行してください。
+- optimizer stepの制御フローはMIT Licenseのbitsandbytesをもとにしています。ライセンス本文は [third_party/bitsandbytes-LICENSE.txt](../third_party/bitsandbytes-LICENSE.txt) を参照してください。
 - 最初の学習試験では既存のAdamW8bit runを上書きせず、別のoutput nameを使用してください。

--- a/docs/adamw8bit_fast-ja.md
+++ b/docs/adamw8bit_fast-ja.md
@@ -51,7 +51,7 @@ GPU全体を1回だけ同期
 次をすべて満たすと同期集約経路を使います。
 
 - non-paged AdamW8bit
-- `percentile_clipping=100`（既定値）かつ`max_unorm=0`
+- optimizer全体およびParameter別overrideの実効設定が`percentile_clipping=100`（既定値）かつ`max_unorm=0`
 - そのstepで`grad is not None`の更新対象が、通常の`torch.nn.Parameter`とdense strided gradient
 - 更新対象のparameterとgradientが同じ1台のCUDA device上
 - 分散world sizeが1

--- a/docs/train_README-ja.md
+++ b/docs/train_README-ja.md
@@ -611,6 +611,7 @@ masterpiece, best quality, 1boy, in business suit, standing at street, looking b
 - `--optimizer_type`
     --オプティマイザの種類を指定します。以下が指定できます。
     - AdamW : [torch.optim.AdamW](https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html)
+    - AdamW8bitFast : AdamW8bit互換の単GPU向け同期集約版。詳細は [adamw8bit_fast-ja.md](adamw8bit_fast-ja.md) を参照
     - 過去のバージョンのオプション未指定時と同じ
     - AdamW8bit : 引数は同上
     - PagedAdamW8bit : 引数は同上

--- a/library/adamw8bit_fast.py
+++ b/library/adamw8bit_fast.py
@@ -1,5 +1,10 @@
+# The optimizer step control flow in this file is adapted from bitsandbytes,
+# which is distributed under the MIT License.
+# See third_party/bitsandbytes-LICENSE.txt.
+
 from __future__ import annotations
 
+import logging
 from typing import Callable, Optional
 
 import torch
@@ -8,6 +13,9 @@ try:
     import bitsandbytes as bnb
 except ImportError as exc:  # pragma: no cover - handled by optimizer selection
     raise ImportError("AdamW8bitFast requires bitsandbytes") from exc
+
+logger = logging.getLogger(__name__)
+BITSANDBYTES_VERSION = getattr(bnb, "__version__", "unknown")
 
 
 class AdamW8bitFast(bnb.optim.AdamW8bit):
@@ -24,13 +32,40 @@ class AdamW8bitFast(bnb.optim.AdamW8bit):
     closure-based calls use the unmodified bitsandbytes implementation.
     """
 
-    def _fast_path_device(self) -> tuple[bool, Optional[torch.device]]:
+    def _log_fast_path_once(self, device: torch.device) -> None:
+        if getattr(self, "_adamw8bit_fast_path_logged", False):
+            return
+        logger.info(
+            "AdamW8bitFast: fast path enabled on %s (bitsandbytes %s)",
+            device,
+            BITSANDBYTES_VERSION,
+        )
+        self._adamw8bit_fast_path_logged = True
+
+    def _log_stock_fallback_once(self, reason: str) -> None:
+        if getattr(self, "_adamw8bit_stock_fallback_logged", False):
+            return
+        logger.warning(
+            "AdamW8bitFast: using stock AdamW8bit step (reason: %s, bitsandbytes %s)",
+            reason,
+            BITSANDBYTES_VERSION,
+        )
+        self._adamw8bit_stock_fallback_logged = True
+
+    def _has_active_gradients(self) -> bool:
+        return any(param.grad is not None for group in self.param_groups for param in group["params"])
+
+    def _fast_path_device(self) -> tuple[bool, Optional[torch.device], Optional[str]]:
         if self.is_paged:
-            return False, None
+            return False, None, "paged optimizer"
+        if getattr(self.args, "percentile_clipping", 100) < 100:
+            return False, None, "percentile_clipping is enabled"
+        if getattr(self.args, "max_unorm", 0.0) > 0.0:
+            return False, None, "max_unorm is enabled"
 
         if torch.distributed.is_available() and torch.distributed.is_initialized():
             if torch.distributed.get_world_size() > 1:
-                return False, None
+                return False, None, f"distributed world size {torch.distributed.get_world_size()}"
 
         active_device: Optional[torch.device] = None
         for group in self.param_groups:
@@ -39,17 +74,19 @@ class AdamW8bitFast(bnb.optim.AdamW8bit):
                 if grad is None:
                     continue
                 if type(param) is not torch.nn.Parameter or type(grad) is not torch.Tensor:
-                    return False, None
-                if param.device.type != "cuda" or grad.device != param.device:
-                    return False, None
+                    return False, None, "parameter or gradient uses a Tensor subclass"
+                if param.device.type != "cuda":
+                    return False, None, f"parameter is on {param.device.type}"
+                if grad.device != param.device:
+                    return False, None, "gradient and parameter are on different devices"
                 if param.layout != torch.strided or grad.layout != torch.strided or grad.is_sparse:
-                    return False, None
+                    return False, None, "parameter or gradient is not dense strided"
                 if active_device is None:
                     active_device = param.device
                 elif param.device != active_device:
-                    return False, None
+                    return False, None, "active gradients span multiple CUDA devices"
 
-        return True, active_device
+        return True, active_device, None
 
     @torch.no_grad()
     def step(self, closure: Optional[Callable[[], torch.Tensor]] = None):
@@ -57,11 +94,17 @@ class AdamW8bitFast(bnb.optim.AdamW8bit):
         # control of closure evaluation and route selection in that uncommon
         # case.
         if closure is not None:
+            self._log_stock_fallback_once("optimizer closure")
             return super().step(closure)
 
-        can_use_fast_path, device = self._fast_path_device()
+        can_use_fast_path, device, fallback_reason = self._fast_path_device()
         if not can_use_fast_path:
+            if self._has_active_gradients():
+                self._log_stock_fallback_once(fallback_reason or "unsupported configuration")
             return super().step()
+
+        if device is not None:
+            self._log_fast_path_once(device)
 
         if not self.initialized:
             self.check_overrides()

--- a/library/adamw8bit_fast.py
+++ b/library/adamw8bit_fast.py
@@ -55,6 +55,34 @@ class AdamW8bitFast(bnb.optim.AdamW8bit):
     def _has_active_gradients(self) -> bool:
         return any(param.grad is not None for group in self.param_groups for param in group["params"])
 
+    def _unsafe_active_override_reason(self) -> Optional[str]:
+        # GlobalOptimManager stores only overridden parameters here. Keep the
+        # common path O(1), and inspect this usually-empty mapping instead of
+        # rebuilding the effective config for every LoRA parameter each step.
+        parameter_overrides = self.mng.index2config
+        if not parameter_overrides:
+            return None
+
+        for (group_index, param_index), override in parameter_overrides.items():
+            if override.get("percentile_clipping", 100) < 100:
+                reason = "parameter override enables percentile_clipping"
+            elif override.get("max_unorm", 0.0) > 0.0:
+                reason = "parameter override enables max_unorm"
+            else:
+                continue
+
+            # Ignore entries whose indices do not exist in this optimizer.
+            # GlobalOptimManager is a singleton and may retain such entries.
+            if group_index >= len(self.param_groups):
+                continue
+            params = self.param_groups[group_index]["params"]
+            if param_index >= len(params):
+                continue
+            if params[param_index].grad is not None:
+                return reason
+
+        return None
+
     def _fast_path_device(self) -> tuple[bool, Optional[torch.device], Optional[str]]:
         if self.is_paged:
             return False, None, "paged optimizer"
@@ -62,6 +90,9 @@ class AdamW8bitFast(bnb.optim.AdamW8bit):
             return False, None, "percentile_clipping is enabled"
         if getattr(self.args, "max_unorm", 0.0) > 0.0:
             return False, None, "max_unorm is enabled"
+        override_reason = self._unsafe_active_override_reason()
+        if override_reason is not None:
+            return False, None, override_reason
 
         if torch.distributed.is_available() and torch.distributed.is_initialized():
             if torch.distributed.get_world_size() > 1:
@@ -97,6 +128,12 @@ class AdamW8bitFast(bnb.optim.AdamW8bit):
             self._log_stock_fallback_once("optimizer closure")
             return super().step(closure)
 
+        # Module-based GlobalOptimManager overrides are mapped to parameter
+        # indices by check_overrides(). Apply them before deciding whether the
+        # effective per-parameter clipping configuration is safe for fast mode.
+        if not self.initialized:
+            self.check_overrides()
+
         can_use_fast_path, device, fallback_reason = self._fast_path_device()
         if not can_use_fast_path:
             if self._has_active_gradients():
@@ -107,7 +144,6 @@ class AdamW8bitFast(bnb.optim.AdamW8bit):
             self._log_fast_path_once(device)
 
         if not self.initialized:
-            self.check_overrides()
             self.to_gpu()
             self.initialized = True
 

--- a/library/adamw8bit_fast.py
+++ b/library/adamw8bit_fast.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import torch
+
+try:
+    import bitsandbytes as bnb
+except ImportError as exc:  # pragma: no cover - handled by optimizer selection
+    raise ImportError("AdamW8bitFast requires bitsandbytes") from exc
+
+
+class AdamW8bitFast(bnb.optim.AdamW8bit):
+    """AdamW8bit with one CUDA synchronization per optimizer step.
+
+    bitsandbytes updates parameters one at a time and synchronizes the whole
+    device after every parameter. LoRA commonly has many small parameter
+    tensors, so those synchronizations dominate the optimizer step. CUDA
+    stream ordering already keeps the queued updates in order; synchronizing
+    once after the final update preserves the synchronous ``step()`` contract.
+
+    The fast path is intentionally limited to ordinary parameters on one CUDA
+    device. Paged, distributed, tensor-subclass, sparse, multi-device, CPU and
+    closure-based calls use the unmodified bitsandbytes implementation.
+    """
+
+    def _fast_path_device(self) -> tuple[bool, Optional[torch.device]]:
+        if self.is_paged:
+            return False, None
+
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            if torch.distributed.get_world_size() > 1:
+                return False, None
+
+        active_device: Optional[torch.device] = None
+        for group in self.param_groups:
+            for param in group["params"]:
+                grad = param.grad
+                if grad is None:
+                    continue
+                if type(param) is not torch.nn.Parameter or type(grad) is not torch.Tensor:
+                    return False, None
+                if param.device.type != "cuda" or grad.device != param.device:
+                    return False, None
+                if param.layout != torch.strided or grad.layout != torch.strided or grad.is_sparse:
+                    return False, None
+                if active_device is None:
+                    active_device = param.device
+                elif param.device != active_device:
+                    return False, None
+
+        return True, active_device
+
+    @torch.no_grad()
+    def step(self, closure: Optional[Callable[[], torch.Tensor]] = None):
+        # A closure may replace gradients, so let bitsandbytes retain complete
+        # control of closure evaluation and route selection in that uncommon
+        # case.
+        if closure is not None:
+            return super().step(closure)
+
+        can_use_fast_path, device = self._fast_path_device()
+        if not can_use_fast_path:
+            return super().step()
+
+        if not self.initialized:
+            self.check_overrides()
+            self.to_gpu()
+            self.initialized = True
+
+        updated = False
+        for group_index, group in enumerate(self.param_groups):
+            for param_index, param in enumerate(group["params"]):
+                if param.grad is None:
+                    continue
+
+                state = self.state[param]
+                if len(state) == 0:
+                    self.init_state(group, param, group_index, param_index)
+
+                self.prefetch_state(param)
+                self.update_step(group, param, group_index, param_index)
+                updated = True
+
+        if updated:
+            # Stock bitsandbytes synchronizes after every parameter. One final
+            # device sync still surfaces asynchronous CUDA errors before step()
+            # returns without introducing per-parameter CPU/GPU round trips.
+            torch.cuda.synchronize(device=device)
+
+        return None

--- a/library/train_util.py
+++ b/library/train_util.py
@@ -3074,7 +3074,7 @@ def add_optimizer_arguments(parser: argparse.ArgumentParser):
         type=str,
         default="",
         help="Optimizer to use / オプティマイザの種類: AdamW (default), AdamW8bit, PagedAdamW, PagedAdamW8bit, PagedAdamW32bit, "
-        "Lion8bit, PagedLion8bit, Lion, SGDNesterov, SGDNesterov8bit, "
+        "AdamW8bitFast, Lion8bit, PagedLion8bit, Lion, SGDNesterov, SGDNesterov8bit, "
         "DAdaptation(DAdaptAdamPreprint), DAdaptAdaGrad, DAdaptAdam, DAdaptAdan, DAdaptAdanIP, DAdaptLion, DAdaptSGD, "
         "AdaFactor. "
         "Also, you can use any optimizer by specifying the full path to the class, like 'bitsandbytes.optim.AdEMAMix8bit' or 'bitsandbytes.optim.PagedAdEMAMix8bit'.",
@@ -4176,7 +4176,7 @@ def resume_from_local_or_hf_if_specified(accelerator, args):
 
 
 def get_optimizer(args, trainable_params):
-    # "Optimizer to use: AdamW, AdamW8bit, Lion, SGDNesterov, SGDNesterov8bit, PagedAdamW, PagedAdamW8bit, PagedAdamW32bit, Lion8bit, PagedLion8bit, AdEMAMix8bit, PagedAdEMAMix8bit, DAdaptation(DAdaptAdamPreprint), DAdaptAdaGrad, DAdaptAdam, DAdaptAdan, DAdaptAdanIP, DAdaptLion, DAdaptSGD, Adafactor"
+    # "Optimizer to use: AdamW, AdamW8bit, AdamW8bitFast, Lion, SGDNesterov, SGDNesterov8bit, PagedAdamW, PagedAdamW8bit, PagedAdamW32bit, Lion8bit, PagedLion8bit, AdEMAMix8bit, PagedAdEMAMix8bit, DAdaptation(DAdaptAdamPreprint), DAdaptAdaGrad, DAdaptAdam, DAdaptAdan, DAdaptAdanIP, DAdaptLion, DAdaptSGD, Adafactor"
 
     optimizer_type = args.optimizer_type
     if args.use_8bit_adam:
@@ -4238,6 +4238,16 @@ def get_optimizer(args, trainable_params):
             raise ImportError("No lion_pytorch / lion_pytorch がインストールされていないようです")
         logger.info(f"use Lion optimizer | {optimizer_kwargs}")
         optimizer_class = lion_pytorch.Lion
+        optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
+
+    elif optimizer_type == "AdamW8bitFast".lower():
+        try:
+            from library.adamw8bit_fast import AdamW8bitFast
+        except ImportError as e:
+            raise ImportError("AdamW8bitFast requires bitsandbytes") from e
+
+        logger.info(f"use synchronized-once 8-bit AdamW optimizer | {optimizer_kwargs}")
+        optimizer_class = AdamW8bitFast
         optimizer = optimizer_class(trainable_params, lr=lr, **optimizer_kwargs)
 
     elif optimizer_type.endswith("8bit".lower()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ftfy==6.1.1
 opencv-python==4.8.1.78
 einops==0.7.0
 pytorch-lightning==1.9.0
-bitsandbytes==0.44.0
+bitsandbytes==0.48.2
 prodigyopt==1.0
 lion-pytorch==0.0.6
 tensorboard

--- a/tests/test_adamw8bit_fast.py
+++ b/tests/test_adamw8bit_fast.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -26,7 +28,7 @@ def _assert_optimizer_state_equal(stock, fast, stock_params, fast_params) -> Non
                 assert stock_value == fast_value, key
 
 
-def test_cpu_parameters_use_stock_bitsandbytes_step(monkeypatch):
+def test_cpu_parameters_use_stock_bitsandbytes_step_and_log_once(monkeypatch, caplog):
     param = torch.nn.Parameter(torch.ones(8))
     param.grad = torch.ones_like(param)
     optimizer = AdamW8bitFast([param], lr=1e-3)
@@ -38,8 +40,16 @@ def test_cpu_parameters_use_stock_bitsandbytes_step(monkeypatch):
 
     monkeypatch.setattr(bnb.optim.AdamW8bit, "step", stock_step)
 
-    assert optimizer.step() == "stock-route"
-    assert calls == [None]
+    with caplog.at_level(logging.WARNING, logger="library.adamw8bit_fast"):
+        assert optimizer.step() == "stock-route"
+        assert optimizer.step() == "stock-route"
+
+    assert calls == [None, None]
+    messages = [record.getMessage() for record in caplog.records if record.name == "library.adamw8bit_fast"]
+    assert len(messages) == 1
+    assert "using stock AdamW8bit step" in messages[0]
+    assert "parameter is on cpu" in messages[0]
+    assert f"bitsandbytes {bnb.__version__}" in messages[0]
 
 
 def test_optimizer_selection_accepts_adamw8bit_fast():
@@ -65,7 +75,12 @@ def test_optimizer_selection_accepts_adamw8bit_fast():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
-def test_fast_step_matches_stock_parameters_and_all_states(dtype):
+@pytest.mark.parametrize(
+    "optimizer_options",
+    [{}, {"block_wise": False}],
+    ids=["default", "non-blockwise"],
+)
+def test_fast_step_matches_stock_parameters_and_all_states(dtype, optimizer_options):
     generator = torch.Generator(device="cuda").manual_seed(20260801)
     shapes = [(64, 80), (32, 80), (64, 128), (48, 64)]  # both sides of min_8bit_size=4096
     initial = [torch.randn(shape, device="cuda", dtype=dtype, generator=generator) * 0.01 for shape in shapes]
@@ -80,7 +95,12 @@ def test_fast_step_matches_stock_parameters_and_all_states(dtype):
         {"params": fast_params[:2], "lr": 3.5e-4},
         {"params": fast_params[2:], "lr": 2.0e-4},
     ]
-    kwargs = {"lr": 1e-3, "betas": (0.9, 0.995), "weight_decay": 0.01}
+    kwargs = {
+        "lr": 1e-3,
+        "betas": (0.9, 0.995),
+        "weight_decay": 0.01,
+        **optimizer_options,
+    }
     stock = bnb.optim.AdamW8bit(stock_groups, **kwargs)
     fast = AdamW8bitFast(fast_groups, **kwargs)
 
@@ -114,6 +134,98 @@ def test_fast_step_matches_stock_parameters_and_all_states(dtype):
     }
     assert torch.uint8 in state_dtypes
     assert torch.float32 in state_dtypes
+
+
+def test_percentile_clipping_uses_stock_step_and_logs_once(monkeypatch, caplog):
+    param = torch.nn.Parameter(torch.ones(8))
+    optimizer = AdamW8bitFast([param], lr=1e-3, percentile_clipping=50)
+    calls = []
+
+    def stock_step(self, closure=None):
+        calls.append(closure)
+        return "stock-route"
+
+    monkeypatch.setattr(bnb.optim.AdamW8bit, "step", stock_step)
+
+    with caplog.at_level(logging.WARNING, logger="library.adamw8bit_fast"):
+        assert optimizer.step() == "stock-route"
+        assert not [record for record in caplog.records if record.name == "library.adamw8bit_fast"]
+        param.grad = torch.ones_like(param)
+        assert optimizer.step() == "stock-route"
+        assert optimizer.step() == "stock-route"
+
+    assert calls == [None, None, None]
+    messages = [record.getMessage() for record in caplog.records if record.name == "library.adamw8bit_fast"]
+    assert len(messages) == 1
+    assert "percentile_clipping is enabled" in messages[0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    ("source_class", "target_class"),
+    [
+        (bnb.optim.AdamW8bit, AdamW8bitFast),
+        (AdamW8bitFast, bnb.optim.AdamW8bit),
+    ],
+    ids=["stock-to-fast", "fast-to-stock"],
+)
+def test_state_dict_can_resume_between_stock_and_fast(source_class, target_class):
+    generator = torch.Generator(device="cuda").manual_seed(20260802)
+    initial = [
+        torch.randn((64, 80), device="cuda", dtype=torch.float32, generator=generator) * 0.01,
+        torch.randn((32, 80), device="cuda", dtype=torch.float32, generator=generator) * 0.01,
+    ]
+    source_params = [torch.nn.Parameter(value.clone()) for value in initial]
+    source_groups = [
+        {"params": source_params[:1], "lr": 3.5e-4},
+        {"params": source_params[1:], "lr": 2.0e-4},
+    ]
+    kwargs = {"lr": 1e-3, "betas": (0.9, 0.995), "weight_decay": 0.01}
+    source = source_class(source_groups, **kwargs)
+
+    for _ in range(3):
+        for param in source_params:
+            param.grad = torch.randn(param.shape, device="cuda", dtype=param.dtype, generator=generator)
+        source.step()
+
+    target_params = [torch.nn.Parameter(param.detach().clone()) for param in source_params]
+    target_groups = [
+        {"params": target_params[:1], "lr": 3.5e-4},
+        {"params": target_params[1:], "lr": 2.0e-4},
+    ]
+    target = target_class(target_groups, **kwargs)
+    target.load_state_dict(copy.deepcopy(source.state_dict()))
+    _assert_optimizer_state_equal(source, target, source_params, target_params)
+
+    for source_param, target_param in zip(source_params, target_params):
+        grad = torch.randn(source_param.shape, device="cuda", dtype=source_param.dtype, generator=generator)
+        source_param.grad = grad.clone()
+        target_param.grad = grad.clone()
+
+    source.step()
+    target.step()
+
+    for source_param, target_param in zip(source_params, target_params):
+        assert torch.equal(source_param, target_param)
+    _assert_optimizer_state_equal(source, target, source_params, target_params)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fast_path_logs_device_and_bitsandbytes_version_once(caplog):
+    param = torch.nn.Parameter(torch.randn((64, 80), device="cuda", dtype=torch.float32))
+    optimizer = AdamW8bitFast([param], lr=1e-3)
+
+    with caplog.at_level(logging.INFO, logger="library.adamw8bit_fast"):
+        optimizer.step()
+        assert not [record for record in caplog.records if record.name == "library.adamw8bit_fast"]
+        for _ in range(2):
+            param.grad = torch.randn_like(param)
+            optimizer.step()
+
+    messages = [record.getMessage() for record in caplog.records if record.name == "library.adamw8bit_fast"]
+    assert len(messages) == 1
+    assert "fast path enabled on cuda:0" in messages[0]
+    assert f"bitsandbytes {bnb.__version__}" in messages[0]
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")

--- a/tests/test_adamw8bit_fast.py
+++ b/tests/test_adamw8bit_fast.py
@@ -12,6 +12,17 @@ bnb = pytest.importorskip("bitsandbytes")
 from library.adamw8bit_fast import AdamW8bitFast
 
 
+@pytest.fixture
+def isolated_global_optim_manager(monkeypatch):
+    manager = bnb.optim.GlobalOptimManager.get_instance()
+    monkeypatch.setattr(manager, "pid2config", {})
+    monkeypatch.setattr(manager, "index2config", {})
+    monkeypatch.setattr(manager, "optimizer", None)
+    monkeypatch.setattr(manager, "uses_config_override", False)
+    monkeypatch.setattr(manager, "module_weight_config_triple", [])
+    return manager
+
+
 def _assert_optimizer_state_equal(stock, fast, stock_params, fast_params) -> None:
     for stock_param, fast_param in zip(stock_params, fast_params):
         stock_state = stock.state[stock_param]
@@ -158,6 +169,89 @@ def test_percentile_clipping_uses_stock_step_and_logs_once(monkeypatch, caplog):
     messages = [record.getMessage() for record in caplog.records if record.name == "library.adamw8bit_fast"]
     assert len(messages) == 1
     assert "percentile_clipping is enabled" in messages[0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize(
+    ("key", "value", "expected_reason"),
+    [
+        ("percentile_clipping", 50, "parameter override enables percentile_clipping"),
+        ("max_unorm", 1.0, "parameter override enables max_unorm"),
+    ],
+)
+def test_unsafe_parameter_overrides_use_stock_step(
+    monkeypatch,
+    caplog,
+    isolated_global_optim_manager,
+    key,
+    value,
+    expected_reason,
+):
+    param = torch.nn.Parameter(torch.ones(4096, device="cuda"))
+    isolated_global_optim_manager.override_config(param, key=key, value=value)
+    isolated_global_optim_manager.register_parameters([param])
+    optimizer = AdamW8bitFast([param], lr=1e-3)
+    param.grad = torch.ones_like(param)
+    calls = []
+
+    def stock_step(self, closure=None):
+        calls.append(closure)
+        return "stock-route"
+
+    monkeypatch.setattr(bnb.optim.AdamW8bit, "step", stock_step)
+
+    with caplog.at_level(logging.WARNING, logger="library.adamw8bit_fast"):
+        assert optimizer.step() == "stock-route"
+
+    assert calls == [None]
+    messages = [record.getMessage() for record in caplog.records if record.name == "library.adamw8bit_fast"]
+    assert len(messages) == 1
+    assert expected_reason in messages[0]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_inactive_unsafe_parameter_override_does_not_disable_fast_path(
+    isolated_global_optim_manager,
+):
+    overridden = torch.nn.Parameter(torch.ones(4096, device="cuda"))
+    active = torch.nn.Parameter(torch.ones(4096, device="cuda"))
+    isolated_global_optim_manager.override_config(overridden, key="percentile_clipping", value=50)
+    isolated_global_optim_manager.register_parameters([overridden, active])
+    optimizer = AdamW8bitFast([overridden, active], lr=1e-3)
+
+    active.grad = torch.ones_like(active)
+    can_use_fast_path, device, reason = optimizer._fast_path_device()
+    assert can_use_fast_path
+    assert device == active.device
+    assert reason is None
+
+    overridden.grad = torch.ones_like(overridden)
+    can_use_fast_path, device, reason = optimizer._fast_path_device()
+    assert not can_use_fast_path
+    assert device is None
+    assert reason == "parameter override enables percentile_clipping"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_module_override_is_applied_before_fast_path_guard(
+    monkeypatch,
+    isolated_global_optim_manager,
+):
+    module = torch.nn.Linear(64, 64, bias=False, device="cuda")
+    isolated_global_optim_manager.register_module_override(module, "weight", {"max_unorm": 1.0})
+    optimizer = AdamW8bitFast(module.parameters(), lr=1e-3)
+    module.weight.grad = torch.ones_like(module.weight)
+    calls = []
+
+    def stock_step(self, closure=None):
+        calls.append(closure)
+        return "stock-route"
+
+    monkeypatch.setattr(bnb.optim.AdamW8bit, "step", stock_step)
+
+    assert optimizer.step() == "stock-route"
+    assert calls == [None]
+    assert isolated_global_optim_manager.index2config[(0, 0)]["max_unorm"] == 1.0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")

--- a/tests/test_adamw8bit_fast.py
+++ b/tests/test_adamw8bit_fast.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+bnb = pytest.importorskip("bitsandbytes")
+
+from library.adamw8bit_fast import AdamW8bitFast
+
+
+def _assert_optimizer_state_equal(stock, fast, stock_params, fast_params) -> None:
+    for stock_param, fast_param in zip(stock_params, fast_params):
+        stock_state = stock.state[stock_param]
+        fast_state = fast.state[fast_param]
+        assert stock_state.keys() == fast_state.keys()
+        for key in stock_state:
+            stock_value = stock_state[key]
+            fast_value = fast_state[key]
+            if isinstance(stock_value, torch.Tensor):
+                assert isinstance(fast_value, torch.Tensor)
+                assert stock_value.dtype == fast_value.dtype
+                assert torch.equal(stock_value, fast_value), key
+            else:
+                assert stock_value == fast_value, key
+
+
+def test_cpu_parameters_use_stock_bitsandbytes_step(monkeypatch):
+    param = torch.nn.Parameter(torch.ones(8))
+    param.grad = torch.ones_like(param)
+    optimizer = AdamW8bitFast([param], lr=1e-3)
+    calls = []
+
+    def stock_step(self, closure=None):
+        calls.append(closure)
+        return "stock-route"
+
+    monkeypatch.setattr(bnb.optim.AdamW8bit, "step", stock_step)
+
+    assert optimizer.step() == "stock-route"
+    assert calls == [None]
+
+
+def test_optimizer_selection_accepts_adamw8bit_fast():
+    from library.train_util import get_optimizer
+
+    args = SimpleNamespace(
+        optimizer_type="AdamW8bitFast",
+        use_8bit_adam=False,
+        use_lion_optimizer=False,
+        fused_backward_pass=False,
+        gradient_accumulation_steps=1,
+        optimizer_args=None,
+        learning_rate=1e-3,
+    )
+    param = torch.nn.Parameter(torch.ones(8))
+
+    optimizer_name, optimizer_args, optimizer = get_optimizer(args, [param])
+
+    assert optimizer_name == "library.adamw8bit_fast.AdamW8bitFast"
+    assert optimizer_args == ""
+    assert isinstance(optimizer, AdamW8bitFast)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+def test_fast_step_matches_stock_parameters_and_all_states(dtype):
+    generator = torch.Generator(device="cuda").manual_seed(20260801)
+    shapes = [(64, 80), (32, 80), (64, 128), (48, 64)]  # both sides of min_8bit_size=4096
+    initial = [torch.randn(shape, device="cuda", dtype=dtype, generator=generator) * 0.01 for shape in shapes]
+    stock_params = [torch.nn.Parameter(value.clone()) for value in initial]
+    fast_params = [torch.nn.Parameter(value.clone()) for value in initial]
+
+    stock_groups = [
+        {"params": stock_params[:2], "lr": 3.5e-4},
+        {"params": stock_params[2:], "lr": 2.0e-4},
+    ]
+    fast_groups = [
+        {"params": fast_params[:2], "lr": 3.5e-4},
+        {"params": fast_params[2:], "lr": 2.0e-4},
+    ]
+    kwargs = {"lr": 1e-3, "betas": (0.9, 0.995), "weight_decay": 0.01}
+    stock = bnb.optim.AdamW8bit(stock_groups, **kwargs)
+    fast = AdamW8bitFast(fast_groups, **kwargs)
+
+    for step in range(7):
+        for index, (stock_param, fast_param) in enumerate(zip(stock_params, fast_params)):
+            if (step + index) % 5 == 0:
+                stock_param.grad = None
+                fast_param.grad = None
+                continue
+            grad = torch.randn(
+                stock_param.shape,
+                device="cuda",
+                dtype=dtype,
+                generator=generator,
+            )
+            stock_param.grad = grad.clone()
+            fast_param.grad = grad.clone()
+
+        stock.step()
+        fast.step()
+
+    for stock_param, fast_param in zip(stock_params, fast_params):
+        assert torch.equal(stock_param, fast_param)
+    _assert_optimizer_state_equal(stock, fast, stock_params, fast_params)
+
+    state_dtypes = {
+        value.dtype
+        for state in fast.state.values()
+        for value in state.values()
+        if isinstance(value, torch.Tensor)
+    }
+    assert torch.uint8 in state_dtypes
+    assert torch.float32 in state_dtypes
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fast_step_synchronizes_once_and_skips_sync_without_gradients(monkeypatch):
+    params = [
+        torch.nn.Parameter(torch.randn((64, 80), device="cuda", dtype=torch.float16)),
+        torch.nn.Parameter(torch.randn((64, 128), device="cuda", dtype=torch.float16)),
+    ]
+    optimizer = AdamW8bitFast(params, lr=1e-3)
+    original_synchronize = torch.cuda.synchronize
+    calls = []
+
+    def synchronize_once(device=None):
+        calls.append(device)
+        return original_synchronize(device=device)
+
+    monkeypatch.setattr(torch.cuda, "synchronize", synchronize_once)
+    for param in params:
+        param.grad = torch.randn_like(param)
+    optimizer.step()
+
+    assert calls == [params[0].device]
+
+    calls.clear()
+    for param in params:
+        param.grad = None
+    optimizer.step()
+
+    assert calls == []

--- a/third_party/bitsandbytes-LICENSE.txt
+++ b/third_party/bitsandbytes-LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Facebook, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/benchmark_adamw8bit_fast.py
+++ b/tools/benchmark_adamw8bit_fast.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+import gc
+import math
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import torch
+from safetensors import safe_open
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import bitsandbytes as bnb
+
+from library.adamw8bit_fast import AdamW8bitFast
+
+
+@dataclass
+class Result:
+    name: str
+    median_ms: float
+    min_ms: float
+    mean_ms: float
+    steady_allocated_mib: float
+    step_peak_extra_mib: float
+
+
+def load_weight_shapes(checkpoint: Path) -> list[tuple[int, ...]]:
+    with safe_open(checkpoint, framework="pt", device="cpu") as file:
+        return [tuple(file.get_slice(key).get_shape()) for key in file.keys() if not key.endswith(".alpha")]
+
+
+def make_parameters(shapes: list[tuple[int, ...]], seed: int, dtype: torch.dtype) -> list[torch.nn.Parameter]:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    parameters = []
+    for shape in shapes:
+        parameter = torch.nn.Parameter(torch.randn(shape, device="cuda", dtype=dtype, generator=generator) * 0.01)
+        parameter.grad = torch.randn(shape, device="cuda", dtype=dtype, generator=generator)
+        parameters.append(parameter)
+    return parameters
+
+
+def benchmark(
+    name: str,
+    factory: Callable[[list[torch.nn.Parameter]], torch.optim.Optimizer],
+    shapes: list[tuple[int, ...]],
+    *,
+    seed: int,
+    dtype: torch.dtype,
+    warmup: int,
+    iterations: int,
+) -> Result:
+    gc.collect()
+    torch.cuda.empty_cache()
+    baseline_allocated = torch.cuda.memory_allocated()
+
+    parameters = make_parameters(shapes, seed, dtype)
+    optimizer = factory(parameters)
+    for _ in range(warmup):
+        optimizer.step()
+    torch.cuda.synchronize()
+
+    steady_allocated = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    samples = []
+    for _ in range(iterations):
+        torch.cuda.synchronize()
+        start = time.perf_counter_ns()
+        optimizer.step()
+        torch.cuda.synchronize()
+        samples.append((time.perf_counter_ns() - start) / 1_000_000.0)
+
+    peak_allocated = torch.cuda.max_memory_allocated()
+    result = Result(
+        name=name,
+        median_ms=statistics.median(samples),
+        min_ms=min(samples),
+        mean_ms=statistics.mean(samples),
+        steady_allocated_mib=(steady_allocated - baseline_allocated) / (1024**2),
+        step_peak_extra_mib=(peak_allocated - steady_allocated) / (1024**2),
+    )
+
+    del optimizer, parameters
+    gc.collect()
+    torch.cuda.empty_cache()
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Compare stock AdamW8bit with AdamW8bitFast on LoRA shapes")
+    parser.add_argument("checkpoint", type=Path, help="LoRA .safetensors checkpoint used only for tensor shapes")
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=20260801)
+    parser.add_argument("--lr", type=float, default=3.5e-4)
+    parser.add_argument(
+        "--dtype",
+        choices=("float32", "float16", "bfloat16"),
+        default="float32",
+        help="Trainable parameter/gradient dtype (ordinary mixed-precision LoRA normally uses float32)",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if args.warmup < 1 or args.iterations < 1:
+        raise ValueError("warmup and iterations must be >= 1")
+    if not args.checkpoint.is_file():
+        raise FileNotFoundError(args.checkpoint)
+
+    dtype = getattr(torch, args.dtype)
+
+    shapes = load_weight_shapes(args.checkpoint)
+    if not shapes:
+        raise ValueError("checkpoint has no non-alpha tensors")
+    tensor_count = len(shapes)
+    element_count = sum(math.prod(shape) for shape in shapes)
+    below_threshold = sum(math.prod(shape) < 4096 for shape in shapes)
+
+    print(
+        f"torch={torch.__version__} cuda={torch.version.cuda} bnb={bnb.__version__} "
+        f"device={torch.cuda.get_device_name()}"
+    )
+    print(
+        f"checkpoint={args.checkpoint} dtype={args.dtype} tensors={tensor_count} elements={element_count} "
+        f"below_min_8bit_size={below_threshold} warmup={args.warmup} iterations={args.iterations}"
+    )
+
+    factories = [
+        ("AdamW8bit", lambda params: bnb.optim.AdamW8bit(params, lr=args.lr)),
+        ("AdamW8bitFast", lambda params: AdamW8bitFast(params, lr=args.lr)),
+    ]
+    results = [
+        benchmark(
+            name,
+            factory,
+            shapes,
+            seed=args.seed,
+            dtype=dtype,
+            warmup=args.warmup,
+            iterations=args.iterations,
+        )
+        for name, factory in factories
+    ]
+
+    print("optimizer,median_ms,min_ms,mean_ms,steady_allocated_mib,step_peak_extra_mib")
+    for result in results:
+        print(
+            f"{result.name},{result.median_ms:.6f},{result.min_ms:.6f},{result.mean_ms:.6f},"
+            f"{result.steady_allocated_mib:.3f},{result.step_peak_extra_mib:.3f}"
+        )
+
+    stock, fast = results
+    print(
+        f"# summary speedup={stock.median_ms / fast.median_ms:.4f}x "
+        f"saved_ms={stock.median_ms - fast.median_ms:.6f} "
+        f"estimated_8400_saved_sec={(stock.median_ms - fast.median_ms) * 8.4:.3f}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

bitsandbytesの`AdamW8bit`を継承し、parameterごとに実行されていたCUDA同期をoptimizer step末尾の1回へ集約する`AdamW8bitFast`を追加します。

```text
--optimizer_type AdamW8bitFast
```

bitsandbytesの更新式、8bit量子化、optimizer state形式は変更しません。bitsandbytes本体のforkや`site-packages`の書き換えも不要です。

## 背景

bitsandbytes 0.48.2の`AdamW8bit`では、概ね次の処理が行われています。

```text
parameter 1を更新 → GPU全体を同期
parameter 2を更新 → GPU全体を同期
...
parameter Nを更新 → GPU全体を同期
```

LoRAは小さいparameter tensorを多数持つため、parameterごとのCPU/GPU同期がoptimizer stepの大きな割合を占めます。

今回の高速経路では、同一CUDA streamの実行順序を利用して次のように処理します。

```text
parameter 1を更新
parameter 2を更新
...
parameter Nを更新
GPU全体を最後に1回だけ同期
```

最後の同期は残すため、optimizer stepが戻る前の完了確認とCUDAエラー検出は維持されます。

## 変更内容

- `bnb.optim.AdamW8bit`を継承した`AdamW8bitFast`を追加
- parameterごとのCUDA同期をstep末尾の1回へ集約
- bitsandbytesの`init_state()`、`update_step()`、8bit/FP32 state選択をそのまま使用
- 高速経路またはstockフォールバックを最初の1回だけログへ表示
- ログにbitsandbytes versionとフォールバック理由を表示
- stock AdamW8bitとのstate dict相互読み込みを維持
- bitsandbytesを実GPU検証済みの0.48.2へ固定
- bitsandbytes由来の制御フローについてMIT Licenseの帰属を追加

高速経路を使用した場合は次のログが出ます。

```text
AdamW8bitFast: fast path enabled on cuda:0 (bitsandbytes 0.48.2)
```

フォールバックした場合は次のように理由を表示します。

```text
AdamW8bitFast: using stock AdamW8bit step (reason: parameter is on cpu, bitsandbytes 0.48.2)
```

## 高速経路の条件

次をすべて満たす場合に高速経路を使用します。

- non-paged AdamW8bit
- 単GPU
- 分散world sizeが1
- 通常の`torch.nn.Parameter`
- dense strided gradient
- 更新対象のparameterとgradientが同じCUDA device上
- optimizer closureを使用しない
- `percentile_clipping=100`
- `max_unorm=0`

CPU、paged optimizer、複数GPU、Tensor subclass、sparse gradient、複数deviceなどではbitsandbytes標準の`step()`へ戻ります。

`percentile_clipping < 100`では履歴stateの`gnorm_vec`がbit完全一致しない可能性が追加テストで確認されたため、安全側としてstock経路へ戻します。

## マイクロベンチマーク

検証環境:

```text
PyTorch       2.9.1+cu130
bitsandbytes  0.48.2
GPU           NVIDIA GeForce RTX 5080
LoRA tensors  1,620
LoRA elements 12,646,400
Parameter     FP32
```

代表的なLoRA checkpointのtensor形状を使用し、warmup後に測定しました。

| optimizer | optimizer step中央値 | optimizer周辺の定常割当 |
|---|---:|---:|
| AdamW8bit | 85.34ms | 125.107MiB |
| AdamW8bitFast | 32.98ms | 125.107MiB |

結果:

- optimizer stepは約2.59倍
- 約52.35ms/step短縮
- optimizer周辺の定常メモリ割当は同一

## 実学習での結果

rank 4の同一学習条件で、optimizer指定だけを変更して8,400 step実行しました。

| optimizer | 総学習時間 |
|---|---:|
| AdamW8bit | 1時間27分35秒 |
| AdamW8bitFast | 1時間22分22秒 |

結果:

- 5分13秒短縮
- 学習時間を約6.0%短縮
- 処理速度換算で約6.3%向上
- 平均約37ms/step短縮

高速版のrunはskipped stepが20少なく、その分optimizer更新を20回多く実行しています。それでも5分13秒短縮しているため、skip数の違いが高速化を作ったものではありません。

マイクロベンチマークより実学習の短縮量が小さくなるのは、forward/backward、データ処理、保存、ログ、gradientのないparameterなど、optimizer以外の処理が含まれるためです。

今回の実測環境はRTX 5080ですが、高速化の対象であるparameter単位のCUDA同期はBlackwell固有の処理ではありません。高速経路の条件を満たすCUDA GPUであれば、AdaやAmpereなど他世代でも同期回数の削減効果が期待できます。

ただし、optimizer計算、メモリ転送、kernel起動、CUDA同期の時間比率はGPUごとに異なるため、短縮率はGPU世代や学習条件によって変わります。他世代GPUでの効果は現時点では未測定です。

## rankや学習条件が異なる場合の予想

今回の実学習確認はrank 4ですが、高速化の主因はLoRA parameterの要素数よりもtensor数とCUDA同期回数です。

同じtarget module構成でrankだけを変更する場合、LoRA tensorの形状と要素数は変わりますが、tensor数は概ね同じです。そのため、rankが変わっても同期削減の効果は期待できます。

| 条件 | 予想 |
|---|---|
| より低いrank | optimizer計算が軽くなり同期の割合が増えるため、同程度以上の短縮率になる可能性がある |
| より高いrank | 同期回数はほぼ同じため絶対時間の短縮は残るが、計算量が増えるため短縮率は小さくなる可能性がある |
| target moduleが多い | parameter tensorと同期回数が増えるため、効果が大きくなる可能性がある |
| target moduleが少ない | 同期回数が減るため、効果も小さくなる可能性がある |
| gradient accumulationが大きい | optimizer更新1回あたりの効果は残るが、forward/backwardの割合が増えるため総時間の短縮率は小さくなる |
| module dropoutやfreezeが多い | `grad=None`のparameterが増えるため、削減できる同期回数も少なくなる |
| GPU世代 | 同期集約の仕組みは特定世代に依存しない。ただし固定的な同期コストとoptimizer計算・メモリ転送の比率が異なるため、短縮率はGPUごとに変わる |

実際の短縮率はGPU、rank、target module数、batch size、gradient accumulation、量子化処理などに左右されます。

## 互換性とテスト

次を確認しています。

- FP32 parameter
- FP16 parameter
- 4,096要素未満のFP32 optimizer state
- 4,096要素以上の8bit optimizer state
- 複数learning-rate group
- 途中の`grad=None`
- `block_wise=False`
- 全parameterのbit完全一致
- 全optimizer stateのbit完全一致
- CUDA同期がstep当たり1回
- gradientがない場合は同期0回
- CPUおよび特殊設定でstockへフォールバック
- フォールバックログが一度だけ出ること
- AdamW8bitからAdamW8bitFastへのstate dict読み込み
- AdamW8bitFastからAdamW8bitへのstate dict読み込み

テスト結果:

```text
34 passed
2 deselected（既存の無関係な丸めテスト）
```

## 注意点

- AdamW8bitの主な利点はoptimizer stateのVRAM使用量とメモリ転送量を削減できることです。
- PyTorch AdamWとの速度比較は、GPU、PyTorch／bitsandbytesのversion、parameter tensorの数と大きさ、rank、VRAM余裕、foreach／fusedの利用状況によって変わります。
- 大きなtensorやメモリ転送が支配的な条件では、8bit化による転送量削減によってAdamW8bitの方が速くなる場合があります。
- 一方、LoRAのように小さいparameter tensorが多数ある条件では、量子化・逆量子化、parameter単位のkernel起動、CUDA同期の固定費が目立ち、stock AdamW8bitがPyTorch AdamWより遅くなる場合があります。
- AdamW8bitFastは8bit処理自体を省略するものではありません。stock AdamW8bitに残っていたparameterごとのCUDA同期を削減し、VRAM削減効果を維持したままAdamW8bit自体を高速化するものです。
- PyTorch AdamWを上回ること、または常に下回ることを前提とした実装ではありません。目的はAdamW8bitを選択した場合の不要な同期待ちを減らすことです。
- parameter update kernel自体は引き続きparameter単位で起動されるため、同期以外の量子化処理やkernel起動のコストは残ります。
- bitsandbytesの内部メソッドを継承しているため、bitsandbytes更新時は回帰テストが必要です。
- 現時点の実GPU検証versionはbitsandbytes 0.48.2です。