### PR TITLE
Speed up rank logging with batched statistics and CSV writes

### DIFF
--- a/networks/lora.py
+++ b/networks/lora.py
@@ -430,6 +430,164 @@ def _compute_lora_effective_rank_stats(lora, eps: float = 1e-12):
         }
 
 
+_RANK_STATS_BATCH_MAX_BYTES = 64 * 1024 * 1024
+
+
+def _rank_stats_batch_chunk_size(entries) -> int:
+    """Keep temporary stacked rank-stat tensors within a bounded size."""
+    if not entries:
+        return 1
+
+    _, _, a, b, r = entries[0]
+    weight_numel = a.numel() + b.numel()
+    # Conservatively account for both the stacked source dtype and its FP32
+    # compute copy. Gram/eigendecomposition tensors are small for normal LoRA
+    # ranks, but include headroom so high-rank custom networks remain bounded.
+    weight_bytes = weight_numel * (max(a.element_size(), b.element_size()) + 4)
+    workspace_bytes = 12 * r * r * 4
+    bytes_per_item = max(1, weight_bytes + workspace_bytes)
+    return max(1, _RANK_STATS_BATCH_MAX_BYTES // bytes_per_item)
+
+
+def _compute_rank_metrics_from_grams(p: torch.Tensor, q: torch.Tensor, r: int, eps: float) -> torch.Tensor:
+    diag_mean = torch.diagonal(q, dim1=-2, dim2=-1).mean(dim=-1)
+    jitter = eps * (diag_mean.abs() + 1.0)
+    eye = torch.eye(r, device=q.device, dtype=q.dtype).unsqueeze(0)
+    chol, info = torch.linalg.cholesky_ex(q + jitter[:, None, None] * eye)
+
+    chol_s = (chol.transpose(1, 2) @ p) @ chol
+
+    # Failed entries are replaced before the batched eigensolve so one bad
+    # Cholesky factor cannot poison the group. `info` travels in the final host
+    # transfer and only failed entries use the original scalar fallback.
+    s = torch.where((info == 0)[:, None, None], chol_s, torch.zeros_like(chol_s))
+    s = (s + s.transpose(1, 2)) * 0.5
+    eigvals = torch.linalg.eigvalsh(s)
+    eigvals = torch.clamp(eigvals, min=0.0)
+    energy = eigvals.sum(dim=-1)
+    weights = eigvals / (energy[:, None] + eps)
+    entropy = -(weights * torch.log(weights + eps)).sum(dim=-1)
+    effective_rank = torch.exp(entropy)
+    top1 = torch.max(weights, dim=-1).values
+    return torch.stack((energy, effective_rank, top1, info.to(dtype=torch.float32)), dim=-1)
+
+
+def _compute_lora_effective_rank_stats_batched(loras, eps: float = 1e-12):
+    """Compute effective-rank diagnostics in shape batches.
+
+    The returned dictionaries and ordering match the scalar helper above. GPU
+    results are copied to the host once per device rather than once per module.
+    Unsupported custom module shapes retain the scalar behavior.
+    """
+    result_slots = [None] * len(loras)
+    groups = {}
+
+    with torch.no_grad():
+        for index, lora in enumerate(loras):
+            w_down_module = getattr(lora, "lora_down", None)
+            w_up_module = getattr(lora, "lora_up", None)
+            if w_down_module is None or w_up_module is None:
+                continue
+
+            a = w_down_module.weight
+            b = w_up_module.weight
+            if a is None or b is None:
+                continue
+            if a.dim() == 4:
+                a = a.reshape(a.shape[0], -1)
+            if b.dim() == 4:
+                # LoRA up-convolutions are 1x1. Keep the existing reshape so a
+                # non-standard kernel raises in the same way as the scalar path.
+                b = b.reshape(b.shape[0], b.shape[1])
+
+            r = a.shape[0]
+            if r <= 0:
+                continue
+
+            if a.dim() != 2 or b.dim() != 2 or a.device != b.device:
+                result_slots[index] = _compute_lora_effective_rank_stats(lora, eps=eps)
+                continue
+
+            key = (a.device, a.dtype, b.dtype, tuple(a.shape), tuple(b.shape))
+            groups.setdefault(key, []).append((index, lora, a, b, int(r)))
+
+        rank_group_counts = {}
+        for entries in groups.values():
+            rank_key = (entries[0][2].device, entries[0][4])
+            rank_group_counts[rank_key] = rank_group_counts.get(rank_key, 0) + len(entries)
+
+        # P/Q consolidation removes repeated tiny solver launches. Keep it only
+        # while a conservative estimate of Gram matrices plus solver workspace
+        # stays within the same temporary-memory budget as the shape batches.
+        consolidate_rank_groups = {
+            (device, r)
+            for (device, r), count in rank_group_counts.items()
+            if count * 12 * r * r * 4 <= _RANK_STATS_BATCH_MAX_BYTES
+        }
+
+        gram_groups = {}
+        device_outputs = {}
+        for entries in groups.values():
+            chunk_size = _rank_stats_batch_chunk_size(entries)
+            for start in range(0, len(entries), chunk_size):
+                chunk = entries[start : start + chunk_size]
+                a_batch = torch.stack([entry[2] for entry in chunk], dim=0).to(dtype=torch.float32)
+                b_batch = torch.stack([entry[3] for entry in chunk], dim=0).to(dtype=torch.float32)
+                r = chunk[0][4]
+
+                p = b_batch.transpose(1, 2) @ b_batch
+                q = a_batch @ a_batch.transpose(1, 2)
+                del a_batch, b_batch
+                rank_key = (q.device, r)
+                if rank_key in consolidate_rank_groups:
+                    gram_groups.setdefault(rank_key, []).append((chunk, p, q))
+                else:
+                    packed = _compute_rank_metrics_from_grams(p, q, r, eps)
+                    device_outputs.setdefault(packed.device, []).append((chunk, packed))
+
+        for (device, r), gram_batches in gram_groups.items():
+            entries = [entry for chunk, _, _ in gram_batches for entry in chunk]
+            if len(gram_batches) == 1:
+                p = gram_batches[0][1]
+                q = gram_batches[0][2]
+            else:
+                p = torch.cat([p_batch for _, p_batch, _ in gram_batches], dim=0)
+                q = torch.cat([q_batch for _, _, q_batch in gram_batches], dim=0)
+            packed = _compute_rank_metrics_from_grams(p, q, r, eps)
+            device_outputs.setdefault(device, []).append((entries, packed))
+
+        for outputs in device_outputs.values():
+            host_values = torch.cat([packed for _, packed in outputs], dim=0).cpu().tolist()
+            offset = 0
+            for chunk, packed in outputs:
+                chunk_values = host_values[offset : offset + packed.shape[0]]
+                offset += packed.shape[0]
+                for entry, values in zip(chunk, chunk_values):
+                    index, lora, _, _, r = entry
+                    raw_energy, effective_rank, top1, cholesky_info = values
+                    if int(cholesky_info) != 0:
+                        result_slots[index] = _compute_lora_effective_rank_stats(lora, eps=eps)
+                        continue
+                    scale = float(getattr(lora, "scale", 1.0))
+                    mult = float(getattr(lora, "multiplier", 1.0))
+                    energy_val = float(raw_energy) * (scale * mult) ** 2
+                    if energy_val <= eps:
+                        sat = 0.0
+                        top1_val = 0.0
+                    else:
+                        sat = float(effective_rank) / float(r)
+                        top1_val = float(top1)
+                    result_slots[index] = {
+                        "module": lora.lora_name,
+                        "r": int(r),
+                        "sat": sat,
+                        "top1": top1_val,
+                        "energy": energy_val,
+                    }
+
+    return [stats for stats in result_slots if stats is not None]
+
+
 class LoRAModule(torch.nn.Module):
     """
     replaces forward method of the original Linear, instead of replacing the original Linear module.
@@ -1941,12 +2099,7 @@ class LoRANetwork(torch.nn.Module):
         if not loras:
             return None
 
-        per_module = []
-        with torch.no_grad():
-            for lora in loras:
-                stats = _compute_lora_effective_rank_stats(lora, eps=eps)
-                if stats is not None:
-                    per_module.append(stats)
+        per_module = _compute_lora_effective_rank_stats_batched(loras, eps=eps)
 
         if not per_module:
             return None

--- a/tests/test_rank_stats.py
+++ b/tests/test_rank_stats.py
@@ -1,0 +1,212 @@
+import builtins
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import networks.lora as lora_module
+from networks.lora import (
+    LoRANetwork,
+    _compute_lora_effective_rank_stats,
+    _compute_lora_effective_rank_stats_batched,
+)
+from train_network import _write_csv_rows
+
+
+def _rank_lora(name, down, up, *, scale=1.0, multiplier=1.0):
+    return SimpleNamespace(
+        lora_name=name,
+        lora_down=SimpleNamespace(weight=torch.nn.Parameter(down.clone())),
+        lora_up=SimpleNamespace(weight=torch.nn.Parameter(up.clone())),
+        scale=scale,
+        multiplier=multiplier,
+    )
+
+
+def _assert_stats_close(actual, expected):
+    assert actual["module"] == expected["module"]
+    assert actual["r"] == expected["r"]
+    assert isinstance(actual["r"], int)
+    for key in ("sat", "top1", "energy"):
+        assert isinstance(actual[key], float)
+        assert actual[key] == pytest.approx(expected[key], rel=2e-5, abs=2e-6)
+
+
+def test_batched_rank_stats_match_scalar_for_mixed_shapes_ranks_and_conv():
+    generator = torch.Generator().manual_seed(1234)
+    loras = [
+        _rank_lora(
+            "linear_a",
+            torch.randn(2, 3, generator=generator),
+            torch.randn(4, 2, generator=generator),
+        ),
+        _rank_lora(
+            "linear_fp16",
+            torch.randn(3, 5, generator=generator, dtype=torch.float16),
+            torch.randn(6, 3, generator=generator, dtype=torch.float16),
+            scale=0.75,
+        ),
+        _rank_lora(
+            "linear_b",
+            torch.randn(2, 3, generator=generator),
+            torch.randn(4, 2, generator=generator),
+        ),
+        _rank_lora(
+            "conv_3x3",
+            torch.randn(2, 2, 3, 3, generator=generator),
+            torch.randn(5, 2, 1, 1, generator=generator),
+            multiplier=0.5,
+        ),
+    ]
+
+    expected = [_compute_lora_effective_rank_stats(item) for item in loras]
+    actual = _compute_lora_effective_rank_stats_batched(loras)
+
+    assert [item["module"] for item in actual] == [item.lora_name for item in loras]
+    for actual_item, expected_item in zip(actual, expected):
+        _assert_stats_close(actual_item, expected_item)
+
+
+def test_batched_rank_stats_analytic_scaling_zero_and_summary_schema():
+    identity2 = torch.eye(2)
+    identity3 = torch.eye(3)
+    rank2 = _rank_lora("rank2", identity2, identity2, scale=2.0, multiplier=0.5)
+    zero = _rank_lora("zero", identity2, torch.zeros_like(identity2), scale=3.0, multiplier=2.0)
+    rank3 = _rank_lora("rank3", identity3, identity3)
+
+    per_module = _compute_lora_effective_rank_stats_batched([rank2, zero, rank3])
+    assert per_module[0]["energy"] == pytest.approx(2.0)
+    assert per_module[0]["sat"] == pytest.approx(1.0)
+    assert per_module[0]["top1"] == pytest.approx(0.5)
+    assert per_module[1] == {"module": "zero", "r": 2, "sat": 0.0, "top1": 0.0, "energy": 0.0}
+    assert per_module[2]["energy"] == pytest.approx(3.0)
+    assert per_module[2]["sat"] == pytest.approx(1.0)
+    assert per_module[2]["top1"] == pytest.approx(1.0 / 3.0)
+
+    network = SimpleNamespace(unet_loras=[rank2, zero, rank3])
+    summary = LoRANetwork.compute_rank_stats(network)
+    assert summary["rank_dim"] is None
+    assert summary["energy_sum"] == pytest.approx(5.0)
+    assert list(summary["by_module"]) == ["rank2", "zero", "rank3"]
+    assert summary["by_module"]["rank2"] is summary["per_module"][0]
+    assert summary["sat_wmean"] == pytest.approx(1.0)
+    assert summary["sat_p50"] == pytest.approx(1.0)
+    assert summary["sat_p95"] == pytest.approx(1.0)
+    assert summary["sat_max"] == pytest.approx(1.0)
+    assert summary["top1_p95"] == pytest.approx(0.5 - (0.5 - 1.0 / 3.0) * 0.05)
+
+
+def test_batched_rank_stats_preserve_cholesky_fallback(monkeypatch):
+    regular = _rank_lora("regular", torch.eye(2), torch.eye(2))
+    singular = _rank_lora(
+        "singular",
+        torch.tensor([[1.0, 0.0], [1.0, 0.0]]),
+        torch.tensor([[1.0, 0.0], [0.0, 2.0]]),
+    )
+
+    expected = [
+        _compute_lora_effective_rank_stats(regular),
+        _compute_lora_effective_rank_stats(singular),
+    ]
+    scalar_calls = []
+    original_scalar = _compute_lora_effective_rank_stats
+    original_cholesky_ex = torch.linalg.cholesky_ex
+
+    def tracked_scalar(item, eps=1e-12):
+        scalar_calls.append(item.lora_name)
+        return original_scalar(item, eps=eps)
+
+    def force_second_batch_item_to_fallback(input, *args, **kwargs):
+        chol, info = original_cholesky_ex(input, *args, **kwargs)
+        if input.dim() == 3:
+            info = info.clone()
+            info[1] = 1
+        return chol, info
+
+    monkeypatch.setattr(lora_module, "_compute_lora_effective_rank_stats", tracked_scalar)
+    monkeypatch.setattr(torch.linalg, "cholesky_ex", force_second_batch_item_to_fallback)
+    actual = _compute_lora_effective_rank_stats_batched([regular, singular])
+
+    assert scalar_calls == ["singular"]
+    for actual_item, expected_item in zip(actual, expected):
+        _assert_stats_close(actual_item, expected_item)
+
+
+def test_batched_rank_stats_skip_missing_modules_and_keep_inputs_and_rng_unchanged(monkeypatch):
+    lora = _rank_lora("kept", torch.tensor([[1.0, 2.0]]), torch.tensor([[3.0], [4.0]]))
+    lora.lora_down.weight.grad = torch.tensor([[5.0, 6.0]])
+    down_before = lora.lora_down.weight.detach().clone()
+    up_before = lora.lora_up.weight.detach().clone()
+    grad_before = lora.lora_down.weight.grad.clone()
+    versions_before = (lora.lora_down.weight._version, lora.lora_up.weight._version)
+    rng_before = torch.get_rng_state().clone()
+
+    monkeypatch.setattr(lora_module, "_RANK_STATS_BATCH_MAX_BYTES", 1)
+    result = _compute_lora_effective_rank_stats_batched(
+        [
+            SimpleNamespace(lora_name="missing"),
+            lora,
+            SimpleNamespace(lora_name="missing_up", lora_down=lora.lora_down),
+        ]
+    )
+
+    assert [item["module"] for item in result] == ["kept"]
+    assert torch.equal(lora.lora_down.weight, down_before)
+    assert torch.equal(lora.lora_up.weight, up_before)
+    assert torch.equal(lora.lora_down.weight.grad, grad_before)
+    assert (lora.lora_down.weight._version, lora.lora_up.weight._version) == versions_before
+    assert torch.equal(torch.get_rng_state(), rng_before)
+    assert LoRANetwork.compute_rank_stats(SimpleNamespace(unet_loras=[])) is None
+    assert LoRANetwork.compute_rank_stats(SimpleNamespace(unet_loras=[lora]), scope="te") is None
+
+
+def test_batched_rank_stats_fall_back_to_bounded_gram_chunks(monkeypatch):
+    loras = [
+        _rank_lora(f"rank2_{index}", torch.eye(2), torch.eye(2))
+        for index in range(3)
+    ]
+    original_compute = lora_module._compute_rank_metrics_from_grams
+    batch_sizes = []
+
+    def tracked_compute(p, q, r, eps):
+        batch_sizes.append(p.shape[0])
+        return original_compute(p, q, r, eps)
+
+    monkeypatch.setattr(lora_module, "_RANK_STATS_BATCH_MAX_BYTES", 1)
+    monkeypatch.setattr(lora_module, "_compute_rank_metrics_from_grams", tracked_compute)
+
+    result = _compute_lora_effective_rank_stats_batched(loras)
+
+    assert [item["module"] for item in result] == [item.lora_name for item in loras]
+    assert batch_sizes == [1, 1, 1]
+
+
+def test_write_csv_rows_batches_an_event_and_appends_without_duplicate_header(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "rank.csv"
+    path.write_text("stale\n", encoding="utf-8")
+    real_open = builtins.open
+    open_modes = []
+
+    def tracked_open(file, mode="r", *args, **kwargs):
+        open_modes.append((str(file), mode))
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", tracked_open)
+
+    header_written = _write_csv_rows(str(path), "module,energy", ["a,1.000000", "b,2.000000"], False)
+    assert header_written is True
+    assert open_modes == [(str(path), "w")]
+    assert path.read_text(encoding="utf-8") == "module,energy\na,1.000000\nb,2.000000\n"
+
+    open_modes.clear()
+    header_written = _write_csv_rows(str(path), "module,energy", ["c,3.000000"], header_written)
+    assert header_written is True
+    assert open_modes == [(str(path), "a")]
+    assert path.read_text(encoding="utf-8") == (
+        "module,energy\na,1.000000\nb,2.000000\nc,3.000000\n"
+    )
+
+    assert _write_csv_rows(str(path), "module,energy", [], header_written) is True
+    assert path.read_text(encoding="utf-8").endswith("c,3.000000\n")

--- a/train_network.py
+++ b/train_network.py
@@ -13,7 +13,7 @@ import toml
 from collections import Counter, deque
 import numpy as np
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from tqdm import tqdm
 
@@ -64,6 +64,21 @@ logger = logging.getLogger(__name__)
 _TORCH_GET_TOTAL_NORM = getattr(torch.nn.utils, "get_total_norm", None)
 _FOREACH_GRAD_NORM_DISABLED = False
 _FOREACH_GRAD_NORM_PATH_LOGGED = False
+
+
+def _write_csv_rows(path: str, header: str, lines: Sequence[str], header_written: bool) -> bool:
+    """Write one CSV event with a single file open and report header state."""
+    if not path or not lines:
+        return header_written
+
+    dirpath = os.path.dirname(path)
+    if dirpath:
+        os.makedirs(dirpath, exist_ok=True)
+    with open(path, "a" if header_written else "w", encoding="utf-8") as f:
+        if not header_written:
+            f.write(header + "\n")
+        f.writelines(line + "\n" for line in lines)
+    return True
 
 
 def _set_delta_fake_quant_compat(network, step, mode, **kwargs):
@@ -1341,30 +1356,27 @@ class NetworkTrainer:
         dq_auto_log_header_written = False
         rank_log_header_written = False
 
-        def _write_csv(path: str, header: str, line: str):
+        def _write_csv_lines(path: str, header: str, lines: Sequence[str]):
             nonlocal dq_log_header_written, dq_auto_log_header_written, rank_log_header_written
             if not path:
                 return
-            dirpath = os.path.dirname(path)
-            if dirpath:
-                os.makedirs(dirpath, exist_ok=True)
             if path == dq_log_path:
                 header_written = dq_log_header_written
             elif path == dq_auto_log_path:
                 header_written = dq_auto_log_header_written
             else:
                 header_written = rank_log_header_written
-            if not header_written:
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(header + "\n")
+            header_written = _write_csv_rows(path, header, lines, header_written)
+            if header_written:
                 if path == dq_log_path:
                     dq_log_header_written = True
                 elif path == dq_auto_log_path:
                     dq_auto_log_header_written = True
                 else:
                     rank_log_header_written = True
-            with open(path, "a", encoding="utf-8") as f:
-                f.write(line + "\n")
+
+        def _write_csv(path: str, header: str, line: str):
+            _write_csv_lines(path, header, (line,))
 
         if dq_auto_enabled:
             if args.dq_delta_stat != "rms":
@@ -4273,6 +4285,7 @@ class NetworkTrainer:
                                     header = _rank_log_header(rank_log_mode)
                                     lr_snapshot = self.collect_rank_log_lr_snapshot(args, lr_scheduler, lr_descriptions)
                                     if rank_log_mode == "per_module":
+                                        rank_log_lines = []
                                         for item in rank_stats.get("per_module", []):
                                             row = [
                                                 epoch + 1,
@@ -4290,7 +4303,8 @@ class NetworkTrainer:
                                                 item.get("top1"),
                                                 item.get("energy"),
                                             ]
-                                            _write_csv(rank_log_path, header, ",".join(_dq_format_value(v) for v in row))
+                                            rank_log_lines.append(",".join(_dq_format_value(v) for v in row))
+                                        _write_csv_lines(rank_log_path, header, rank_log_lines)
                                     else:
                                         row = [
                                             epoch + 1,


### PR DESCRIPTION
## 概要

rank logの統計計算とCSV出力をバッチ化し、学習中のrank logイベントによる停止時間を削減します。

## 変更内容

- LoRAモジュールをweight shapeごとにまとめてGram行列をバッチ計算
- Gram行列生成後は、同一device・rankのモジュールをさらに統合
- `energy`、effective rank、`top1`、Cholesky結果をまとめてCPUへ転送
- Choleskyに失敗した要素だけ既存のscalar実装へフォールバック
- 高rank構成では一時メモリの見積りに基づいて自動的にchunk処理
- per-module rank logのCSVを、モジュールごとのopen/writeからイベント単位の一括書き込みへ変更

## 互換性

以下の挙動は維持しています。

- `per_module`の出力順
- rank statsの戻り値とsummary schema
- `(scale * multiplier) ** 2`によるenergy補正
- scaled energyを使ったzero/active判定
- LinearおよびConv2d LoRAの処理
- Cholesky失敗時の既存eigh fallback

rank logはread-onlyかつ`torch.no_grad()`で実行されるため、学習weight、gradient、RNG状態には影響しません。

DQ設定、`dq_delta_scope`、現在のText Encoder量子化挙動にも変更はありません。

バッチ演算では演算順が変わるため、rank logの末尾桁は完全なbit一致にはなりません。実成果物で確認した最大相対差は約`4.52e-6`です。

## ベンチマーク

環境:

- NVIDIA GeForce RTX 5080
- rank 4
- UNet LoRA 722モジュール
- weight shape 8種類
- 実学習成果物を使用

結果:

| 実装 | rank stats / event |
|---|---:|
| 変更前 scalar | 658.98 ms |
| 変更後 batched | 2.83 ms |

rank stats計算部分で約233倍の高速化です。

8400 stepの学習で、`--rank_log_every 100`かつ`--rank_log_mode per_module`を使用する場合、rank logイベントは約84回発生します。

この条件では、rank stats計算だけで合計約55秒の短縮が見込まれます。加えて、各イベントのCSVファイルopen回数も722回から1回になります。

この数値はrank log処理部分の短縮量であり、学習全体が233倍高速化するという意味ではありません。

## テスト

以下を実行しました。

```text
pytest tests/test_rank_stats.py tests/test_speed_optimizations.py tests/test_avg_cp.py -q
```

結果:

```text
27 passed
```

追加テストでは以下を確認しています。

- scalar版との統計値比較
- mixed shape / mixed rank
- Linear / Conv2d / FP16
- zero energyとscale/multiplier補正
- summaryおよび`by_module`互換
- Cholesky失敗時のscalar fallback
- weight、gradient、RNG状態の非変更
- 高rank向けメモリ制限経路
- CSVの一括書き込み、追記、ヘッダー非重複
