### PR TITLE
feat: add Standard mode and beginner report to DQ profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 **ツール一覧**
 | ツール名 | 概要 | 説明 |
 |---|---|---|
-| `python -m dq_profile` | Experimental DQ Dataset Profilerを直接起動し、Local Body／Tailレポートを生成 | 既定は日常用`standard`（固定5点・短いQA）。`--dq-profile-mode=strict`でreference-depth検算。出力は`lora_output/dq_dataset_profiler`。Safety/Fidelity診断であり最終画質推薦ではない。使い方: [docs/dq_dataset_profiler-ja.md](docs/dq_dataset_profiler-ja.md) |
+| `python -m dq_profile` | Experimental DQ Dataset Profilerを直接起動し、Local Body／Tailレポートを生成 | 既定は正式診断用`standard`。短時間の傾向確認は`--dq-profile-mode=quick`、reference-depth検算は`strict`。出力は`lora_output/dq_dataset_profiler`。Safety/Fidelity診断であり最終画質推薦ではない。使い方: [docs/dq_dataset_profiler-ja.md](docs/dq_dataset_profiler-ja.md) |
 | `sdxl_tokenize.py` | SDXLのTE1/TE2トークン分割の表示と候補探索 | [docs/sdxl_tokenize_tool-ja.md](docs/sdxl_tokenize_tool-ja.md) |
 | `make_lora_diagnostic_report.py` | LoRA学習ログ（`grad_norm` / `dq_delta`）とLoRA重みを診断し、グラフ内蔵HTMLを生成 | 使い方とオプション詳細: [docs/make_lora_diagnostic_report-ja.md](docs/make_lora_diagnostic_report-ja.md) |
 | `sdxl_lora_report_gui.py` | SDXL LoRAの一括生成・比較HTMLレポートをGUIで作成 | [docs/sdxl_lora_report_README-ja.md](docs/sdxl_lora_report_README-ja.md) |
@@ -71,8 +71,9 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 
 この診断は最終画質、量子化の採用可否、best mulを自動判定するものではありません。
 比較可能性を保つため、初期Betaではrank 4、AdamW8bitFast、fp16 strictなどの
-検証済み条件を固定します。日常診断の`standard`と、環境変更・リリース前・再現性調査用の
-`strict`は同じLocal Body／Tail測定量を使い、Prefix検算とedge探索の深さだけが異なります。
+検証済み条件を固定します。既定の`standard`は最大32画像の正式診断、`quick`は最大16画像と
+独立snapshot 1回による短時間の傾向確認、`strict`は環境変更・リリース前・再現性調査用です。
+QuickもBody／Tailの定義とreplica数は維持しますが、samplingが少ないためconfidenceに上限を付けます。
 
 ```bat
 .\venv\Scripts\python.exe -m dq_profile ^

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 **ツール一覧**
 | ツール名 | 概要 | 説明 |
 |---|---|---|
-| `python -m dq_profile` | Experimental DQ Dataset Profilerを直接起動し、Local Body／Tailレポートを生成 | 既定は正式診断用`standard`。短時間の傾向確認は`--dq-profile-mode=quick`、reference-depth検算は`strict`。出力は`lora_output/dq_dataset_profiler`。Safety/Fidelity診断であり最終画質推薦ではない。使い方: [docs/dq_dataset_profiler-ja.md](docs/dq_dataset_profiler-ja.md) |
+| `python -m dq_profile` | Experimental DQ Dataset Profilerを直接起動し、Local Body／Tailレポートを生成 | 既定は最大32画像・独立snapshot 1回の`standard`。二重snapshotとreference-depth検算は`strict`。出力は`lora_output/dq_dataset_profiler`。Safety/Fidelity診断であり最終画質推薦ではない。使い方: [docs/dq_dataset_profiler-ja.md](docs/dq_dataset_profiler-ja.md) |
 | `sdxl_tokenize.py` | SDXLのTE1/TE2トークン分割の表示と候補探索 | [docs/sdxl_tokenize_tool-ja.md](docs/sdxl_tokenize_tool-ja.md) |
 | `make_lora_diagnostic_report.py` | LoRA学習ログ（`grad_norm` / `dq_delta`）とLoRA重みを診断し、グラフ内蔵HTMLを生成 | 使い方とオプション詳細: [docs/make_lora_diagnostic_report-ja.md](docs/make_lora_diagnostic_report-ja.md) |
 | `sdxl_lora_report_gui.py` | SDXL LoRAの一括生成・比較HTMLレポートをGUIで作成 | [docs/sdxl_lora_report_README-ja.md](docs/sdxl_lora_report_README-ja.md) |
@@ -71,9 +71,9 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 
 この診断は最終画質、量子化の採用可否、best mulを自動判定するものではありません。
 比較可能性を保つため、初期Betaではrank 4、AdamW8bitFast、fp16 strictなどの
-検証済み条件を固定します。既定の`standard`は最大32画像の正式診断、`quick`は最大16画像と
-独立snapshot 1回による短時間の傾向確認、`strict`は環境変更・リリース前・再現性調査用です。
-QuickもBody／Tailの定義とreplica数は維持しますが、samplingが少ないためconfidenceに上限を付けます。
+検証済み条件を固定します。既定の`standard`は最大32画像と独立snapshot 1回を使う日常診断、
+`strict`は独立snapshot A/B、長いPrefix、bounded edge再測定を使う環境変更・リリース前・
+再現性調査用です。旧16画像Quickはsamplingによる結果の揺れを避けるため、新規CLIから廃止しました。
 
 ```bat
 .\venv\Scripts\python.exe -m dq_profile ^

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 **ツール一覧**
 | ツール名 | 概要 | 説明 |
 |---|---|---|
-| `python -m dq_profile` | Experimental DQ Dataset Profilerを直接起動し、Local Body／Tailレポートを生成 | 既定出力は `lora_output/dq_dataset_profiler`。Safety/Fidelity診断であり最終画質推薦ではない。使い方: [docs/dq_dataset_profiler-ja.md](docs/dq_dataset_profiler-ja.md) |
+| `python -m dq_profile` | Experimental DQ Dataset Profilerを直接起動し、Local Body／Tailレポートを生成 | 既定は日常用`standard`（固定5点・短いQA）。`--dq-profile-mode=strict`でreference-depth検算。出力は`lora_output/dq_dataset_profiler`。Safety/Fidelity診断であり最終画質推薦ではない。使い方: [docs/dq_dataset_profiler-ja.md](docs/dq_dataset_profiler-ja.md) |
 | `sdxl_tokenize.py` | SDXLのTE1/TE2トークン分割の表示と候補探索 | [docs/sdxl_tokenize_tool-ja.md](docs/sdxl_tokenize_tool-ja.md) |
 | `make_lora_diagnostic_report.py` | LoRA学習ログ（`grad_norm` / `dq_delta`）とLoRA重みを診断し、グラフ内蔵HTMLを生成 | 使い方とオプション詳細: [docs/make_lora_diagnostic_report-ja.md](docs/make_lora_diagnostic_report-ja.md) |
 | `sdxl_lora_report_gui.py` | SDXL LoRAの一括生成・比較HTMLレポートをGUIで作成 | [docs/sdxl_lora_report_README-ja.md](docs/sdxl_lora_report_README-ja.md) |
@@ -71,10 +71,12 @@ bf16 環境での挙動は未検証です。GradScaler が不要になるため 
 
 この診断は最終画質、量子化の採用可否、best mulを自動判定するものではありません。
 比較可能性を保つため、初期Betaではrank 4、AdamW8bitFast、fp16 strictなどの
-検証済み条件を固定したExperimental strict referenceとして提供します。
+検証済み条件を固定します。日常診断の`standard`と、環境変更・リリース前・再現性調査用の
+`strict`は同じLocal Body／Tail測定量を使い、Prefix検算とedge探索の深さだけが異なります。
 
 ```bat
 .\venv\Scripts\python.exe -m dq_profile ^
+  --dq-profile-mode=standard ^
   --pretrained_model_name_or_path="D:\models\sdxl_base.safetensors" ^
   --dataset_config="D:\datasets\example\dataset.toml"
 ```

--- a/docs/dq_dataset_profiler-ja.md
+++ b/docs/dq_dataset_profiler-ja.md
@@ -51,7 +51,7 @@ datasetと`range_mul`の組み合わせが学習勾配へ与える数値的な�
 - model、dataset TOML、各`image_dir`が存在する。
 - 学習loaderと同じ拡張子・大文字小文字規則および非再帰探索で、各`image_dir`直下に画像があり、dataset全体で8画像以上、独立した`image_dir`が4 group以上ある。
 - source-group prefixとworkerが返す画像keyを一致させるため、`image_dir`へ`.`／`..`のpath componentを含めず、どの階層にもsymlink、junctionなどのreparse pointを含めない。
-- すべての有効な`image_dir` groupをprobeへ最低1件ずつ含められることを確認する。group数が検証済みprobe上限を超える設定は、部分的なconfidenceを出さず開始前に拒否する。
+- 有効な`image_dir` groupの全inventoryをsource contractへ保存する。group数がprobe上限を超える場合は、TOMLの全source順序を均等に覆う決定的な部分集合をprobe対象とし、probe数／全group数とcoverageをレポートへ明示する。
 - `cache_latents`と両立しない`color_aug=true`または`random_crop=true`が、subset／dataset／`[general]`のfallback後に有効でないことを確認する。
 - DreamBooth loaderに必須の`resolution`が、datasetまたは`[general]`のfallback後に定義されていることを確認する。
 - TOMLの`[general]`／dataset／subset fallbackを解決し、batch・bucket設定（`bucket_no_upscale=false`を含む）が`canonical-v1`と一致することを確認する。
@@ -60,7 +60,7 @@ datasetと`range_mul`の組み合わせが学習勾配へ与える数値的な�
 - Git HEAD、ソースhash、preset、model内容のSHA-256、dataset、source inventoryからprotocol fingerprintを作る。
 - 各GPU workerの起動直前にmodel内容とsource inventoryを再度hash照合し、長い多段runの途中でmodel、画像、caption、cache sidecarが変化した場合は混在させず停止する。
 - repositoryに追跡済みの未コミット変更がある場合は、HEADとの差分全体もbinary diffとしてhash化する。未追跡ファイルは対象外と明記する。
-- 実画像数と`min(実画像数, 32)`であるprobe budgetを記録する。
+- 実画像数とmode別probe budgetに加え、全source group数、probe対象group数、決定的な選択規則を記録する。
 
 `--dq-profile-preflight`ではここまで実行し、GPU stageを起動しません。
 通常のpreflight／dry-runを含む全runで`execution_plan.json`も作り、GPU process数、
@@ -111,12 +111,13 @@ no-quantと各固定mulの勾配を比較します。
 - dropoutを無効にした`structural_dropout_off` regimeで測る。
 - module単位の勾配を集約し、Body、Tail、hard-safety、source別の不確実性を作る。
 
-比較用branchの先頭replay windowは固定したままです。この固定windowにrepeat数の少ない
+比較用branchの先頭replay windowは固定したままです。この固定windowにprobe対象の
 `image_dir` groupが含まれなかった場合だけ、DataLoaderを最大2 epoch分追加走査します。
-不足groupを初めて含んだbatchだけをprobe用に保持し、全source groupを揃えてから画像を
-round-robin選択します。追加batchはbranchの128-step prefixへ混ぜないため、候補間比較の
-再現契約は変わりません。極端にrepeatが偏るdatasetでは、このcoverage走査ぶんだけ
-Local計測開始前の時間が増える場合があります。
+不足groupを初めて含んだbatchだけをprobe用に保持し、対象groupを揃えてから画像を
+round-robin選択します。group数が画像上限を超える場合、source inventory自体は省略せず、
+TOMLの先頭だけへ偏らない決定的な等間隔選択で対象groupを絞ります。追加batchはbranchの
+prefixへ混ぜないため、候補間比較の再現契約は変わりません。極端にrepeatが偏るdatasetでは、
+このcoverage走査ぶんだけLocal計測開始前の時間が増える場合があります。
 
 このLocal結果だけを通常レポートのSafety/Fidelityと候補削減に使用します。dropout有効の
 128-step Trajectoryは研究専用の別channelであり、現在の製品入口では実行しません。
@@ -141,8 +142,9 @@ total = I × 4 × (3 + 4M)
 両者の違いはLocal画像上限です。Standardは最大32画像、Quickは最大16画像です。Quickでも
 4 timestep帯、no-quant 3 replicas、candidate 2 noise × 2 quant repeatsを維持するため、Body／Tailの
 定義は変えません。ただしsamplingが薄いため、レポートのconfidence上限をMediumとし、
-`reduced_descriptive`と明示します。独立source groupが16を超えるdatasetは、全groupを最低1件ずつ
-含められないためQuickを開始前に拒否します。その場合はStandardを使用してください。
+`reduced_descriptive`と明示します。独立source groupが画像上限を超えるdatasetも実行できますが、
+Quickは最大16群、Standard／Strictは最大32群だけを決定的にprobeします。全groupはsource contractに
+残り、レポートには`probe / total`を表示します。未probe群がある結果は完全coverageと同一視しません。
 
 `strict`はcore grid `2.70, 3.15, 3.45`から開始します。候補集合が測定端に残る場合だけ、
 最大2段まで外側を追加します。下端側は`2.25`、なお未解決なら`1.80`、上端側は`3.75`、
@@ -291,6 +293,9 @@ d = sqrt(1 + norm_ratio^2 - 2 * norm_ratio * gradient_cosine)
 
 NaN、Inf、極端なgradient explosion、optimizer stateの非finiteがなかった候補です。
 これは最低限の安全条件であり、画質保証ではありません。
+1件でも非finiteなgradient probeが出たmulは、その候補全体を数値比較から外して
+`Hard unsafe`として残します。他の有限なmulはbootstrapとHTML生成を継続するため、
+1候補の異常だけで診断全体を失敗させません。原因と非finite件数はsummary／候補カードへ保存します。
 
 ### Fidelity retained
 
@@ -505,8 +510,10 @@ QuickでもBody／Tailの数式、4 timestep帯、replica数、bootstrap、hard-
 | QA表示 | `Quick smoke` | `Standard smoke` | `Strict reference` |
 | confidence上限 | Medium | 通常 | 通常 |
 
-Quickでは全source groupをprobeへ最低1件ずつ含める契約を維持します。独立groupが16を超える場合は、
-部分的な結果を黙って出さずpreflightで拒否します。Standardへ切り替えてください。
+source groupがmodeの画像上限を超える場合もpreflightでは拒否しません。全inventoryをsource contractへ
+保持したまま、Quickは最大16群、Standard／Strictは最大32群をTOML全域から決定的に選びます。
+`report.html`とsummaryには`source_group_count_probed`／`source_group_count_total`／coverage規則を
+残し、未probe群がある場合はLocal confidenceを過大評価しません。
 
 `--dq_profile_level=standard`は低レベルprotocol内部の別概念です。公開CLIの
 `--dq-profile-mode=standard`と混同しないよう、成果物には`execution_mode`、`qa_depth`、

--- a/docs/dq_dataset_profiler-ja.md
+++ b/docs/dq_dataset_profiler-ja.md
@@ -186,7 +186,7 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 | 要因 | 時間への影響 |
 |---|---|
 | 通常学習相当の総step数 | 5% warmup境界が変わる。画像repeatやdataset設定が多いほど、各GPU stageの境界作成が長くなる |
-| 実画像数 | Local部分は8～32画像の範囲でほぼ比例する。32画像を超える分は直接増えない |
+| 実画像数 | Local部分はprobe上限までほぼ比例する。Quickは最大16画像、Standard／Strictは最大32画像 |
 | bucket解像度 | 高解像度bucketが多いほど各forward/backwardが重くなる |
 | edge延長回数 | 0～2回。現在は拡張grid全体を再測定するため、もっとも大きな可変要因 |
 | GPU、precision、backend | 同じprotocolでも1 probe当たりの時間が変わる |
@@ -196,11 +196,25 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 
 | mode | 実行内容 | 実測例を基準にした概算 |
 |---|---|---:|
-| Quick | Snapshot 1回、8A／8B／16、最大16画像、固定5点、edgeなし | 約60～75分（37画像・warmup 1,480 step級での事前見積もり） |
 | Standard | 8A／8B／16、固定5点を1回、edgeなし | 約37分 |
 | Strict（edgeなし） | 64A／64B／128、core 3点 | 約46分 |
 | Strict（edge 1回） | 上記＋拡張grid再測定1回 | 約65分 |
 | Strict（edge 2回） | 上記＋拡張grid再測定2回 | 約88分 |
+
+別の37画像、29,600 training-step相当、warmup境界1,480 stepのdatasetでは、同じGPUで
+次の実測になりました。このdatasetは上の13画像例よりwarmupとLocalの両方が重いため、
+絶対時間を直接比較しないでください。
+
+| mode | probe画像数 | GPU process数 | 実測時間 | Standard比 |
+|---|---:|---:|---:|---:|
+| Quick | 16 | 3 | 約1時間07分32秒 | 約33.1%短縮（約1.50倍速） |
+| Standard | 32 | 4 | 約1時間40分59秒 | 基準 |
+
+Quickの事前計画値は約68.5分で、実測約67.5分と近い結果でした。共有する先頭16画像・3候補の
+raw probeを同一source contractで検算したところ、gradient-tail 828行とno-quant自然変動192行が
+全列exact一致しました。一方、Quickはsourceごとの標本が少ないためCIが広がり、Standardなら
+robustに除外できた候補を除外せず全候補をretainedとする場合がありました。これは故障ではなく、
+縮小sampling時に無理な候補削減を避ける意図したabstain動作です。
 
 これは保証値ではありません。実行中は`status.json`の`current_stage`と`run.log`の
 `RUN`／`DONE`時刻で進行を確認してください。

--- a/docs/dq_dataset_profiler-ja.md
+++ b/docs/dq_dataset_profiler-ja.md
@@ -71,11 +71,11 @@ warmup境界、Prefix update数、Local probe数、固定grid、参考時間の�
 通常学習コードと同じ規則で`dq_delta_begin_step`を求め、量子化開始直前までno-quantで
 warmupします。`canonical-v1`では40 epoch相当の総stepと5% LR warmupから境界が決まります。
 
-`standard`と`strict`は、同じ初期状態からSnapshot AとSnapshot Bを別processで作り、LoRA重み、
-optimizer、scheduler、GradScaler、Guardian、RNG、replay位置などのfingerprintを比較します。
-`quick`はSnapshot Aを1回だけ作り、後続のPrefix processが同じ境界を再現できたかを比較します。
-どのmodeでも境界fingerprintが一致しなければmul比較を開始しません。Quickは独立snapshotを
-1回減らすぶん速い一方、同じstageを2回作る検算深度はStandardより低くなります。
+`strict`は、同じ初期状態からSnapshot AとSnapshot Bを別processで作り、LoRA重み、optimizer、
+scheduler、GradScaler、Guardian、RNG、replay位置などのfingerprintを比較します。`standard`は
+Snapshot Aを1回だけ作り、後続のPrefix processが同じ境界を再現できたかを比較します。
+どちらも境界fingerprintが一致しなければmul比較を開始しません。Standardは専用のSnapshot Bを
+省くぶん速い一方、同じsnapshot-only stageを2回作る検算深度はStrictより低くなります。
 
 以下で時間例に使う小規模datasetは、通常学習が8,400 stepだったため、境界は
 `8,400 × 0.05 = 420 step`でした。
@@ -86,15 +86,14 @@ optimizer、scheduler、GradScaler、Guardian、RNG、replay位置などのfinge
 
 | execution mode | short A | short B | long | 比較checkpoint | 合計branch update |
 |---|---:|---:|---:|---|---:|
-| `quick` | 8 | 8 | 16 | `0, 1, 4, 8` | 64 |
 | `standard` | 8 | 8 | 16 | `0, 1, 4, 8` | 64 |
 | `strict` | 64 | 64 | 128 | `0, 1, 32, 64` | 512 |
 
 各modeでA対B、およびA対long runの同じ先頭prefixを比較します。sample、noise、timestep、
 rank／network dropout、量子化乱数、Loss、LR、skip、勾配、LoRA重み、optimizer、scheduler、
 GradScaler、Guardian、replay cursorを検査します。このstageは通常学習に近い経路を検査するため
-dropout有効です。`quick`と`standard`は短いsmoke QA、`strict`は環境変更・リリース前・
-再現性調査用のreference QAです。Quickは独立snapshot検算を1回減らします。同じ`PASS`でも深度が異なるため、`execution_mode`と
+dropout有効です。`standard`は短いsmoke QA、`strict`は環境変更・リリース前・
+再現性調査用のreference QAです。Standardは独立snapshot検算を1回減らします。同じ`PASS`でも深度が異なるため、`execution_mode`と
 `qa_depth`をJSONとレポートへ別々に記録します。prefix gateまたはsource contractが失敗した場合、
 Local計測へ進みません。
 
@@ -103,7 +102,7 @@ Local計測へ進みません。
 ここが製品レポートの診断本体です。optimizer更新を行わず、同じ画像、noise、timestepで
 no-quantと各固定mulの勾配を比較します。
 
-- 画像数: Standard／Strictは8～32、Quickは8～16。各上限を超えてもprobe budgetは増えない。
+- 画像数: Standard／Strictとも8～32。上限を超えてもprobe budgetは増えない。
 - timestep: 4帯。
 - no-quant: 3 noise replicas。
 - 各mul: 2 noise replicas × 2 stochastic quant repeats。
@@ -133,17 +132,15 @@ total = I × 4 × (3 + 4M)
 各probeにはforward、backward、activation/gradient hook、module集計が含まれます。そのため、
 通常学習の単純な1 stepと完全に同じ費用ではありません。
 
-### 3.5 Quick、Standard、Strictの候補探索
+### 3.5 StandardとStrictの候補探索
 
-`quick`と`standard`は`2.70, 3.15, 3.45, 3.75, 4.05`を1 processで一度だけ測ります。
+`standard`は`2.70, 3.15, 3.45, 3.75, 4.05`を1 processで一度だけ測ります。
 端点でも改善傾向が続く場合は`edge_unresolved`と表示しますが、範囲外を追跡しません。
 この場合、単一代表を出さず、Fidelity retained候補を1点へ自動縮約しません。
 
-両者の違いはLocal画像上限です。Standardは最大32画像、Quickは最大16画像です。Quickでも
-4 timestep帯、no-quant 3 replicas、candidate 2 noise × 2 quant repeatsを維持するため、Body／Tailの
-定義は変えません。ただしsamplingが薄いため、レポートのconfidence上限をMediumとし、
-`reduced_descriptive`と明示します。独立source groupが画像上限を超えるdatasetも実行できますが、
-Quickは最大16群、Standard／Strictは最大32群だけを決定的にprobeします。全groupはsource contractに
+Standard／Strictとも最大32画像、4 timestep帯、no-quant 3 replicas、candidate 2 noise ×
+2 quant repeatsを使うため、Local Body／Tailの物差しは共通です。独立source groupが画像上限を
+超えるdatasetも実行できますが、最大32群だけを決定的にprobeします。全groupはsource contractに
 残り、レポートには`probe / total`を表示します。未probe群がある結果は完全coverageと同一視しません。
 
 `strict`はcore grid `2.70, 3.15, 3.45`から開始します。候補集合が測定端に残る場合だけ、
@@ -188,7 +185,7 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 | 要因 | 時間への影響 |
 |---|---|
 | 通常学習相当の総step数 | 5% warmup境界が変わる。画像repeatやdataset設定が多いほど、各GPU stageの境界作成が長くなる |
-| 実画像数 | Local部分はprobe上限までほぼ比例する。Quickは最大16画像、Standard／Strictは最大32画像 |
+| 実画像数 | Local部分はprobe上限までほぼ比例する。Standard／Strictとも最大32画像 |
 | bucket解像度 | 高解像度bucketが多いほど各forward/backwardが重くなる |
 | edge延長回数 | 0～2回。現在は拡張grid全体を再測定するため、もっとも大きな可変要因 |
 | GPU、precision、backend | 同じprotocolでも1 probe当たりの時間が変わる |
@@ -198,25 +195,16 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 
 | mode | 実行内容 | 実測例を基準にした概算 |
 |---|---|---:|
-| Standard | 8A／8B／16、固定5点を1回、edgeなし | 約37分 |
+| Standard | snapshot 1回、8A／8B／16、固定5点を1回、edgeなし | 約33分（旧4-process実測からの概算） |
 | Strict（edgeなし） | 64A／64B／128、core 3点 | 約46分 |
 | Strict（edge 1回） | 上記＋拡張grid再測定1回 | 約65分 |
 | Strict（edge 2回） | 上記＋拡張grid再測定2回 | 約88分 |
 
-別の37画像、29,600 training-step相当、warmup境界1,480 stepのdatasetでは、同じGPUで
-次の実測になりました。このdatasetは上の13画像例よりwarmupとLocalの両方が重いため、
-絶対時間を直接比較しないでください。
-
-| mode | probe画像数 | GPU process数 | 実測時間 | Standard比 |
-|---|---:|---:|---:|---:|
-| Quick | 16 | 3 | 約1時間07分32秒 | 約33.1%短縮（約1.50倍速） |
-| Standard | 32 | 4 | 約1時間40分59秒 | 基準 |
-
-Quickの事前計画値は約68.5分で、実測約67.5分と近い結果でした。共有する先頭16画像・3候補の
-raw probeを同一source contractで検算したところ、gradient-tail 828行とno-quant自然変動192行が
-全列exact一致しました。一方、Quickはsourceごとの標本が少ないためCIが広がり、Standardなら
-robustに除外できた候補を除外せず全候補をretainedとする場合がありました。これは故障ではなく、
-縮小sampling時に無理な候補削減を避ける意図したabstain動作です。
+別の37画像、29,600 training-step相当、warmup境界1,480 stepのdatasetでは、旧4-process
+Standardが同じGPUで約1時間40分59秒でした。現Standardは最大32画像を維持したまま
+snapshot-only processを1回省くため、同条件では約1時間27～31分を見込みます。これはまだ
+現仕様での実測値ではなく、旧実測からsnapshot境界作成1回分を引いた概算です。このdatasetは
+上の13画像例よりwarmupとLocalの両方が重いため、絶対時間を直接比較しないでください。
 
 これは保証値ではありません。実行中は`status.json`の`current_stage`と`run.log`の
 `RUN`／`DONE`時刻で進行を確認してください。
@@ -224,13 +212,14 @@ robustに除外できた候補を除外せず全候補をretainedとする場合
 ### 3.9 軽量化の境界
 
 `standard`は、最大32画像、4 timestep帯、no-quant 3 replicas、candidate 2 noise × 2 quant repeatsを
-Strictと同じまま保ちます。短縮したのは長いPrefix検算とedge再測定です。そのためStandardは、
-同じLocal物差しを短いQAで使う日常modeです。
+Strictと同じまま保ちます。短縮するのは専用Snapshot B、長いPrefix検算、edge再測定です。
+Snapshot Aと後続Prefix processの境界parityは維持するため、同じLocal物差しを短いQAで使う
+日常modeです。
 
-`quick`は4 timestep帯とreplica数を保ったまま、Local画像上限を16へ下げ、独立snapshotを
-2回から1回へ減らします。Body／Tailの定義やhard-safetyは変えませんが、sourceと画像のsamplingが
-薄くなるため、Standardと同じ証拠量とは扱いません。Quickは新しいdatasetの傾向を早く見る用途、
-Standardは通常の正式診断、Strictは環境・実装のreference検算に使い分けてください。
+`strict`は独立Snapshot A/B、長いPrefix、bounded edge再測定を使うreference modeです。コード、
+CUDA、PyTorch、bitsandbytesの変更後、リリース前、またはStandardの結果が疑わしい場合に使います。
+旧16画像Quickはsamplingによる結果の揺れを避けるため新規CLIから廃止しました。既存Quick成果物の
+レポート表示互換性だけは維持します。
 
 ## 4. Mul affinity curveの読み方
 
@@ -333,16 +322,8 @@ python -m dq_profile ^
   --dataset_config="D:\datasets\example\dataset.toml"
 ```
 
-最初に短時間で傾向を確認したい場合は、modeだけ`quick`へ変えます。
-
-```bat
-python -m dq_profile ^
-  --dq-profile-mode=quick ^
-  --pretrained_model_name_or_path="D:\models\sdxl_base.safetensors" ^
-  --dataset_config="D:\datasets\example\dataset.toml"
-```
-
-Quickは最大16画像の縮小samplingです。正式な通常診断は既定のStandardを使用してください。
+通常は既定の`standard`を使用します。コード、CUDA、PyTorch、bitsandbytesの変更後や、
+Standardの結果が疑わしい場合だけ`--dq-profile-mode=strict`へ切り替えます。
 
 診断名、出力先、完了後のレポート表示まで指定する推奨例です。
 
@@ -376,7 +357,7 @@ python -m dq_profile ^
 | `--dq-profile-name` | 任意 | `output_name` | datasetごとの親フォルダ名 |
 | `--dq-profile-output-dir` | 任意 | repositoryの`..\lora_output\dq_dataset_profiler` | 診断runを格納する基底ディレクトリ |
 | `--dq-profile-preset` | 任意 | `canonical-v1` | versioned互換性・計測契約。現在の対応presetは1つ |
-| `--dq-profile-mode` | 任意 | `standard` | `quick`: 最大16画像の短時間傾向確認、`standard`: 日常用の正式診断、`strict`: 長いreference QA＋bounded edge再測定 |
+| `--dq-profile-mode` | 任意 | `standard` | `standard`: 最大32画像・snapshot 1回の日常診断、`strict`: 独立snapshot A/B・長いreference QA＋bounded edge再測定 |
 | `--dq-profile-preflight` | 任意 | false | パス、source、CLI契約、fingerprintまで作りGPUを起動しない |
 | `--dq-profile-dry-run` | 任意 | false | `execution_plan.json`と解決済みCore commandを書き、GPUを起動しない |
 | `--dq-profile-open-report` | 任意 | false | Windowsで正常完了した場合に`report.html`を開く |
@@ -477,7 +458,7 @@ TOMLの`[general]`またはdataset sectionで`batch_size`、`enable_bucket`、`b
 | 項目 | 固定値・動作 |
 |---|---|
 | 製品scope | Local Body／Tail Safety/Fidelity。最終画質Utilityではない |
-| probe画像数 | Standard／Strictは`min(dataset実画像数, 32)`、Quickは`min(dataset実画像数, 16)`。最低8画像 |
+| probe画像数 | Standard／Strictとも`min(dataset実画像数, 32)`。最低8画像 |
 | timestep bins | `4` |
 | no-quant replicas | noise 3回 |
 | candidate replicas | noise 2回 × stochastic quant 2回 |
@@ -490,28 +471,24 @@ TOMLの`[general]`またはdataset sectionで`batch_size`、`enable_bucket`、`b
 | CPU threads/process | `8` |
 | bootstrap | source単位、2,000回、固定seed |
 
-QuickでもBody／Tailの数式、4 timestep帯、replica数、bootstrap、hard-safetyは変えません。
-`sampling_depth=reduced_16_image`、`confidence_ceiling=reduced_descriptive`を成果物へ保存し、
-証拠量が少ないことをStandard／Strictと区別します。
-
 ### 6.5 execution modeごとのQA・候補探索契約
 
-| 項目 | `quick` | `standard` | `strict` |
-|---|---|---|---|
-| 用途 | 新規datasetの短時間傾向確認 | 日常の正式dataset診断 | コード／CUDA／PyTorch／bitsandbytes変更後、リリース前、再現性調査 |
-| 独立snapshot | 1回。Prefix processとの境界一致を検査 | A/Bの2回 | A/Bの2回 |
-| Prefix | 8A／8B／16@8 | 8A／8B／16@8 | 64A／64B／128@64 |
-| state checkpoints | `0, 1, 4, 8` | `0, 1, 4, 8` | `0, 1, 32, 64` |
-| Prefix branch updates | 64 | 64 | 512 |
-| Local画像上限 | 16 | 32 | 32 |
-| 最初のgrid | `2.70, 3.15, 3.45, 3.75, 4.05` | `2.70, 3.15, 3.45, 3.75, 4.05` | `2.70, 3.15, 3.45` |
-| edge extension | なし。端点傾向は未解決として表示 | なし。端点傾向は未解決として表示 | 最大2 round、拡張gridを再測定してparity検査 |
-| GPU process数 | 3 | 4 | 4～6 |
-| QA表示 | `Quick smoke` | `Standard smoke` | `Strict reference` |
-| confidence上限 | Medium | 通常 | 通常 |
+| 項目 | `standard` | `strict` |
+|---|---|---|
+| 用途 | 日常の正式dataset診断 | コード／CUDA／PyTorch／bitsandbytes変更後、リリース前、再現性調査 |
+| 独立snapshot | 1回。Prefix processとの境界一致を検査 | A/Bの2回 |
+| Prefix | 8A／8B／16@8 | 64A／64B／128@64 |
+| state checkpoints | `0, 1, 4, 8` | `0, 1, 32, 64` |
+| Prefix branch updates | 64 | 512 |
+| Local画像上限 | 32 | 32 |
+| 最初のgrid | `2.70, 3.15, 3.45, 3.75, 4.05` | `2.70, 3.15, 3.45` |
+| edge extension | なし。端点傾向は未解決として表示 | 最大2 round、拡張gridを再測定してparity検査 |
+| GPU process数 | 3 | 4～6 |
+| QA表示 | `Standard smoke` | `Strict reference` |
+| confidence上限 | 通常 | 通常 |
 
 source groupがmodeの画像上限を超える場合もpreflightでは拒否しません。全inventoryをsource contractへ
-保持したまま、Quickは最大16群、Standard／Strictは最大32群をTOML全域から決定的に選びます。
+保持したまま、Standard／Strictは最大32群をTOML全域から決定的に選びます。
 `report.html`とsummaryには`source_group_count_probed`／`source_group_count_total`／coverage規則を
 残し、未probe群がある場合はLocal confidenceを過大評価しません。
 

--- a/docs/dq_dataset_profiler-ja.md
+++ b/docs/dq_dataset_profiler-ja.md
@@ -66,14 +66,16 @@ datasetと`range_mul`の組み合わせが学習勾配へ与える数値的な�
 通常のpreflight／dry-runを含む全runで`execution_plan.json`も作り、GPU process数、
 warmup境界、Prefix update数、Local probe数、固定grid、参考時間の算出条件を記録します。
 
-### 3.2 量子化開始境界とSnapshot A/B
+### 3.2 量子化開始境界とsnapshot検算
 
 通常学習コードと同じ規則で`dq_delta_begin_step`を求め、量子化開始直前までno-quantで
 warmupします。`canonical-v1`では40 epoch相当の総stepと5% LR warmupから境界が決まります。
 
-同じ初期状態からSnapshot AとSnapshot Bを別processで作り、LoRA重み、optimizer、scheduler、
-GradScaler、Guardian、RNG、replay位置などのfingerprintを比較します。一致しなければ、mul比較を
-開始しません。
+`standard`と`strict`は、同じ初期状態からSnapshot AとSnapshot Bを別processで作り、LoRA重み、
+optimizer、scheduler、GradScaler、Guardian、RNG、replay位置などのfingerprintを比較します。
+`quick`はSnapshot Aを1回だけ作り、後続のPrefix processが同じ境界を再現できたかを比較します。
+どのmodeでも境界fingerprintが一致しなければmul比較を開始しません。Quickは独立snapshotを
+1回減らすぶん速い一方、同じstageを2回作る検算深度はStandardより低くなります。
 
 以下で時間例に使う小規模datasetは、通常学習が8,400 stepだったため、境界は
 `8,400 × 0.05 = 420 step`でした。
@@ -84,14 +86,15 @@ GradScaler、Guardian、RNG、replay位置などのfingerprintを比較します
 
 | execution mode | short A | short B | long | 比較checkpoint | 合計branch update |
 |---|---:|---:|---:|---|---:|
+| `quick` | 8 | 8 | 16 | `0, 1, 4, 8` | 64 |
 | `standard` | 8 | 8 | 16 | `0, 1, 4, 8` | 64 |
 | `strict` | 64 | 64 | 128 | `0, 1, 32, 64` | 512 |
 
 各modeでA対B、およびA対long runの同じ先頭prefixを比較します。sample、noise、timestep、
 rank／network dropout、量子化乱数、Loss、LR、skip、勾配、LoRA重み、optimizer、scheduler、
 GradScaler、Guardian、replay cursorを検査します。このstageは通常学習に近い経路を検査するため
-dropout有効です。`standard`は日常利用の短いsmoke QA、`strict`は環境変更・リリース前・
-再現性調査用のreference QAです。同じ`PASS`でも深度が異なるため、`execution_mode`と
+dropout有効です。`quick`と`standard`は短いsmoke QA、`strict`は環境変更・リリース前・
+再現性調査用のreference QAです。Quickは独立snapshot検算を1回減らします。同じ`PASS`でも深度が異なるため、`execution_mode`と
 `qa_depth`をJSONとレポートへ別々に記録します。prefix gateまたはsource contractが失敗した場合、
 Local計測へ進みません。
 
@@ -100,7 +103,7 @@ Local計測へ進みません。
 ここが製品レポートの診断本体です。optimizer更新を行わず、同じ画像、noise、timestepで
 no-quantと各固定mulの勾配を比較します。
 
-- 画像数: 8～32。32画像を超えてもprobe budgetは32。
+- 画像数: Standard／Strictは8～32、Quickは8～16。各上限を超えてもprobe budgetは増えない。
 - timestep: 4帯。
 - no-quant: 3 noise replicas。
 - 各mul: 2 noise replicas × 2 stochastic quant repeats。
@@ -129,11 +132,17 @@ total = I × 4 × (3 + 4M)
 各probeにはforward、backward、activation/gradient hook、module集計が含まれます。そのため、
 通常学習の単純な1 stepと完全に同じ費用ではありません。
 
-### 3.5 StandardとStrictの候補探索
+### 3.5 Quick、Standard、Strictの候補探索
 
-`standard`は`2.70, 3.15, 3.45, 3.75, 4.05`を1 processで一度だけ測ります。
+`quick`と`standard`は`2.70, 3.15, 3.45, 3.75, 4.05`を1 processで一度だけ測ります。
 端点でも改善傾向が続く場合は`edge_unresolved`と表示しますが、範囲外を追跡しません。
 この場合、単一代表を出さず、Fidelity retained候補を1点へ自動縮約しません。
+
+両者の違いはLocal画像上限です。Standardは最大32画像、Quickは最大16画像です。Quickでも
+4 timestep帯、no-quant 3 replicas、candidate 2 noise × 2 quant repeatsを維持するため、Body／Tailの
+定義は変えません。ただしsamplingが薄いため、レポートのconfidence上限をMediumとし、
+`reduced_descriptive`と明示します。独立source groupが16を超えるdatasetは、全groupを最低1件ずつ
+含められないためQuickを開始前に拒否します。その場合はStandardを使用してください。
 
 `strict`はcore grid `2.70, 3.15, 3.45`から開始します。候補集合が測定端に残る場合だけ、
 最大2段まで外側を追加します。下端側は`2.25`、なお未解決なら`1.80`、上端側は`3.75`、
@@ -187,6 +196,7 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 
 | mode | 実行内容 | 実測例を基準にした概算 |
 |---|---|---:|
+| Quick | Snapshot 1回、8A／8B／16、最大16画像、固定5点、edgeなし | 約60～75分（37画像・warmup 1,480 step級での事前見積もり） |
 | Standard | 8A／8B／16、固定5点を1回、edgeなし | 約37分 |
 | Strict（edgeなし） | 64A／64B／128、core 3点 | 約46分 |
 | Strict（edge 1回） | 上記＋拡張grid再測定1回 | 約65分 |
@@ -197,12 +207,14 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 
 ### 3.9 軽量化の境界
 
-`standard`は、画像数、4 timestep帯、no-quant 3 replicas、candidate 2 noise × 2 quant repeatsを
-Strictと同じまま保ちます。短縮したのは長いPrefix検算とedge再測定です。そのため、
-「物差しを粗くしたQuick」ではなく「同じLocal物差しを短いQAで使う日常mode」です。
+`standard`は、最大32画像、4 timestep帯、no-quant 3 replicas、candidate 2 noise × 2 quant repeatsを
+Strictと同じまま保ちます。短縮したのは長いPrefix検算とedge再測定です。そのためStandardは、
+同じLocal物差しを短いQAで使う日常modeです。
 
-画像数やreplicaを減らす本当のQuick modeは未実装です。まずStandardとStrictの共通raw probeが
-一致し、所要時間短縮が確認できてから別段階で検討します。
+`quick`は4 timestep帯とreplica数を保ったまま、Local画像上限を16へ下げ、独立snapshotを
+2回から1回へ減らします。Body／Tailの定義やhard-safetyは変えませんが、sourceと画像のsamplingが
+薄くなるため、Standardと同じ証拠量とは扱いません。Quickは新しいdatasetの傾向を早く見る用途、
+Standardは通常の正式診断、Strictは環境・実装のreference検算に使い分けてください。
 
 ## 4. Mul affinity curveの読み方
 
@@ -302,6 +314,17 @@ python -m dq_profile ^
   --dataset_config="D:\datasets\example\dataset.toml"
 ```
 
+最初に短時間で傾向を確認したい場合は、modeだけ`quick`へ変えます。
+
+```bat
+python -m dq_profile ^
+  --dq-profile-mode=quick ^
+  --pretrained_model_name_or_path="D:\models\sdxl_base.safetensors" ^
+  --dataset_config="D:\datasets\example\dataset.toml"
+```
+
+Quickは最大16画像の縮小samplingです。正式な通常診断は既定のStandardを使用してください。
+
 診断名、出力先、完了後のレポート表示まで指定する推奨例です。
 
 ```bat
@@ -334,7 +357,7 @@ python -m dq_profile ^
 | `--dq-profile-name` | 任意 | `output_name` | datasetごとの親フォルダ名 |
 | `--dq-profile-output-dir` | 任意 | repositoryの`..\lora_output\dq_dataset_profiler` | 診断runを格納する基底ディレクトリ |
 | `--dq-profile-preset` | 任意 | `canonical-v1` | versioned互換性・計測契約。現在の対応presetは1つ |
-| `--dq-profile-mode` | 任意 | `standard` | `standard`: 日常用の短いQA＋固定5点、`strict`: 長いreference QA＋bounded edge再測定 |
+| `--dq-profile-mode` | 任意 | `standard` | `quick`: 最大16画像の短時間傾向確認、`standard`: 日常用の正式診断、`strict`: 長いreference QA＋bounded edge再測定 |
 | `--dq-profile-preflight` | 任意 | false | パス、source、CLI契約、fingerprintまで作りGPUを起動しない |
 | `--dq-profile-dry-run` | 任意 | false | `execution_plan.json`と解決済みCore commandを書き、GPUを起動しない |
 | `--dq-profile-open-report` | 任意 | false | Windowsで正常完了した場合に`report.html`を開く |
@@ -430,12 +453,12 @@ TOMLの`[general]`またはdataset sectionで`batch_size`、`enable_bucket`、`b
 現在の実測と同じ物差しではなくなります。既存presetの値を暗黙に変えず、別のversioned presetを
 追加し、snapshot／prefix／Local parityを検証してから使用します。
 
-### 6.4 mode間で共通のLocal測定契約
+### 6.4 Local測定契約
 
 | 項目 | 固定値・動作 |
 |---|---|
 | 製品scope | Local Body／Tail Safety/Fidelity。最終画質Utilityではない |
-| probe画像数 | `min(dataset実画像数, 32)`、最低8画像 |
+| probe画像数 | Standard／Strictは`min(dataset実画像数, 32)`、Quickは`min(dataset実画像数, 16)`。最低8画像 |
 | timestep bins | `4` |
 | no-quant replicas | noise 3回 |
 | candidate replicas | noise 2回 × stochastic quant 2回 |
@@ -448,18 +471,28 @@ TOMLの`[general]`またはdataset sectionで`batch_size`、`enable_bucket`、`b
 | CPU threads/process | `8` |
 | bootstrap | source単位、2,000回、固定seed |
 
+QuickでもBody／Tailの数式、4 timestep帯、replica数、bootstrap、hard-safetyは変えません。
+`sampling_depth=reduced_16_image`、`confidence_ceiling=reduced_descriptive`を成果物へ保存し、
+証拠量が少ないことをStandard／Strictと区別します。
+
 ### 6.5 execution modeごとのQA・候補探索契約
 
-| 項目 | `standard` | `strict` |
-|---|---|---|
-| 用途 | 日常のdataset診断 | コード／CUDA／PyTorch／bitsandbytes変更後、リリース前、再現性調査 |
-| Prefix | 8A／8B／16@8 | 64A／64B／128@64 |
-| state checkpoints | `0, 1, 4, 8` | `0, 1, 32, 64` |
-| Prefix branch updates | 64 | 512 |
-| 最初のgrid | `2.70, 3.15, 3.45, 3.75, 4.05` | `2.70, 3.15, 3.45` |
-| edge extension | なし。端点傾向は未解決として表示 | 最大2 round、拡張gridを再測定してparity検査 |
-| GPU process数 | 4 | 4～6 |
-| QA表示 | `Standard smoke` | `Strict reference` |
+| 項目 | `quick` | `standard` | `strict` |
+|---|---|---|---|
+| 用途 | 新規datasetの短時間傾向確認 | 日常の正式dataset診断 | コード／CUDA／PyTorch／bitsandbytes変更後、リリース前、再現性調査 |
+| 独立snapshot | 1回。Prefix processとの境界一致を検査 | A/Bの2回 | A/Bの2回 |
+| Prefix | 8A／8B／16@8 | 8A／8B／16@8 | 64A／64B／128@64 |
+| state checkpoints | `0, 1, 4, 8` | `0, 1, 4, 8` | `0, 1, 32, 64` |
+| Prefix branch updates | 64 | 64 | 512 |
+| Local画像上限 | 16 | 32 | 32 |
+| 最初のgrid | `2.70, 3.15, 3.45, 3.75, 4.05` | `2.70, 3.15, 3.45, 3.75, 4.05` | `2.70, 3.15, 3.45` |
+| edge extension | なし。端点傾向は未解決として表示 | なし。端点傾向は未解決として表示 | 最大2 round、拡張gridを再測定してparity検査 |
+| GPU process数 | 3 | 4 | 4～6 |
+| QA表示 | `Quick smoke` | `Standard smoke` | `Strict reference` |
+| confidence上限 | Medium | 通常 | 通常 |
+
+Quickでは全source groupをprobeへ最低1件ずつ含める契約を維持します。独立groupが16を超える場合は、
+部分的な結果を黙って出さずpreflightで拒否します。Standardへ切り替えてください。
 
 `--dq_profile_level=standard`は低レベルprotocol内部の別概念です。公開CLIの
 `--dq-profile-mode=standard`と混同しないよう、成果物には`execution_mode`、`qa_depth`、

--- a/docs/dq_dataset_profiler-ja.md
+++ b/docs/dq_dataset_profiler-ja.md
@@ -153,7 +153,12 @@ exact parityで検査します。Strictの再測定は校正能力を高めま�
 
 最後にsource groupを等重みとするbootstrapを2,000回行い、Body、Tail、95%区間、
 Fidelity retained set、robust dominance、source LOOなどを作ります。`report.html`、
-`technical_report.html`、JSON、CSVへ保存します。
+`beginner_report.html`、`technical_report.html`、JSON、CSVへ保存します。
+
+`beginner_report.html`は最上部のMul affinity curveから読み始められる概要版です。
+Body／Tail／ヒゲ、候補の役割、Body × Tailマップ、5軸の性格カルテ、
+source／timestep偏りを短い説明付きで表示します。性格カルテの参照位置は、
+匿名化した固定Standard参照設定内での相対位置であり、良否の閾値や画質推薦には使いません。
 
 同じGPU測定済みCSVから、候補選択へ加点しない説明専用channelも作ります。
 
@@ -295,6 +300,21 @@ d = sqrt(1 + norm_ratio^2 - 2 * norm_ratio * gradient_cosine)
 この場合は`edge_unresolved=true`とし、最良mulを宣言しません。
 
 ## 5. レポートの候補集合
+
+### 表の記号
+
+「試したmulと役割」の記号は、すべて同じ意味の合格票ではありません。
+
+- 緑の`✓`: Hard-safetyを通過した候補
+- 青の`✓`: Fidelity retained setに残った候補
+- 橙の`注意`: Hard-safetyは通過したが、同じdataset内の他候補よりBody・Tailの摂動が強い候補
+- 紫の`★`: Body代表、Tail代表、または単一代表
+- `●`: その挙動分類に該当
+- 灰色の`—`: 非該当
+
+特に橙の`注意`は「学習結果や画質が悪い」という判定ではありません。no-quantからの勾配変形が
+候補内で相対的に強いため、穏やかな候補とは別枠で比較するとよい、という注意表示です。
+`✓`、`注意`、`★`はそれぞれ安全性・相対的な摂動・数値上の代表という別の役割を示します。
 
 ### Hard-safety pass
 
@@ -592,6 +612,7 @@ experimentalと明記する範囲:
   <profile_name>\
     <YYYYMMDD_HHMMSS>_<protocol fingerprint>\
       report.html
+      beginner_report.html
       technical_report.html
       summary.json
       status.json
@@ -603,6 +624,7 @@ experimentalと明記する範囲:
 最低限、次を保管します。
 
 - `report.html`: 通常利用向けの自己完結Local-onlyレポート
+- `beginner_report.html`: 結論から段階的に読める自己完結の概要レポート
 - `technical_report.html`: 解析詳細を残す技術レポート
 - `practical_report.json`と`report_contract.json`: 表示モデルと意味契約
 - `summary.json`

--- a/docs/dq_dataset_profiler-ja.md
+++ b/docs/dq_dataset_profiler-ja.md
@@ -63,6 +63,8 @@ datasetと`range_mul`の組み合わせが学習勾配へ与える数値的な�
 - 実画像数と`min(実画像数, 32)`であるprobe budgetを記録する。
 
 `--dq-profile-preflight`ではここまで実行し、GPU stageを起動しません。
+通常のpreflight／dry-runを含む全runで`execution_plan.json`も作り、GPU process数、
+warmup境界、Prefix update数、Local probe数、固定grid、参考時間の算出条件を記録します。
 
 ### 3.2 量子化開始境界とSnapshot A/B
 
@@ -80,20 +82,18 @@ GradScaler、Guardian、RNG、replay位置などのfingerprintを比較します
 
 同じsnapshotから、no-quantとanchor候補`mul=3.15`について次を実行します。
 
-- 64-step run A
-- 64-step run B
-- 128-step run
+| execution mode | short A | short B | long | 比較checkpoint | 合計branch update |
+|---|---:|---:|---:|---|---:|
+| `standard` | 8 | 8 | 16 | `0, 1, 4, 8` | 64 |
+| `strict` | 64 | 64 | 128 | `0, 1, 32, 64` | 512 |
 
-計算量は概ね次の512 branch stepです。
-
-```text
-(no_quant + mul 3.15) × (64 + 64 + 128) = 512 branch steps
-```
-
-64Aと64B、および64Aと128-step runの先頭64 stepについて、sample、noise、timestep、
-dropout、量子化乱数、LR、skip、勾配、重み、optimizer stateを検査します。このstageは
-通常学習に近い経路を検査するためdropout有効です。prefix gateまたはsource contractが
-失敗した場合、Local計測へ進みません。
+各modeでA対B、およびA対long runの同じ先頭prefixを比較します。sample、noise、timestep、
+rank／network dropout、量子化乱数、Loss、LR、skip、勾配、LoRA重み、optimizer、scheduler、
+GradScaler、Guardian、replay cursorを検査します。このstageは通常学習に近い経路を検査するため
+dropout有効です。`standard`は日常利用の短いsmoke QA、`strict`は環境変更・リリース前・
+再現性調査用のreference QAです。同じ`PASS`でも深度が異なるため、`execution_mode`と
+`qa_depth`をJSONとレポートへ別々に記録します。prefix gateまたはsource contractが失敗した場合、
+Local計測へ進みません。
 
 ### 3.4 Local Body／Tail scan
 
@@ -129,15 +129,17 @@ total = I × 4 × (3 + 4M)
 各probeにはforward、backward、activation/gradient hook、module集計が含まれます。そのため、
 通常学習の単純な1 stepと完全に同じ費用ではありません。
 
-### 3.5 Bounded edge extension
+### 3.5 StandardとStrictの候補探索
 
-core gridは`2.70, 3.15, 3.45`です。候補集合が測定端に残る場合だけ、最大2段まで
-外側を追加します。下端側は`2.25`、なお未解決なら`1.80`、上端側は`3.75`、
+`standard`は`2.70, 3.15, 3.45, 3.75, 4.05`を1 processで一度だけ測ります。
+端点でも改善傾向が続く場合は`edge_unresolved`と表示しますが、範囲外を追跡しません。
+この場合、単一代表を出さず、Fidelity retained候補を1点へ自動縮約しません。
+
+`strict`はcore grid `2.70, 3.15, 3.45`から開始します。候補集合が測定端に残る場合だけ、
+最大2段まで外側を追加します。下端側は`2.25`、なお未解決なら`1.80`、上端側は`3.75`、
 なお未解決なら`4.05`です。両端が残る場合は両方向を同じroundで追加します。
-
-現在のBeta実装は再現性を優先し、edge追加時に以前のmulも含む拡張grid全体を別processで
-再測定します。その後、共通mulの全probe行が以前のstageと一致することをexact parityで
-検査します。この再測定が現在の主要な時間増加要因です。
+edge追加時は以前のmulも含む拡張grid全体を別processで再測定し、共通mulの全probe行を
+exact parityで検査します。Strictの再測定は校正能力を高めますが、主要な時間増加要因です。
 
 ### 3.6 CPU解析とレポート
 
@@ -150,8 +152,8 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 
 ### 3.7 13画像・8,400 step datasetの参考実測例
 
-同じPC・GPUにおけるproduction smoke runを基準にしています。対応する通常40 epoch学習は
-約1時間23分、この診断は約1時間28分02秒でした。
+同じPC・GPUにおけるStrict実測runを基準にしています。対応する通常40 epoch学習は
+約1時間23分、Strict診断は約1時間28分02秒でした。
 
 | stage | 目的 | 実測時間 | 全体比 |
 |---|---|---:|---:|
@@ -183,25 +185,24 @@ Fidelity retained set、robust dominance、source LOOなどを作ります。`re
 
 この実測例と同じGPU・似たbucket構成・似たwarmup step数なら、次が目安です。
 
-| edge延長 | 実測例を基準にした概算 |
-|---|---:|
-| なし | 約46分 |
-| 1回 | 約65分 |
-| 2回 | 約88分 |
+| mode | 実行内容 | 実測例を基準にした概算 |
+|---|---|---:|
+| Standard | 8A／8B／16、固定5点を1回、edgeなし | 約37分 |
+| Strict（edgeなし） | 64A／64B／128、core 3点 | 約46分 |
+| Strict（edge 1回） | 上記＋拡張grid再測定1回 | 約65分 |
+| Strict（edge 2回） | 上記＋拡張grid再測定2回 | 約88分 |
 
 これは保証値ではありません。実行中は`status.json`の`current_stage`と`run.log`の
 `RUN`／`DONE`時刻で進行を確認してください。
 
-### 3.9 高速化と簡易モードの候補
+### 3.9 軽量化の境界
 
-現時点で`--quick`のような簡易診断モードは実装していません。精度を落とさずに最初に
-検討すべきなのは、edge延長時に新しいmulだけを測り、共通no-quant probeとsnapshot fingerprintで
-安全に統合する方法です。この実測例ではLocal 3 stageが合計約58分でしたが、5 mulを一度だけ
-測る時間は約23分だったため、最大約35分の削減余地があります。
+`standard`は、画像数、4 timestep帯、no-quant 3 replicas、candidate 2 noise × 2 quant repeatsを
+Strictと同じまま保ちます。短縮したのは長いPrefix検算とedge再測定です。そのため、
+「物差しを粗くしたQuick」ではなく「同じLocal物差しを短いQAで使う日常mode」です。
 
-次の候補は完全snapshotの安全な再利用と、既に同一contractで検証済みの場合だけ使える
-`strict`／`verified-fast`の分離です。画像数、timestep帯、noise/quant repeatsを減らす方法は
-Tailの信頼性も同時に下げるため、最初の高速化手段にはしません。
+画像数やreplicaを減らす本当のQuick modeは未実装です。まずStandardとStrictの共通raw probeが
+一致し、所要時間短縮が確認できてから別段階で検討します。
 
 ## 4. Mul affinity curveの読み方
 
@@ -296,6 +297,7 @@ BodyとTailが同じ候補を支持し、候補削減規則と矛盾しない場
 cd /d D:\work\sd-scripts
 
 python -m dq_profile ^
+  --dq-profile-mode=standard ^
   --pretrained_model_name_or_path="D:\models\sdxl_base.safetensors" ^
   --dataset_config="D:\datasets\example\dataset.toml"
 ```
@@ -309,6 +311,7 @@ python -m dq_profile ^
   --dq-profile-name="example_dataset" ^
   --dq-profile-output-dir="D:\outputs\dq_diagnostics" ^
   --dq-profile-preset="canonical-v1" ^
+  --dq-profile-mode=standard ^
   --dq-profile-open-report ^
   --pretrained_model_name_or_path="D:\models\sdxl_base.safetensors" ^
   --dataset_config="D:\datasets\example\dataset.toml" ^
@@ -331,8 +334,9 @@ python -m dq_profile ^
 | `--dq-profile-name` | 任意 | `output_name` | datasetごとの親フォルダ名 |
 | `--dq-profile-output-dir` | 任意 | repositoryの`..\lora_output\dq_dataset_profiler` | 診断runを格納する基底ディレクトリ |
 | `--dq-profile-preset` | 任意 | `canonical-v1` | versioned互換性・計測契約。現在の対応presetは1つ |
+| `--dq-profile-mode` | 任意 | `standard` | `standard`: 日常用の短いQA＋固定5点、`strict`: 長いreference QA＋bounded edge再測定 |
 | `--dq-profile-preflight` | 任意 | false | パス、source、CLI契約、fingerprintまで作りGPUを起動しない |
-| `--dq-profile-dry-run` | 任意 | false | 解決済みCore commandを`dry_run_command.json`へ書き、GPUを起動しない |
+| `--dq-profile-dry-run` | 任意 | false | `execution_plan.json`と解決済みCore commandを書き、GPUを起動しない |
 | `--dq-profile-open-report` | 任意 | false | Windowsで正常完了した場合に`report.html`を開く |
 
 `resolution`はdataset sectionまたは`[general]`で指定してください（例: `resolution = 1024`）。`image_dir`はドライブ名またはUNCから始まる絶対パスで指定し、4つ以上の独立したsource groupを用意してください。`~`は学習loaderが展開しないため使用できません。子孫フォルダだけにある画像は通常のDreamBooth学習loaderから見えないため診断でも数えません。子フォルダを個別subsetとしてTOMLへ列挙するか、画像を`image_dir`直下へ配置してください。`num_repeats`は1以上が必要です。画像inventoryがworkerごとに変わり得る`cache_info=true`は現在のdiagnostic contractでは拒否します。
@@ -426,13 +430,11 @@ TOMLの`[general]`またはdataset sectionで`batch_size`、`enable_bucket`、`b
 現在の実測と同じ物差しではなくなります。既存presetの値を暗黙に変えず、別のversioned presetを
 追加し、snapshot／prefix／Local parityを検証してから使用します。
 
-### 6.4 `canonical-v1`が固定する診断設定
+### 6.4 mode間で共通のLocal測定契約
 
 | 項目 | 固定値・動作 |
 |---|---|
 | 製品scope | Local Body／Tail Safety/Fidelity。最終画質Utilityではない |
-| core mul grid | `2.70, 3.15, 3.45` |
-| edge extension | 端点が残った場合だけ下側`2.25 → 1.80`、上側`3.75 → 4.05`。最大2回 |
 | probe画像数 | `min(dataset実画像数, 32)`、最低8画像 |
 | timestep bins | `4` |
 | no-quant replicas | noise 3回 |
@@ -446,7 +448,24 @@ TOMLの`[general]`またはdataset sectionで`batch_size`、`enable_bucket`、`b
 | CPU threads/process | `8` |
 | bootstrap | source単位、2,000回、固定seed |
 
-### 6.5 明示しても診断値へ置き換えるオプション
+### 6.5 execution modeごとのQA・候補探索契約
+
+| 項目 | `standard` | `strict` |
+|---|---|---|
+| 用途 | 日常のdataset診断 | コード／CUDA／PyTorch／bitsandbytes変更後、リリース前、再現性調査 |
+| Prefix | 8A／8B／16@8 | 64A／64B／128@64 |
+| state checkpoints | `0, 1, 4, 8` | `0, 1, 32, 64` |
+| Prefix branch updates | 64 | 512 |
+| 最初のgrid | `2.70, 3.15, 3.45, 3.75, 4.05` | `2.70, 3.15, 3.45` |
+| edge extension | なし。端点傾向は未解決として表示 | 最大2 round、拡張gridを再測定してparity検査 |
+| GPU process数 | 4 | 4～6 |
+| QA表示 | `Standard smoke` | `Strict reference` |
+
+`--dq_profile_level=standard`は低レベルprotocol内部の別概念です。公開CLIの
+`--dq-profile-mode=standard`と混同しないよう、成果物には`execution_mode`、`qa_depth`、
+`internal_profile_level`を別フィールドで保存します。
+
+### 6.6 明示しても診断値へ置き換えるオプション
 
 次は過去の長い学習commandを受け取りやすくするためエラーにしませんが、診断にはそのまま
 使用しません。`resolved_args.json`へ`overridden_with_reason`として値と理由を保存します。
@@ -463,7 +482,7 @@ TOMLの`[general]`またはdataset sectionで`batch_size`、`enable_bucket`、`b
 | `dq_delta_log_every`, `dq_delta_log_scope`, `dq_delta_log_mode` | protocolが記録頻度・範囲を管理 |
 | `dq_delta_log_error_parts` | Local protocol独自の誤差分解を使用 |
 
-### 6.6 拒否するオプション
+### 6.7 拒否するオプション
 
 | オプション | 拒否理由 |
 |---|---|
@@ -540,6 +559,7 @@ experimentalと明記する範囲:
 - `summary.json`
 - `resolved_args.json`
 - `protocol_fingerprint.json`
+- `execution_plan.json`: GPU process数、warmup、Prefix、Local probe数、非保証の参考時間
 - `dataset_config_snapshot.toml`
 - `source_manifest.json`と`candidate_definitions.json`
 - `status.json`

--- a/docs/dq_dataset_profiler-ja.md
+++ b/docs/dq_dataset_profiler-ja.md
@@ -155,6 +155,24 @@ exact parityで検査します。Strictの再測定は校正能力を高めま�
 Fidelity retained set、robust dominance、source LOOなどを作ります。`report.html`、
 `technical_report.html`、JSON、CSVへ保存します。
 
+同じGPU測定済みCSVから、候補選択へ加点しない説明専用channelも作ります。
+
+- **Source localization**: candidateごとにsource等重みのq85／q90／q95を基準とし、
+  Tailの超過負担がどのsourceへ集中するか、上位source比率、実効source数、thresholdを
+  変えたときの安定性を記録します。最大負担sourceと、source LOOでTailが最も下がるsourceは
+  別々に表示します。高い集中率でも絶対Tailが小さい場合は、それだけで警告にしません。
+- **No-quant baseline profile**: candidate／quant repeat間で重複保存された同一no-quant参照を
+  probe単位にまとめ、勾配normのq05／median／q95／RMS、source別energy比、実効source数、
+  timestep別信号規模を記録します。収束、最終画質、rank、LR、epoch数は予測しません。
+- **Dataset character vector**: 絶対的な受容帯、mul応答、Tail増幅、source集中、no-quant信号を
+  独立した5 channelとして並べます。多数決や平均による単一スコアには変換しません。
+- **Image coverage**: probe画像数／dataset実画像数を表示します。32画像を超えるdatasetでは
+  未probe画像が残るため、説明値をdataset全体の完全観測とは扱いません。
+
+これらは`selector_input=false`、`not_quality_or_utility=true`として保存します。
+Fidelity retained set、Hard Safety、代表候補の決定規則は変えません。同じmodel、network、
+optimizer、precision契約のrun同士で比較するときのdataset体質記述に使用します。
+
 この実測例では各CPU解析は5～7秒程度で、HTML生成を含めても全時間への影響は
 小さいものでした。
 
@@ -595,6 +613,10 @@ experimentalと明記する範囲:
 - `source_manifest.json`と`candidate_definitions.json`
 - `status.json`
 - 候補・timestep・bootstrapのCSV
+- `source_localization.json/.csv`と`source_localization_detail.csv`: Tail負担のsource集中
+- `no_quant_baseline_profile.json`、`no_quant_source_load.csv`、
+  `no_quant_timestep_profile.csv`: no-quant短期勾配の規模と偏り
+- `dataset_character_vector.json`: 合成点を作らないdataset体質の5 channel
 - 実行ログ
 
 ### 第三者へ共有する前のプライバシーチェック

--- a/dq_profile/README.md
+++ b/dq_profile/README.md
@@ -14,6 +14,7 @@ measurement settings, and output defaults to
 ```powershell
 python -m dq_profile `
   --dq-profile-name="example_dataset" `
+  --dq-profile-mode=standard `
   --pretrained_model_name_or_path="D:\models\sdxl_base.safetensors" `
   --dataset_config="D:\datasets\example\dataset.toml"
 ```
@@ -57,7 +58,21 @@ as if they were one package version:
 - runtime and prefix-gate artifacts use schema/metric `2.1.0`;
 - Local Body/Tail acceptance metrics use definition `2.4.0`;
 - the current practical-report model uses schema
-  `2.4.2-practical-report-prototype`.
+  `2.4.3-practical-report-beta`.
+
+The public execution modes share the same `canonical-v1` training preset and
+`local-body-tail-v1` measurement contract:
+
+- `standard`: daily-use 8A/8B/16@8 prefix smoke and one fixed five-point
+  Local scan (`2.70, 3.15, 3.45, 3.75, 4.05`), without edge remeasurement;
+- `strict`: 64A/64B/128@64 reference parity, a three-point core, and up to
+  two bounded edge-extension remeasurements.
+
+Both modes retain up to 32 images, four timestep bins, three no-quant noise
+replicas, and two candidate-noise by two stochastic-quant repeats. The mode,
+QA depth, shared Local contract hash, and execution-specific hash are recorded
+separately. Use Strict after code/runtime/backend changes or while investigating
+reproducibility; use Standard for ordinary dataset characterization.
 
 Role-specific constants name these layers. The older generic v2.1 constant
 names remain compatibility aliases so existing artifacts and readers keep the

--- a/dq_profile/__main__.py
+++ b/dq_profile/__main__.py
@@ -39,12 +39,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "--dq-profile-mode",
-        choices=("quick", "standard", "strict"),
+        choices=("standard", "strict"),
         default="standard",
         help=(
-            "production execution/QA depth; standard is the daily default, quick "
-            "is an explicit reduced-sampling mode, and strict preserves the longer "
-            "reference workflow"
+            "production execution/QA depth; standard is the daily one-snapshot "
+            "default and strict preserves the two-snapshot reference workflow"
         ),
     )
     parser.add_argument(

--- a/dq_profile/__main__.py
+++ b/dq_profile/__main__.py
@@ -38,6 +38,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="versioned compatibility preset (default: canonical-v1)",
     )
     parser.add_argument(
+        "--dq-profile-mode",
+        choices=("standard", "strict"),
+        default="strict",
+        help=(
+            "production execution/QA depth; strict preserves the reference workflow "
+            "while standard is the shorter daily workflow (development default: strict)"
+        ),
+    )
+    parser.add_argument(
         "--dq-profile-preflight",
         action="store_true",
         help="validate inputs and write provenance without starting GPU stages",
@@ -56,6 +65,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     return run_profile_mode(
         training_argv,
         preset_name=selectors.dq_profile_preset,
+        execution_mode_name=selectors.dq_profile_mode,
         output_base=selectors.dq_profile_output_dir,
         profile_name=selectors.dq_profile_name,
         preflight_only=bool(selectors.dq_profile_preflight),

--- a/dq_profile/__main__.py
+++ b/dq_profile/__main__.py
@@ -40,10 +40,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--dq-profile-mode",
         choices=("standard", "strict"),
-        default="strict",
+        default="standard",
         help=(
-            "production execution/QA depth; strict preserves the reference workflow "
-            "while standard is the shorter daily workflow (development default: strict)"
+            "production execution/QA depth; standard is the daily default while "
+            "strict preserves the longer reference workflow"
         ),
     )
     parser.add_argument(

--- a/dq_profile/__main__.py
+++ b/dq_profile/__main__.py
@@ -39,11 +39,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "--dq-profile-mode",
-        choices=("standard", "strict"),
+        choices=("quick", "standard", "strict"),
         default="standard",
         help=(
-            "production execution/QA depth; standard is the daily default while "
-            "strict preserves the longer reference workflow"
+            "production execution/QA depth; standard is the daily default, quick "
+            "is an explicit reduced-sampling mode, and strict preserves the longer "
+            "reference workflow"
         ),
     )
     parser.add_argument(

--- a/dq_profile/geometry.py
+++ b/dq_profile/geometry.py
@@ -16,6 +16,8 @@ class SourceRule:
     pattern: str
     source_group: str
     match: str = "exact"
+    probe_selected: bool = True
+    probe_selection_rank: Optional[int] = None
 
 
 class SourceGroupMap:
@@ -56,7 +58,28 @@ class SourceGroupMap:
             raise ValueError(f"source group record requires image_key/pattern and source_group: {record!r}")
         if match not in {"exact", "prefix"}:
             raise ValueError(f"source group match must be exact or prefix, got {match!r}")
-        return SourceRule(str(pattern), str(group), match)
+        selected_value = record.get("probe_selected", True)
+        if isinstance(selected_value, str):
+            probe_selected = selected_value.strip().casefold() not in {
+                "",
+                "0",
+                "false",
+                "no",
+                "off",
+            }
+        else:
+            probe_selected = bool(selected_value)
+        rank_value = record.get("probe_selection_rank")
+        probe_selection_rank = (
+            None if rank_value in (None, "") else int(rank_value)
+        )
+        return SourceRule(
+            str(pattern),
+            str(group),
+            match,
+            probe_selected,
+            probe_selection_rank,
+        )
 
     def resolve(self, image_key: str) -> str:
         normalized_key = _normalized(image_key)
@@ -73,10 +96,32 @@ class SourceGroupMap:
         return str(image_key)
 
     def manifest(self) -> dict[str, Any]:
+        all_groups = list(dict.fromkeys(str(rule.source_group) for rule in self.rules))
+        selected_groups = list(
+            dict.fromkeys(
+                str(rule.source_group)
+                for rule in self.rules
+                if rule.probe_selected
+            )
+        )
+        total = len(all_groups)
+        selected = len(selected_groups)
         return {
             "provided": bool(self.rules),
             "rule_count": len(self.rules),
             "fallback": "image_key_is_source_group",
+            "source_group_count_total": total,
+            "source_group_count_probed": selected,
+            "source_group_coverage_complete": selected == total,
+            "source_group_coverage_fraction": (
+                float(selected / total) if total else 1.0
+            ),
+            "source_group_selection_policy": (
+                "all_source_groups"
+                if selected == total
+                else "deterministic_evenly_spaced_source_groups_v1"
+            ),
+            "probed_source_groups": selected_groups,
             "rules": [rule.__dict__ for rule in self.rules],
         }
 

--- a/dq_profile/production_cli.py
+++ b/dq_profile/production_cli.py
@@ -166,7 +166,7 @@ def resolve_training_cli(
     argv: Sequence[str],
     *,
     preset_name: str = "canonical-v1",
-    execution_mode_name: str = "strict",
+    execution_mode_name: str = "standard",
 ) -> ResolvedProfileRequest:
     preset = get_preset(preset_name)
     local_measurement = get_local_measurement_contract()

--- a/dq_profile/production_cli.py
+++ b/dq_profile/production_cli.py
@@ -6,7 +6,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
-from dq_profile.production_preset import DiagnosticPreset, get_preset
+from dq_profile.production_preset import (
+    ExecutionMode,
+    LocalMeasurementContract,
+    TrainingPreset,
+    get_execution_mode,
+    get_local_measurement_contract,
+    get_preset,
+)
 
 
 SENSITIVE_NAME = re.compile(r"(?:token|secret|password|api[_-]?key)", re.IGNORECASE)
@@ -41,7 +48,9 @@ class ProfileCompatibilityError(ValueError):
 
 @dataclass(frozen=True)
 class ResolvedProfileRequest:
-    preset: DiagnosticPreset
+    preset: TrainingPreset
+    local_measurement: LocalMeasurementContract
+    execution_mode: ExecutionMode
     model_path: Path
     dataset_config: Path
     output_name: str
@@ -53,6 +62,10 @@ class ResolvedProfileRequest:
         return {
             "schema_version": "1.0",
             "preset": self.preset.name,
+            "local_measurement_contract": self.local_measurement.contract(),
+            "execution_mode": self.execution_mode.contract(),
+            "qa_depth": self.execution_mode.qa_depth,
+            "internal_profile_level": self.execution_mode.internal_profile_level,
             "pretrained_model_name_or_path": str(self.model_path),
             "dataset_config": str(self.dataset_config),
             "output_name": self.output_name,
@@ -153,8 +166,11 @@ def resolve_training_cli(
     argv: Sequence[str],
     *,
     preset_name: str = "canonical-v1",
+    execution_mode_name: str = "strict",
 ) -> ResolvedProfileRequest:
     preset = get_preset(preset_name)
+    local_measurement = get_local_measurement_contract()
+    execution_mode = get_execution_mode(execution_mode_name)
     parser = _training_parser()
     namespace, unknown = parser.parse_known_args(list(argv))
     issues: list[CompatibilityIssue] = []
@@ -263,6 +279,8 @@ def resolve_training_cli(
     normal_output_dir = Path(str(raw_output_dir)).expanduser().resolve() if raw_output_dir else None
     return ResolvedProfileRequest(
         preset=preset,
+        local_measurement=local_measurement,
+        execution_mode=execution_mode,
         model_path=model_path,
         dataset_config=dataset_config,
         output_name=output_name,

--- a/dq_profile/production_cli.py
+++ b/dq_profile/production_cli.py
@@ -169,8 +169,10 @@ def resolve_training_cli(
     execution_mode_name: str = "standard",
 ) -> ResolvedProfileRequest:
     preset = get_preset(preset_name)
-    local_measurement = get_local_measurement_contract()
     execution_mode = get_execution_mode(execution_mode_name)
+    local_measurement = get_local_measurement_contract(
+        execution_mode.local_measurement_name
+    )
     parser = _training_parser()
     namespace, unknown = parser.parse_known_args(list(argv))
     issues: list[CompatibilityIssue] = []

--- a/dq_profile/production_entry.py
+++ b/dq_profile/production_entry.py
@@ -16,7 +16,7 @@ def run_profile_mode(
     training_argv: Sequence[str],
     *,
     preset_name: str = "canonical-v1",
-    execution_mode_name: str = "strict",
+    execution_mode_name: str = "standard",
     output_base: Path = DEFAULT_OUTPUT_BASE,
     profile_name: str | None = None,
     preflight_only: bool = False,

--- a/dq_profile/production_entry.py
+++ b/dq_profile/production_entry.py
@@ -16,13 +16,18 @@ def run_profile_mode(
     training_argv: Sequence[str],
     *,
     preset_name: str = "canonical-v1",
+    execution_mode_name: str = "strict",
     output_base: Path = DEFAULT_OUTPUT_BASE,
     profile_name: str | None = None,
     preflight_only: bool = False,
     dry_run: bool = False,
     open_report: bool = False,
 ) -> int:
-    request = resolve_training_cli(training_argv, preset_name=preset_name)
+    request = resolve_training_cli(
+        training_argv,
+        preset_name=preset_name,
+        execution_mode_name=execution_mode_name,
+    )
     result = run_profile_request(
         request,
         ProductionRunOptions(

--- a/dq_profile/production_preset.py
+++ b/dq_profile/production_preset.py
@@ -4,50 +4,30 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 
-PRESET_SCHEMA_VERSION = "1.0"
+PRESET_SCHEMA_VERSION = "2.0"
+LOCAL_MEASUREMENT_SCHEMA_VERSION = "1.0"
+EXECUTION_MODE_SCHEMA_VERSION = "1.0"
 
 
 @dataclass(frozen=True)
-class DiagnosticPreset:
+class TrainingPreset:
     name: str
-    metric_definition_version: str
     description: str
     expected_explicit: Mapping[str, Any]
     ignored_explicit: Mapping[str, str]
     unsupported_explicit: Mapping[str, str]
     training_tokens: tuple[str, ...]
-    core_grid: tuple[float, ...]
-    max_images: int
-    timestep_bins: int
-    stochastic_repeats: int
-    sweep_steps: int
-    branch_repeats: int
-    sketch_width: int
-    sketch_seeds: int
-    max_edge_extension_rounds: int
-    minimum_source_groups: int
     num_cpu_threads_per_process: int
 
     def contract(self) -> dict[str, Any]:
         return {
             "schema_version": PRESET_SCHEMA_VERSION,
             "name": self.name,
-            "metric_definition_version": self.metric_definition_version,
             "description": self.description,
             "expected_explicit": dict(self.expected_explicit),
             "ignored_explicit": dict(self.ignored_explicit),
             "unsupported_explicit": dict(self.unsupported_explicit),
             "training_tokens": list(self.training_tokens),
-            "core_grid": list(self.core_grid),
-            "max_images": self.max_images,
-            "timestep_bins": self.timestep_bins,
-            "stochastic_repeats": self.stochastic_repeats,
-            "sweep_steps": self.sweep_steps,
-            "branch_repeats": self.branch_repeats,
-            "sketch_width": self.sketch_width,
-            "sketch_seeds": self.sketch_seeds,
-            "max_edge_extension_rounds": self.max_edge_extension_rounds,
-            "minimum_source_groups": self.minimum_source_groups,
             "num_processes": 1,
             "num_machines": 1,
             "num_cpu_threads_per_process": self.num_cpu_threads_per_process,
@@ -57,9 +37,104 @@ class DiagnosticPreset:
         }
 
 
-CANONICAL_V1 = DiagnosticPreset(
+@dataclass(frozen=True)
+class LocalMeasurementContract:
+    """The Body/Tail ruler shared by every production execution mode."""
+
+    name: str
+    metric_definition_version: str
+    max_images: int
+    timestep_bins: int
+    stochastic_repeats: int
+    no_quant_noise_replicas: int
+    candidate_noise_replicas: int
+    stochastic_quant_repeats: int
+    sweep_steps: int
+    branch_repeats: int
+    sketch_width: int
+    sketch_seeds: int
+    minimum_source_groups: int
+    bootstrap_iterations: int
+    bootstrap_seed: int
+
+    def contract(self) -> dict[str, Any]:
+        return {
+            "schema_version": LOCAL_MEASUREMENT_SCHEMA_VERSION,
+            "name": self.name,
+            "metric_definition_version": self.metric_definition_version,
+            "max_images": self.max_images,
+            "timestep_bins": self.timestep_bins,
+            "stochastic_repeats": self.stochastic_repeats,
+            "no_quant_noise_replicas": self.no_quant_noise_replicas,
+            "candidate_noise_replicas": self.candidate_noise_replicas,
+            "stochastic_quant_repeats": self.stochastic_quant_repeats,
+            "sweep_steps": self.sweep_steps,
+            "branch_repeats": self.branch_repeats,
+            "sketch_width": self.sketch_width,
+            "sketch_seeds": self.sketch_seeds,
+            "minimum_source_groups": self.minimum_source_groups,
+            "bootstrap_iterations": self.bootstrap_iterations,
+            "bootstrap_seed": self.bootstrap_seed,
+            "probe_regime": "structural_dropout_off",
+            "diagnostic_target": "numerical_gradient_acceptance_by_fixed_range_mul",
+            "not_quality_or_utility": True,
+        }
+
+
+@dataclass(frozen=True)
+class ExecutionMode:
+    """Production orchestration and QA depth, not the low-level profile level."""
+
+    name: str
+    description: str
+    qa_depth: str
+    core_grid: tuple[float, ...]
+    max_edge_extension_rounds: int
+    edge_policy: str
+    prefix_short_steps: int
+    prefix_long_steps: int
+    prefix_anchor_mul: float = 3.15
+    snapshot_a_max_images: int = 8
+    internal_profile_level: str = "standard"
+
+    @property
+    def prefix_checkpoints(self) -> tuple[int, ...]:
+        return tuple(sorted({0, 1, self.prefix_short_steps // 2, self.prefix_short_steps}))
+
+    @property
+    def prefix_branch_updates(self) -> int:
+        return 2 * (self.prefix_short_steps * 2 + self.prefix_long_steps)
+
+    @property
+    def gpu_process_count_range(self) -> tuple[int, int]:
+        base = 4
+        return base, base + self.max_edge_extension_rounds
+
+    def contract(self) -> dict[str, Any]:
+        minimum_processes, maximum_processes = self.gpu_process_count_range
+        return {
+            "schema_version": EXECUTION_MODE_SCHEMA_VERSION,
+            "name": self.name,
+            "description": self.description,
+            "qa_depth": self.qa_depth,
+            "core_grid": list(self.core_grid),
+            "max_edge_extension_rounds": self.max_edge_extension_rounds,
+            "edge_policy": self.edge_policy,
+            "prefix_anchor_mul": self.prefix_anchor_mul,
+            "prefix_short_steps": self.prefix_short_steps,
+            "prefix_long_steps": self.prefix_long_steps,
+            "prefix_checkpoints": list(self.prefix_checkpoints),
+            "prefix_branch_updates": self.prefix_branch_updates,
+            "snapshot_replica_count": 2,
+            "snapshot_a_max_images": self.snapshot_a_max_images,
+            "internal_profile_level": self.internal_profile_level,
+            "gpu_process_count_min": minimum_processes,
+            "gpu_process_count_max": maximum_processes,
+        }
+
+
+CANONICAL_V1 = TrainingPreset(
     name="canonical-v1",
-    metric_definition_version="2.4.0",
     description=(
         "Validated SDXL rank-4 Local Body/Tail preset. This is a numerical "
         "Safety/Fidelity diagnostic, not a quality or Utility predictor."
@@ -201,26 +276,86 @@ CANONICAL_V1 = DiagnosticPreset(
         "--rank_log",
         "--rank_log_mode=per_module",
     ),
-    core_grid=(2.70, 3.15, 3.45),
-    max_images=32,
-    timestep_bins=4,
-    stochastic_repeats=2,
-    sweep_steps=128,
-    branch_repeats=5,
-    sketch_width=512,
-    sketch_seeds=2,
-    max_edge_extension_rounds=2,
-    minimum_source_groups=4,
     num_cpu_threads_per_process=8,
 )
 
 
+LOCAL_BODY_TAIL_V1 = LocalMeasurementContract(
+    name="local-body-tail-v1",
+    metric_definition_version="2.4.0",
+    max_images=32,
+    timestep_bins=4,
+    stochastic_repeats=2,
+    no_quant_noise_replicas=3,
+    candidate_noise_replicas=2,
+    stochastic_quant_repeats=2,
+    sweep_steps=128,
+    branch_repeats=5,
+    sketch_width=512,
+    sketch_seeds=2,
+    minimum_source_groups=4,
+    bootstrap_iterations=2000,
+    bootstrap_seed=2401,
+)
+
+
+STRICT_MODE = ExecutionMode(
+    name="strict",
+    description="Reference-depth QA with long prefix parity and bounded edge extension.",
+    qa_depth="strict_reference",
+    core_grid=(2.70, 3.15, 3.45),
+    max_edge_extension_rounds=2,
+    edge_policy="bounded_dynamic_full_grid_remeasurement",
+    prefix_short_steps=64,
+    prefix_long_steps=128,
+)
+
+
+STANDARD_MODE = ExecutionMode(
+    name="standard",
+    description="Daily-use QA with short prefix parity and one fixed five-point Local scan.",
+    qa_depth="standard_smoke",
+    core_grid=(2.70, 3.15, 3.45, 3.75, 4.05),
+    max_edge_extension_rounds=0,
+    edge_policy="fixed_tested_envelope_no_extension",
+    prefix_short_steps=8,
+    prefix_long_steps=16,
+)
+
+
 PRESETS = {CANONICAL_V1.name: CANONICAL_V1}
+LOCAL_MEASUREMENT_CONTRACTS = {LOCAL_BODY_TAIL_V1.name: LOCAL_BODY_TAIL_V1}
+EXECUTION_MODES = {
+    STANDARD_MODE.name: STANDARD_MODE,
+    STRICT_MODE.name: STRICT_MODE,
+}
 
 
-def get_preset(name: str) -> DiagnosticPreset:
+def get_preset(name: str) -> TrainingPreset:
     try:
         return PRESETS[name]
     except KeyError as error:
         supported = ", ".join(sorted(PRESETS))
         raise ValueError(f"unknown DQ profile preset {name!r}; supported: {supported}") from error
+
+
+def get_local_measurement_contract(name: str = "local-body-tail-v1") -> LocalMeasurementContract:
+    try:
+        return LOCAL_MEASUREMENT_CONTRACTS[name]
+    except KeyError as error:
+        supported = ", ".join(sorted(LOCAL_MEASUREMENT_CONTRACTS))
+        raise ValueError(
+            f"unknown Local measurement contract {name!r}; supported: {supported}"
+        ) from error
+
+
+def get_execution_mode(name: str) -> ExecutionMode:
+    try:
+        return EXECUTION_MODES[name]
+    except KeyError as error:
+        supported = ", ".join(sorted(EXECUTION_MODES))
+        raise ValueError(f"unknown DQ profile execution mode {name!r}; supported: {supported}") from error
+
+
+# Compatibility for callers that imported the old type name.
+DiagnosticPreset = TrainingPreset

--- a/dq_profile/production_preset.py
+++ b/dq_profile/production_preset.py
@@ -5,8 +5,8 @@ from typing import Any, Mapping
 
 
 PRESET_SCHEMA_VERSION = "2.0"
-LOCAL_MEASUREMENT_SCHEMA_VERSION = "1.0"
-EXECUTION_MODE_SCHEMA_VERSION = "1.0"
+LOCAL_MEASUREMENT_SCHEMA_VERSION = "1.1"
+EXECUTION_MODE_SCHEMA_VERSION = "1.1"
 
 
 @dataclass(frozen=True)
@@ -56,6 +56,8 @@ class LocalMeasurementContract:
     minimum_source_groups: int
     bootstrap_iterations: int
     bootstrap_seed: int
+    sampling_depth: str
+    confidence_ceiling: str
 
     def contract(self) -> dict[str, Any]:
         return {
@@ -75,6 +77,8 @@ class LocalMeasurementContract:
             "minimum_source_groups": self.minimum_source_groups,
             "bootstrap_iterations": self.bootstrap_iterations,
             "bootstrap_seed": self.bootstrap_seed,
+            "sampling_depth": self.sampling_depth,
+            "confidence_ceiling": self.confidence_ceiling,
             "probe_regime": "structural_dropout_off",
             "diagnostic_target": "numerical_gradient_acceptance_by_fixed_range_mul",
             "not_quality_or_utility": True,
@@ -93,9 +97,15 @@ class ExecutionMode:
     edge_policy: str
     prefix_short_steps: int
     prefix_long_steps: int
+    local_measurement_name: str = "local-body-tail-v1"
+    standalone_snapshot_count: int = 2
     prefix_anchor_mul: float = 3.15
     snapshot_a_max_images: int = 8
     internal_profile_level: str = "standard"
+
+    def __post_init__(self) -> None:
+        if self.standalone_snapshot_count not in {1, 2}:
+            raise ValueError("standalone_snapshot_count must be 1 or 2")
 
     @property
     def prefix_checkpoints(self) -> tuple[int, ...]:
@@ -107,7 +117,7 @@ class ExecutionMode:
 
     @property
     def gpu_process_count_range(self) -> tuple[int, int]:
-        base = 4
+        base = self.standalone_snapshot_count + 2
         return base, base + self.max_edge_extension_rounds
 
     def contract(self) -> dict[str, Any]:
@@ -125,7 +135,9 @@ class ExecutionMode:
             "prefix_long_steps": self.prefix_long_steps,
             "prefix_checkpoints": list(self.prefix_checkpoints),
             "prefix_branch_updates": self.prefix_branch_updates,
-            "snapshot_replica_count": 2,
+            "local_measurement_name": self.local_measurement_name,
+            "standalone_snapshot_count": self.standalone_snapshot_count,
+            "snapshot_replica_count": self.standalone_snapshot_count,
             "snapshot_a_max_images": self.snapshot_a_max_images,
             "internal_profile_level": self.internal_profile_level,
             "gpu_process_count_min": minimum_processes,
@@ -296,6 +308,29 @@ LOCAL_BODY_TAIL_V1 = LocalMeasurementContract(
     minimum_source_groups=4,
     bootstrap_iterations=2000,
     bootstrap_seed=2401,
+    sampling_depth="reference_32_image",
+    confidence_ceiling="data_driven_up_to_high",
+)
+
+
+LOCAL_BODY_TAIL_QUICK_V1 = LocalMeasurementContract(
+    name="local-body-tail-quick-v1",
+    metric_definition_version="2.4.0",
+    max_images=16,
+    timestep_bins=4,
+    stochastic_repeats=2,
+    no_quant_noise_replicas=3,
+    candidate_noise_replicas=2,
+    stochastic_quant_repeats=2,
+    sweep_steps=128,
+    branch_repeats=5,
+    sketch_width=512,
+    sketch_seeds=2,
+    minimum_source_groups=4,
+    bootstrap_iterations=2000,
+    bootstrap_seed=2401,
+    sampling_depth="reduced_16_image",
+    confidence_ceiling="reduced_descriptive",
 )
 
 
@@ -323,9 +358,30 @@ STANDARD_MODE = ExecutionMode(
 )
 
 
+QUICK_MODE = ExecutionMode(
+    name="quick",
+    description=(
+        "Explicit faster workflow with short prefix parity, one standalone "
+        "snapshot check, and a reduced 16-image Local scan."
+    ),
+    qa_depth="quick_smoke",
+    core_grid=(2.70, 3.15, 3.45, 3.75, 4.05),
+    max_edge_extension_rounds=0,
+    edge_policy="fixed_tested_envelope_no_extension",
+    prefix_short_steps=8,
+    prefix_long_steps=16,
+    local_measurement_name=LOCAL_BODY_TAIL_QUICK_V1.name,
+    standalone_snapshot_count=1,
+)
+
+
 PRESETS = {CANONICAL_V1.name: CANONICAL_V1}
-LOCAL_MEASUREMENT_CONTRACTS = {LOCAL_BODY_TAIL_V1.name: LOCAL_BODY_TAIL_V1}
+LOCAL_MEASUREMENT_CONTRACTS = {
+    LOCAL_BODY_TAIL_V1.name: LOCAL_BODY_TAIL_V1,
+    LOCAL_BODY_TAIL_QUICK_V1.name: LOCAL_BODY_TAIL_QUICK_V1,
+}
 EXECUTION_MODES = {
+    QUICK_MODE.name: QUICK_MODE,
     STANDARD_MODE.name: STANDARD_MODE,
     STRICT_MODE.name: STRICT_MODE,
 }

--- a/dq_profile/production_preset.py
+++ b/dq_profile/production_preset.py
@@ -6,7 +6,7 @@ from typing import Any, Mapping
 
 PRESET_SCHEMA_VERSION = "2.0"
 LOCAL_MEASUREMENT_SCHEMA_VERSION = "1.1"
-EXECUTION_MODE_SCHEMA_VERSION = "1.1"
+EXECUTION_MODE_SCHEMA_VERSION = "1.2"
 
 
 @dataclass(frozen=True)
@@ -313,27 +313,6 @@ LOCAL_BODY_TAIL_V1 = LocalMeasurementContract(
 )
 
 
-LOCAL_BODY_TAIL_QUICK_V1 = LocalMeasurementContract(
-    name="local-body-tail-quick-v1",
-    metric_definition_version="2.4.0",
-    max_images=16,
-    timestep_bins=4,
-    stochastic_repeats=2,
-    no_quant_noise_replicas=3,
-    candidate_noise_replicas=2,
-    stochastic_quant_repeats=2,
-    sweep_steps=128,
-    branch_repeats=5,
-    sketch_width=512,
-    sketch_seeds=2,
-    minimum_source_groups=4,
-    bootstrap_iterations=2000,
-    bootstrap_seed=2401,
-    sampling_depth="reduced_16_image",
-    confidence_ceiling="reduced_descriptive",
-)
-
-
 STRICT_MODE = ExecutionMode(
     name="strict",
     description="Reference-depth QA with long prefix parity and bounded edge extension.",
@@ -348,29 +327,16 @@ STRICT_MODE = ExecutionMode(
 
 STANDARD_MODE = ExecutionMode(
     name="standard",
-    description="Daily-use QA with short prefix parity and one fixed five-point Local scan.",
+    description=(
+        "Daily-use QA with short prefix parity, one standalone snapshot, and one "
+        "fixed five-point Local scan."
+    ),
     qa_depth="standard_smoke",
     core_grid=(2.70, 3.15, 3.45, 3.75, 4.05),
     max_edge_extension_rounds=0,
     edge_policy="fixed_tested_envelope_no_extension",
     prefix_short_steps=8,
     prefix_long_steps=16,
-)
-
-
-QUICK_MODE = ExecutionMode(
-    name="quick",
-    description=(
-        "Explicit faster workflow with short prefix parity, one standalone "
-        "snapshot check, and a reduced 16-image Local scan."
-    ),
-    qa_depth="quick_smoke",
-    core_grid=(2.70, 3.15, 3.45, 3.75, 4.05),
-    max_edge_extension_rounds=0,
-    edge_policy="fixed_tested_envelope_no_extension",
-    prefix_short_steps=8,
-    prefix_long_steps=16,
-    local_measurement_name=LOCAL_BODY_TAIL_QUICK_V1.name,
     standalone_snapshot_count=1,
 )
 
@@ -378,10 +344,8 @@ QUICK_MODE = ExecutionMode(
 PRESETS = {CANONICAL_V1.name: CANONICAL_V1}
 LOCAL_MEASUREMENT_CONTRACTS = {
     LOCAL_BODY_TAIL_V1.name: LOCAL_BODY_TAIL_V1,
-    LOCAL_BODY_TAIL_QUICK_V1.name: LOCAL_BODY_TAIL_QUICK_V1,
 }
 EXECUTION_MODES = {
-    QUICK_MODE.name: QUICK_MODE,
     STANDARD_MODE.name: STANDARD_MODE,
     STRICT_MODE.name: STRICT_MODE,
 }

--- a/dq_profile/production_runner.py
+++ b/dq_profile/production_runner.py
@@ -14,14 +14,19 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from dq_profile.production_cli import ResolvedProfileRequest
-from dq_profile.protocol import loader_visible_image_files, resolve_dataset_layout
+from dq_profile.protocol import (
+    inspect_dataset_config,
+    loader_visible_image_files,
+    resolve_dataset_layout,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_ROOT = REPO_ROOT.parent
 PROFILE_SCRIPT = REPO_ROOT / "sdxl_dq_dataset_profile.py"
 DEFAULT_OUTPUT_BASE = PROJECT_ROOT / "lora_output" / "dq_dataset_profiler"
-RUN_SCHEMA_VERSION = "1.0-beta"
+RUN_SCHEMA_VERSION = "1.1-beta"
+EXECUTION_PLAN_SCHEMA_VERSION = "1.0-beta"
 INVALID_FILENAME = re.compile(r"[<>:\"/\\|?*\x00-\x1f]")
 WINDOWS_RESERVED = {
     "CON", "PRN", "AUX", "NUL",
@@ -406,18 +411,44 @@ def build_protocol_fingerprint(
         REPO_ROOT / "tools" / "check_dq_calibration_gate.py",
     )
     tracked_state = git_tracked_state()
+    training_contract = request.preset.contract()
+    local_contract = request.local_measurement.contract()
+    execution_contract = request.execution_mode.contract()
+    model_identity = _model_identity(request.model_path)
+    dataset_contract = {
+        "path": str(request.dataset_config),
+        "sha256": sha256_file(request.dataset_config),
+        "source_map_sha256": canonical_sha256(source_map_payload),
+    }
+    shared_local_contract = {
+        "training": training_contract,
+        "local_measurement": local_contract,
+        "model": model_identity,
+        "dataset": dataset_contract,
+        "profile_seed": int(request.preset.expected_explicit["seed"]),
+        "scope": "local_body_tail_only",
+    }
     payload = {
         "schema_version": RUN_SCHEMA_VERSION,
         "git_head": git_head(),
         "git_tracked_dirty": tracked_state["dirty"],
         "git_tracked_state": tracked_state,
-        "preset": request.preset.contract(),
-        "model": _model_identity(request.model_path),
-        "dataset_config": {
-            "path": str(request.dataset_config),
-            "sha256": sha256_file(request.dataset_config),
+        "preset": training_contract,
+        "local_measurement_contract": local_contract,
+        "execution_mode": execution_contract,
+        "qa_depth": request.execution_mode.qa_depth,
+        "internal_profile_level": request.execution_mode.internal_profile_level,
+        "model": model_identity,
+        "dataset_config": dataset_contract,
+        "source_map_sha256": dataset_contract["source_map_sha256"],
+        "contract_hashes": {
+            "training_contract_sha256": canonical_sha256(training_contract),
+            "dataset_contract_sha256": canonical_sha256(dataset_contract),
+            "local_measurement_contract_sha256": canonical_sha256(local_contract),
+            "execution_qa_contract_sha256": canonical_sha256(execution_contract),
+            "local_probe_contract_sha256": canonical_sha256(shared_local_contract),
+            "shared_local_contract_sha256": canonical_sha256(shared_local_contract),
         },
-        "source_map_sha256": canonical_sha256(source_map_payload),
         "code": {
             str(path.relative_to(REPO_ROOT)).replace("\\", "/"): sha256_file(path)
             for path in code_files
@@ -426,7 +457,203 @@ def build_protocol_fingerprint(
         "trajectory": "research_only_not_run",
         "not_quality_or_utility": True,
     }
-    return {**payload, "fingerprint_sha256": canonical_sha256(payload)}
+    fingerprint_sha256 = canonical_sha256(payload)
+    return {
+        **payload,
+        "fingerprint_sha256": fingerprint_sha256,
+        "full_protocol_fingerprint_sha256": fingerprint_sha256,
+    }
+
+
+def _local_probe_counts(
+    *,
+    probe_images: int,
+    timestep_bins: int,
+    mul_count: int,
+    no_quant_noise_replicas: int,
+    candidate_noise_replicas: int,
+    stochastic_quant_repeats: int,
+) -> dict[str, int]:
+    points = int(probe_images) * int(timestep_bins)
+    no_quant = points * int(no_quant_noise_replicas)
+    per_candidate = (
+        points
+        * int(candidate_noise_replicas)
+        * int(stochastic_quant_repeats)
+    )
+    candidates = int(mul_count) * per_candidate
+    return {
+        "probe_images": int(probe_images),
+        "timestep_bins": int(timestep_bins),
+        "mul_count": int(mul_count),
+        "no_quant_probes": no_quant,
+        "candidate_probes_per_mul": per_candidate,
+        "candidate_probes": candidates,
+        "total_local_probes": no_quant + candidates,
+    }
+
+
+def build_execution_plan(
+    request: ResolvedProfileRequest,
+    *,
+    image_count: int,
+    probe_budget: int,
+) -> dict[str, Any]:
+    """Describe deterministic work volume before any GPU worker starts.
+
+    The timing section is deliberately secondary.  It extrapolates one known
+    RTX 5080 run and is not a promise: bucket shape, cache state, storage,
+    driver/library versions, and the warmup boundary can all change runtime.
+    """
+
+    preset = request.preset
+    local = request.local_measurement
+    execution = request.execution_mode
+    expected = preset.expected_explicit
+    preflight_summary = inspect_dataset_config(
+        request.dataset_config,
+        max_train_epochs=int(expected["max_train_epochs"]),
+        max_train_steps=None,
+        lr_warmup_steps=float(expected["lr_warmup_steps"]),
+        branch_steps_override=int(local.sweep_steps),
+        max_images=int(local.max_images),
+        timestep_bins=int(local.timestep_bins),
+        stochastic_repeats=int(local.stochastic_repeats),
+        train_batch_size=int(expected["train_batch_size"]),
+        enable_bucket=bool(expected["enable_bucket"]),
+        bucket_no_upscale=bool(expected["bucket_no_upscale"]),
+        min_bucket_reso=int(expected["min_bucket_reso"]),
+        max_bucket_reso=int(expected["max_bucket_reso"]),
+        bucket_reso_steps=int(expected["bucket_reso_steps"]),
+        dataset_repeats=1,
+        cache_info=False,
+        minimum_source_groups=int(local.minimum_source_groups),
+        require_resolution=True,
+    )
+    if int(preflight_summary.unique_images) != int(image_count):
+        raise RuntimeError(
+            "dataset image inventory disagrees between source-map and execution-plan "
+            f"preflight: source_map={image_count}, protocol={preflight_summary.unique_images}"
+        )
+
+    core_counts = _local_probe_counts(
+        probe_images=probe_budget,
+        timestep_bins=local.timestep_bins,
+        mul_count=len(execution.core_grid),
+        no_quant_noise_replicas=local.no_quant_noise_replicas,
+        candidate_noise_replicas=local.candidate_noise_replicas,
+        stochastic_quant_repeats=local.stochastic_quant_repeats,
+    )
+    minimum_processes, maximum_processes = execution.gpu_process_count_range
+    warmup = int(preflight_summary.dq_begin_step)
+
+    # Historical calibration from one 13-image/420-warmup RTX 5080 run.
+    # Keep these constants in the artifact so the estimate is auditable.
+    reference_warmup_seconds = 247.0 * warmup / 420.0
+    reference_prefix_update_seconds = 1033.0 / 512.0
+    reference_local_probe_seconds = 1115.0 / 1196.0
+
+    def estimated_local_seconds(mul_count: int) -> float:
+        counts = _local_probe_counts(
+            probe_images=probe_budget,
+            timestep_bins=local.timestep_bins,
+            mul_count=mul_count,
+            no_quant_noise_replicas=local.no_quant_noise_replicas,
+            candidate_noise_replicas=local.candidate_noise_replicas,
+            stochastic_quant_repeats=local.stochastic_quant_repeats,
+        )
+        return (
+            reference_warmup_seconds
+            + counts["total_local_probes"] * reference_local_probe_seconds
+        )
+
+    base_seconds = (
+        2.0 * reference_warmup_seconds
+        + reference_warmup_seconds
+        + execution.prefix_branch_updates * reference_prefix_update_seconds
+        + estimated_local_seconds(len(execution.core_grid))
+    )
+    maximum_seconds = base_seconds
+    projected_edge_mul_counts: list[int] = []
+    for round_index in range(1, execution.max_edge_extension_rounds + 1):
+        # Strict historically adds one adjacent edge point per round.  The
+        # actual conditional plan is reported separately and can stop early.
+        mul_count = len(execution.core_grid) + round_index
+        projected_edge_mul_counts.append(mul_count)
+        maximum_seconds += estimated_local_seconds(mul_count)
+
+    estimate_minutes = {
+        "minimum": round(base_seconds / 60.0, 1),
+        "maximum_if_all_edge_rounds_run": round(maximum_seconds / 60.0, 1),
+    }
+    exact_process_count = (
+        minimum_processes if minimum_processes == maximum_processes else None
+    )
+    payload: dict[str, Any] = {
+        "schema_version": EXECUTION_PLAN_SCHEMA_VERSION,
+        "execution_mode": execution.name,
+        "qa_depth": execution.qa_depth,
+        "internal_profile_level": execution.internal_profile_level,
+        "measurement_contract": local.name,
+        "work_volume": {
+            "gpu_process_count": exact_process_count,
+            "gpu_process_count_min": minimum_processes,
+            "gpu_process_count_max": maximum_processes,
+            "warmup_boundary_updates": warmup,
+            "warmup_executions": exact_process_count,
+            "warmup_executions_min": minimum_processes,
+            "warmup_executions_max": maximum_processes,
+            "total_warmup_updates": (
+                warmup * exact_process_count
+                if exact_process_count is not None
+                else None
+            ),
+            "total_warmup_updates_min": warmup * minimum_processes,
+            "total_warmup_updates_max": warmup * maximum_processes,
+            "snapshot_replica_count": 2,
+            "prefix": {
+                "candidates": ["no_quant", f"mul_{execution.prefix_anchor_mul:.2f}"],
+                "short_run_a_updates": execution.prefix_short_steps,
+                "short_run_b_updates": execution.prefix_short_steps,
+                "long_run_updates": execution.prefix_long_steps,
+                "checkpoints": list(execution.prefix_checkpoints),
+                "total_branch_updates": execution.prefix_branch_updates,
+            },
+            "local": {
+                **core_counts,
+                "fixed_grid": list(execution.core_grid),
+                "edge_extension": execution.edge_policy,
+                "maximum_edge_extension_rounds": execution.max_edge_extension_rounds,
+                "projected_mul_counts_if_each_edge_round_adds_one": projected_edge_mul_counts,
+            },
+            "dataset": {
+                "unique_images": int(preflight_summary.unique_images),
+                "repeat_weighted_samples": int(preflight_summary.repeat_weighted_samples),
+                "steps_per_epoch": int(preflight_summary.steps_per_epoch),
+                "normal_training_steps": int(preflight_summary.normal_training_steps),
+                "probe_images": int(probe_budget),
+            },
+        },
+        "reference_time_estimate": {
+            "minutes": estimate_minutes,
+            "is_guarantee": False,
+            "basis": "single historical RTX 5080 run with 13 probe images and warmup boundary 420",
+            "calibration": {
+                "warmup_seconds_at_420_updates": 247.0,
+                "prefix_seconds_per_branch_update": reference_prefix_update_seconds,
+                "local_seconds_per_probe": reference_local_probe_seconds,
+            },
+            "important_variability": [
+                "bucket resolutions and aspect ratios",
+                "latent cache state and storage speed",
+                "GPU, driver, CUDA, PyTorch, bitsandbytes, and Triton versions",
+                "dataset repeat weighting, which changes the warmup boundary",
+                "conditional edge stages in strict mode",
+            ],
+        },
+        "scope": "numerical Local Body/Tail Safety/Fidelity; not final image quality or Utility",
+    }
+    return {**payload, "execution_plan_sha256": canonical_sha256(payload)}
 
 
 def allocate_run_directory(output_base: Path, profile_name: str, fingerprint: str) -> Path:
@@ -553,6 +780,8 @@ def profile_command(
     snapshot_only: bool = False,
 ) -> list[str]:
     preset = request.preset
+    local = request.local_measurement
+    execution = request.execution_mode
     command = [
         *accelerate_prefix(preset),
         f"--pretrained_model_name_or_path={request.model_path}",
@@ -560,21 +789,28 @@ def profile_command(
         f"--output_dir={run_dir / '_internal_training_output'}",
         f"--output_name={request.output_name}",
         *preset.training_tokens,
-        f"--training_comment=DQ Profiler Beta {preset.name} Local-only",
+        (
+            f"--training_comment=DQ Profiler Beta {preset.name} "
+            f"{execution.name} Local-only"
+        ),
         f"--dq_profile_output_dir={run_dir}",
         f"--dq_profile_name={name}",
-        "--dq_profile_level=standard",
+        f"--dq_profile_level={execution.internal_profile_level}",
         f"--dq_profile_protocol={protocol}",
+        f"--dq_profile_execution_mode={execution.name}",
+        f"--dq_profile_qa_depth={execution.qa_depth}",
         "--dq_profile_prefix_kernel_mode=deterministic",
+        f"--dq_profile_prefix_short_steps={execution.prefix_short_steps}",
+        f"--dq_profile_prefix_long_steps={execution.prefix_long_steps}",
         f"--dq_profile_max_images={max_images}",
-        f"--dq_profile_timestep_bins={preset.timestep_bins}",
-        f"--dq_profile_stochastic_repeats={preset.stochastic_repeats}",
+        f"--dq_profile_timestep_bins={local.timestep_bins}",
+        f"--dq_profile_stochastic_repeats={local.stochastic_repeats}",
         "--dq_profile_range_muls=" + ",".join(f"{value:.2f}" for value in range_muls),
-        f"--dq_profile_sweep_steps={preset.sweep_steps}",
-        f"--dq_profile_branch_repeats={preset.branch_repeats}",
+        f"--dq_profile_sweep_steps={local.sweep_steps}",
+        f"--dq_profile_branch_repeats={local.branch_repeats}",
         "--dq_profile_guardian_ablation=common_only",
-        f"--dq_profile_sketch_width={preset.sketch_width}",
-        f"--dq_profile_sketch_seeds={preset.sketch_seeds}",
+        f"--dq_profile_sketch_width={local.sketch_width}",
+        f"--dq_profile_sketch_seeds={local.sketch_seeds}",
         f"--dq_profile_source_group_map={source_map}",
     ]
     if gate is not None:
@@ -650,6 +886,7 @@ def run_snapshot_parity(launcher: Launcher, left: Path, right: Path, output_name
 def run_local_analysis(
     launcher: Launcher,
     *,
+    request: ResolvedProfileRequest,
     profile: Path,
     output_name: str,
     dataset_id: str,
@@ -669,9 +906,9 @@ def run_local_analysis(
             "--dataset-id",
             dataset_id,
             "--iterations",
-            "2000",
+            str(request.local_measurement.bootstrap_iterations),
             "--seed",
-            "2401",
+            str(request.local_measurement.bootstrap_seed),
         ],
         label=f"Local Body/Tail analysis / {output_name}",
     )
@@ -705,6 +942,7 @@ def run_local_pipeline(
     dataset_id: str,
 ) -> tuple[Path, Path, tuple[float, ...], int]:
     names = stage_names()
+    execution = request.execution_mode
     update_status(launcher.run_dir, status="running", current_stage="snapshot_a")
     snapshot_a = run_profile(
         launcher,
@@ -712,8 +950,8 @@ def run_local_pipeline(
         source_map=source_map,
         name=names["snapshot_a"],
         protocol="v2-prefix-smoke",
-        range_muls=(3.15,),
-        max_images=8,
+        range_muls=(execution.prefix_anchor_mul,),
+        max_images=execution.snapshot_a_max_images,
         snapshot_only=True,
     )
     update_status(launcher.run_dir, status="running", current_stage="snapshot_b")
@@ -723,7 +961,7 @@ def run_local_pipeline(
         source_map=source_map,
         name=names["snapshot_b"],
         protocol="v2-prefix-smoke",
-        range_muls=(3.15,),
+        range_muls=(execution.prefix_anchor_mul,),
         max_images=probe_budget,
         snapshot_only=True,
     )
@@ -736,7 +974,7 @@ def run_local_pipeline(
         source_map=source_map,
         name=names["prefix"],
         protocol="v2-prefix-smoke",
-        range_muls=(3.15,),
+        range_muls=(execution.prefix_anchor_mul,),
         max_images=probe_budget,
     )
     run_snapshot_parity(launcher, snapshot_b, prefix, names["prefix_snapshot_parity"])
@@ -761,7 +999,7 @@ def run_local_pipeline(
     )
 
     update_status(launcher.run_dir, status="running", current_stage="core_local")
-    active_grid = tuple(float(value) for value in request.preset.core_grid)
+    active_grid = tuple(float(value) for value in execution.core_grid)
     active_profile = run_profile(
         launcher,
         request,
@@ -774,6 +1012,7 @@ def run_local_pipeline(
     )
     active_analysis = run_local_analysis(
         launcher,
+        request=request,
         profile=active_profile,
         output_name=names["core_analysis"],
         dataset_id=dataset_id,
@@ -783,7 +1022,7 @@ def run_local_pipeline(
 
     selection = read_json(active_analysis / "local_selection.json")
     completed_edge_rounds = 0
-    for round_index in range(1, request.preset.max_edge_extension_rounds + 1):
+    for round_index in range(1, execution.max_edge_extension_rounds + 1):
         if selection.get("selection_valid") is not True:
             break
         additions = tuple(float(value) for value in selection.get("edge_extension_recommended", ()))
@@ -809,6 +1048,7 @@ def run_local_pipeline(
         )
         edge_analysis = run_local_analysis(
             launcher,
+            request=request,
             profile=edge_profile,
             output_name=round_names["analysis"],
             dataset_id=dataset_id,
@@ -903,10 +1143,10 @@ def preflight(request: ResolvedProfileRequest, source_dirs: Sequence[Path]) -> N
         raise FileNotFoundError(f"DQ profile preflight is missing required files: {missing}")
     if not request.model_path.exists():
         raise FileNotFoundError(f"pretrained model path was not found: {request.model_path}")
-    if len(source_dirs) < request.preset.minimum_source_groups:
+    if len(source_dirs) < request.local_measurement.minimum_source_groups:
         raise ValueError(
             "canonical diagnostic source bootstrap requires at least "
-            f"{request.preset.minimum_source_groups} active image_dir groups; "
+            f"{request.local_measurement.minimum_source_groups} active image_dir groups; "
             f"found {len(source_dirs)}"
         )
     if importlib.util.find_spec("accelerate.commands.launch") is None:
@@ -933,9 +1173,11 @@ def _write_initial_artifacts(
     source_map_payload: Sequence[Mapping[str, Any]],
     image_count: int,
     probe_budget: int,
+    execution_plan: Mapping[str, Any],
 ) -> None:
     write_json(run_dir / "resolved_args.json", request.provenance())
     write_json(run_dir / "protocol_fingerprint.json", fingerprint)
+    write_json(run_dir / "execution_plan.json", execution_plan)
     write_json(run_dir / "source_group_map.json", source_map_payload)
     shutil.copy2(request.dataset_config, run_dir / "dataset_config_snapshot.toml")
     write_json(
@@ -946,11 +1188,16 @@ def _write_initial_artifacts(
             "current_stage": "preflight",
             "started_at": datetime.now(timezone.utc).isoformat(),
             "preset": request.preset.name,
+            "execution_mode": request.execution_mode.name,
+            "qa_depth": request.execution_mode.qa_depth,
+            "internal_profile_level": request.execution_mode.internal_profile_level,
+            "local_measurement_contract": request.local_measurement.name,
             "profile_scope": "local_body_tail_only",
             "image_count": image_count,
             "probe_budget": probe_budget,
             "source_group_count": len(source_map_payload),
             "fingerprint_sha256": fingerprint["fingerprint_sha256"],
+            "execution_plan_sha256": execution_plan["execution_plan_sha256"],
             "not_quality_or_utility": True,
             "normal_training_sources_modified": False,
         },
@@ -971,7 +1218,7 @@ def run_profile_request(
         min_bucket_reso=int(request.preset.expected_explicit["min_bucket_reso"]),
         max_bucket_reso=int(request.preset.expected_explicit["max_bucket_reso"]),
         bucket_reso_steps=int(request.preset.expected_explicit["bucket_reso_steps"]),
-        minimum_source_groups=request.preset.minimum_source_groups,
+        minimum_source_groups=request.local_measurement.minimum_source_groups,
     )
     preflight(request, source_dirs)
     output_base = validate_output_base(
@@ -983,12 +1230,17 @@ def run_profile_request(
         source_dirs,
         dataset_key=sanitize_profile_name(options.profile_name or request.output_name).casefold(),
     )
-    probe_budget = min(image_count, request.preset.max_images)
+    probe_budget = min(image_count, request.local_measurement.max_images)
     _validate_source_probe_capacity(
         source_group_count=len(source_map_payload),
         probe_budget=probe_budget,
     )
     fingerprint = build_protocol_fingerprint(request, source_map_payload=source_map_payload)
+    execution_plan = build_execution_plan(
+        request,
+        image_count=image_count,
+        probe_budget=probe_budget,
+    )
     run_dir = allocate_run_directory(
         output_base,
         options.profile_name or request.output_name,
@@ -1001,10 +1253,37 @@ def run_profile_request(
         source_map_payload=source_map_payload,
         image_count=image_count,
         probe_budget=probe_budget,
+        execution_plan=execution_plan,
     )
     launcher = Launcher(run_dir, dry_run=options.dry_run)
     launcher.log(f"DQ Profiler Beta run directory: {run_dir}")
     launcher.log("Scope: Local Body/Tail numerical Safety/Fidelity only; not quality or Utility")
+    work = execution_plan["work_volume"]
+    timing = execution_plan["reference_time_estimate"]["minutes"]
+    process_text = (
+        str(work["gpu_process_count"])
+        if work["gpu_process_count"] is not None
+        else f"{work['gpu_process_count_min']}-{work['gpu_process_count_max']}"
+    )
+    time_text = (
+        f"{timing['minimum']:.1f} min"
+        if timing["minimum"] == timing["maximum_if_all_edge_rounds_run"]
+        else (
+            f"{timing['minimum']:.1f}-"
+            f"{timing['maximum_if_all_edge_rounds_run']:.1f} min"
+        )
+    )
+    launcher.log(
+        "Execution plan: "
+        f"mode={request.execution_mode.name}, GPU processes={process_text}, "
+        f"warmup boundary={work['warmup_boundary_updates']} updates, "
+        f"prefix branch updates={work['prefix']['total_branch_updates']}, "
+        f"Local probes={work['local']['total_local_probes']}"
+    )
+    launcher.log(
+        "Reference time estimate (not guaranteed): "
+        f"{time_text}; see execution_plan.json for assumptions"
+    )
     try:
         if options.preflight_only:
             update_status(
@@ -1025,7 +1304,7 @@ def run_profile_request(
                 source_map=run_dir / "source_group_map.json",
                 name=names["core_raw"],
                 protocol="v24-acceptance-local",
-                range_muls=request.preset.core_grid,
+                range_muls=request.execution_mode.core_grid,
                 max_images=probe_budget,
                 gate=gate,
             )
@@ -1071,6 +1350,9 @@ def run_profile_request(
             active_profile=str(active_profile),
             active_analysis=str(active_analysis),
             measured_grid=list(measured_grid),
+            execution_mode=request.execution_mode.name,
+            qa_depth=request.execution_mode.qa_depth,
+            edge_policy=request.execution_mode.edge_policy,
             edge_extension_rounds=edge_rounds,
             edge_unresolved=bool(selection.get("edge_unresolved")),
             selection_valid=bool(selection.get("selection_valid")),

--- a/dq_profile/production_runner.py
+++ b/dq_profile/production_runner.py
@@ -1194,6 +1194,13 @@ PROMOTED_ANALYSIS_FILES = (
     "robust_dominance.csv",
     "source_loo.csv",
     "natural_gradient_baseline.json",
+    "source_localization.json",
+    "source_localization.csv",
+    "source_localization_detail.csv",
+    "no_quant_baseline_profile.json",
+    "no_quant_source_load.csv",
+    "no_quant_timestep_profile.csv",
+    "dataset_character_vector.json",
     "acceptance_contract.json",
 )
 

--- a/dq_profile/production_runner.py
+++ b/dq_profile/production_runner.py
@@ -266,6 +266,77 @@ def build_source_map(source_dirs: Sequence[Path], *, dataset_key: str) -> tuple[
     return payload, image_count
 
 
+def _apply_source_probe_selection(
+    source_map_payload: Sequence[Mapping[str, Any]],
+    *,
+    probe_budget: int,
+) -> list[dict[str, Any]]:
+    """Annotate which source groups must be represented in the local probe.
+
+    The complete source inventory remains in the source map and therefore in
+    the source contract. When there are more independent image_dir groups than
+    probe images, only the probe requirement is reduced. Evenly spaced indices
+    cover the full deterministic TOML/source order instead of taking a biased
+    prefix.
+    """
+
+    total = len(source_map_payload)
+    budget = int(probe_budget)
+    if total <= 0:
+        raise ValueError("source probe selection requires at least one source group")
+    if budget <= 0:
+        raise ValueError("source probe selection requires a positive probe budget")
+    selected_count = min(total, budget)
+    if selected_count == total:
+        selected_indices = list(range(total))
+        policy = "all_source_groups"
+    elif selected_count == 1:
+        selected_indices = [0]
+        policy = "deterministic_evenly_spaced_source_groups_v1"
+    else:
+        denominator = selected_count - 1
+        selected_indices = [
+            (rank * (total - 1) + denominator // 2) // denominator
+            for rank in range(selected_count)
+        ]
+        policy = "deterministic_evenly_spaced_source_groups_v1"
+    if len(set(selected_indices)) != selected_count:
+        raise RuntimeError("deterministic source probe selection produced duplicate indices")
+    rank_by_index = {index: rank for rank, index in enumerate(selected_indices)}
+    return [
+        {
+            **dict(row),
+            "probe_selected": index in rank_by_index,
+            "probe_selection_rank": rank_by_index.get(index),
+            "probe_selection_policy": policy,
+        }
+        for index, row in enumerate(source_map_payload)
+    ]
+
+
+def _source_probe_selection_summary(
+    source_map_payload: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    total = len(source_map_payload)
+    selected = sum(bool(row.get("probe_selected", True)) for row in source_map_payload)
+    policy = next(
+        (
+            str(row.get("probe_selection_policy"))
+            for row in source_map_payload
+            if row.get("probe_selection_policy")
+        ),
+        "all_source_groups" if selected == total else "custom_partial_source_groups",
+    )
+    return {
+        "source_group_count_total": total,
+        "source_group_count_probed": selected,
+        "source_group_count_omitted": total - selected,
+        "source_group_coverage_complete": selected == total,
+        "source_group_coverage_fraction": float(selected / total) if total else 1.0,
+        "source_group_selection_policy": policy,
+    }
+
+
 def validate_source_map_inventory(source_map: Path) -> None:
     """Refuse to mix worker stages that observed different dataset bytes."""
 
@@ -498,6 +569,9 @@ def build_execution_plan(
     *,
     image_count: int,
     probe_budget: int,
+    source_group_count: int | None = None,
+    probed_source_group_count: int | None = None,
+    source_group_selection_policy: str = "all_source_groups",
 ) -> dict[str, Any]:
     """Describe deterministic work volume before any GPU worker starts.
 
@@ -633,6 +707,20 @@ def build_execution_plan(
                 "steps_per_epoch": int(preflight_summary.steps_per_epoch),
                 "normal_training_steps": int(preflight_summary.normal_training_steps),
                 "probe_images": int(probe_budget),
+                "source_group_count_total": (
+                    None if source_group_count is None else int(source_group_count)
+                ),
+                "source_group_count_probed": (
+                    None
+                    if probed_source_group_count is None
+                    else int(probed_source_group_count)
+                ),
+                "source_group_coverage_complete": (
+                    None
+                    if source_group_count is None or probed_source_group_count is None
+                    else int(source_group_count) == int(probed_source_group_count)
+                ),
+                "source_group_selection_policy": source_group_selection_policy,
             },
         },
         "reference_time_estimate": {
@@ -1169,16 +1257,6 @@ def preflight(request: ResolvedProfileRequest, source_dirs: Sequence[Path]) -> N
         )
 
 
-def _validate_source_probe_capacity(*, source_group_count: int, probe_budget: int) -> None:
-    if int(source_group_count) > int(probe_budget):
-        raise ValueError(
-            "canonical diagnostic must represent every active image_dir group in its "
-            f"structural probe, but source_groups={source_group_count} exceeds "
-            f"probe_budget={probe_budget}. Consolidate source groups or use a preset "
-            "with a larger validated probe budget."
-        )
-
-
 def _write_initial_artifacts(
     run_dir: Path,
     request: ResolvedProfileRequest,
@@ -1189,6 +1267,7 @@ def _write_initial_artifacts(
     probe_budget: int,
     execution_plan: Mapping[str, Any],
 ) -> None:
+    source_probe = _source_probe_selection_summary(source_map_payload)
     write_json(run_dir / "resolved_args.json", request.provenance())
     write_json(run_dir / "protocol_fingerprint.json", fingerprint)
     write_json(run_dir / "execution_plan.json", execution_plan)
@@ -1211,7 +1290,8 @@ def _write_initial_artifacts(
             "profile_scope": "local_body_tail_only",
             "image_count": image_count,
             "probe_budget": probe_budget,
-            "source_group_count": len(source_map_payload),
+            "source_group_count": source_probe["source_group_count_total"],
+            **source_probe,
             "fingerprint_sha256": fingerprint["fingerprint_sha256"],
             "execution_plan_sha256": execution_plan["execution_plan_sha256"],
             "not_quality_or_utility": True,
@@ -1247,15 +1327,21 @@ def run_profile_request(
         dataset_key=sanitize_profile_name(options.profile_name or request.output_name).casefold(),
     )
     probe_budget = min(image_count, request.local_measurement.max_images)
-    _validate_source_probe_capacity(
-        source_group_count=len(source_map_payload),
+    source_map_payload = _apply_source_probe_selection(
+        source_map_payload,
         probe_budget=probe_budget,
     )
+    source_probe = _source_probe_selection_summary(source_map_payload)
     fingerprint = build_protocol_fingerprint(request, source_map_payload=source_map_payload)
     execution_plan = build_execution_plan(
         request,
         image_count=image_count,
         probe_budget=probe_budget,
+        source_group_count=source_probe["source_group_count_total"],
+        probed_source_group_count=source_probe["source_group_count_probed"],
+        source_group_selection_policy=source_probe[
+            "source_group_selection_policy"
+        ],
     )
     run_dir = allocate_run_directory(
         output_base,
@@ -1295,6 +1381,13 @@ def run_profile_request(
         f"warmup boundary={work['warmup_boundary_updates']} updates, "
         f"prefix branch updates={work['prefix']['total_branch_updates']}, "
         f"Local probes={work['local']['total_local_probes']}"
+    )
+    launcher.log(
+        "Source coverage: "
+        f"{source_probe['source_group_count_probed']}/"
+        f"{source_probe['source_group_count_total']} groups in the probe "
+        f"({source_probe['source_group_selection_policy']}); "
+        "the full inventory remains in the source contract"
     )
     launcher.log(
         "Reference time estimate (not guaranteed): "

--- a/dq_profile/production_runner.py
+++ b/dq_profile/production_runner.py
@@ -1181,6 +1181,7 @@ def run_local_pipeline(
 
 PROMOTED_ANALYSIS_FILES = (
     "report.html",
+    "beginner_report.html",
     "technical_report.html",
     "summary.json",
     "practical_report.json",
@@ -1212,7 +1213,13 @@ def promote_analysis(run_dir: Path, analysis_dir: Path) -> list[str]:
         if source.is_file():
             shutil.copy2(source, run_dir / name)
             promoted.append(name)
-    for required in ("report.html", "technical_report.html", "summary.json", "practical_report.json"):
+    for required in (
+        "report.html",
+        "beginner_report.html",
+        "technical_report.html",
+        "summary.json",
+        "practical_report.json",
+    ):
         if required not in promoted:
             raise FileNotFoundError(f"required product artifact was not generated: {analysis_dir / required}")
     return promoted
@@ -1462,6 +1469,7 @@ def run_profile_request(
             current_stage="complete",
             completed_at=datetime.now(timezone.utc).isoformat(),
             report="report.html",
+            beginner_report="beginner_report.html",
             technical_report="technical_report.html",
             active_profile=str(active_profile),
             active_analysis=str(active_analysis),
@@ -1478,6 +1486,7 @@ def run_profile_request(
         )
         report = run_dir / "report.html"
         launcher.log(f"Primary report: {report}")
+        launcher.log(f"Beginner report: {run_dir / 'beginner_report.html'}")
         launcher.log(f"Technical report: {run_dir / 'technical_report.html'}")
         if options.open_report and os.name == "nt":
             os.startfile(report)  # type: ignore[attr-defined]

--- a/dq_profile/production_runner.py
+++ b/dq_profile/production_runner.py
@@ -568,7 +568,7 @@ def build_execution_plan(
         )
 
     base_seconds = (
-        2.0 * reference_warmup_seconds
+        execution.standalone_snapshot_count * reference_warmup_seconds
         + reference_warmup_seconds
         + execution.prefix_branch_updates * reference_prefix_update_seconds
         + estimated_local_seconds(len(execution.core_grid))
@@ -610,7 +610,8 @@ def build_execution_plan(
             ),
             "total_warmup_updates_min": warmup * minimum_processes,
             "total_warmup_updates_max": warmup * maximum_processes,
-            "snapshot_replica_count": 2,
+            "standalone_snapshot_count": execution.standalone_snapshot_count,
+            "snapshot_replica_count": execution.standalone_snapshot_count,
             "prefix": {
                 "candidates": ["no_quant", f"mul_{execution.prefix_anchor_mul:.2f}"],
                 "short_run_a_updates": execution.prefix_short_steps,
@@ -799,6 +800,9 @@ def profile_command(
         f"--dq_profile_protocol={protocol}",
         f"--dq_profile_execution_mode={execution.name}",
         f"--dq_profile_qa_depth={execution.qa_depth}",
+        f"--dq_profile_measurement_contract={local.name}",
+        f"--dq_profile_sampling_depth={local.sampling_depth}",
+        f"--dq_profile_confidence_ceiling={local.confidence_ceiling}",
         "--dq_profile_prefix_kernel_mode=deterministic",
         f"--dq_profile_prefix_short_steps={execution.prefix_short_steps}",
         f"--dq_profile_prefix_long_steps={execution.prefix_long_steps}",
@@ -954,18 +958,23 @@ def run_local_pipeline(
         max_images=execution.snapshot_a_max_images,
         snapshot_only=True,
     )
-    update_status(launcher.run_dir, status="running", current_stage="snapshot_b")
-    snapshot_b = run_profile(
-        launcher,
-        request,
-        source_map=source_map,
-        name=names["snapshot_b"],
-        protocol="v2-prefix-smoke",
-        range_muls=(execution.prefix_anchor_mul,),
-        max_images=probe_budget,
-        snapshot_only=True,
-    )
-    run_snapshot_parity(launcher, snapshot_a, snapshot_b, names["snapshot_parity"])
+    snapshot_reference = snapshot_a
+    if execution.standalone_snapshot_count >= 2:
+        update_status(launcher.run_dir, status="running", current_stage="snapshot_b")
+        snapshot_b = run_profile(
+            launcher,
+            request,
+            source_map=source_map,
+            name=names["snapshot_b"],
+            protocol="v2-prefix-smoke",
+            range_muls=(execution.prefix_anchor_mul,),
+            max_images=probe_budget,
+            snapshot_only=True,
+        )
+        run_snapshot_parity(
+            launcher, snapshot_a, snapshot_b, names["snapshot_parity"]
+        )
+        snapshot_reference = snapshot_b
 
     update_status(launcher.run_dir, status="running", current_stage="prefix_gate")
     prefix = run_profile(
@@ -977,7 +986,12 @@ def run_local_pipeline(
         range_muls=(execution.prefix_anchor_mul,),
         max_images=probe_budget,
     )
-    run_snapshot_parity(launcher, snapshot_b, prefix, names["prefix_snapshot_parity"])
+    run_snapshot_parity(
+        launcher,
+        snapshot_reference,
+        prefix,
+        names["prefix_snapshot_parity"],
+    )
     gate = prefix / "calibration_gate.json"
     launcher.run(
         [
@@ -1192,6 +1206,8 @@ def _write_initial_artifacts(
             "qa_depth": request.execution_mode.qa_depth,
             "internal_profile_level": request.execution_mode.internal_profile_level,
             "local_measurement_contract": request.local_measurement.name,
+            "sampling_depth": request.local_measurement.sampling_depth,
+            "confidence_ceiling": request.local_measurement.confidence_ceiling,
             "profile_scope": "local_body_tail_only",
             "image_count": image_count,
             "probe_budget": probe_budget,

--- a/dq_profile/trainer_runtime.py
+++ b/dq_profile/trainer_runtime.py
@@ -2601,6 +2601,27 @@ class DiagnosticProfileRuntime:
                 "qa_depth": str(
                     getattr(self.args, "dq_profile_qa_depth", "strict_reference")
                 ),
+                "measurement_contract": str(
+                    getattr(
+                        self.args,
+                        "dq_profile_measurement_contract",
+                        "local-body-tail-v1",
+                    )
+                ),
+                "sampling_depth": str(
+                    getattr(
+                        self.args,
+                        "dq_profile_sampling_depth",
+                        "reference_32_image",
+                    )
+                ),
+                "confidence_ceiling": str(
+                    getattr(
+                        self.args,
+                        "dq_profile_confidence_ceiling",
+                        "data_driven_up_to_high",
+                    )
+                ),
                 "internal_profile_level": self.args.dq_profile_level,
                 "prefix_short_steps": int(
                     getattr(self.args, "dq_profile_prefix_short_steps", 64)

--- a/dq_profile/trainer_runtime.py
+++ b/dq_profile/trainer_runtime.py
@@ -422,6 +422,8 @@ class DiagnosticProfileRuntime:
     def _source_group_order(source_group_map: SourceGroupMap) -> tuple[str, ...]:
         result: list[str] = []
         for rule in source_group_map.rules:
+            if not rule.probe_selected:
+                continue
             group = str(rule.source_group)
             if group not in result:
                 result.append(group)
@@ -2293,6 +2295,37 @@ class DiagnosticProfileRuntime:
         )
         for candidate_name in candidate_names:
             probe_rows = [row for row in per_image_rows if row["candidate"] == candidate_name]
+            nonfinite_probe_rows: list[dict[str, Any]] = []
+            for probe_row in probe_rows:
+                fields: list[str] = []
+                for field in (
+                    "loss",
+                    "gradient_norm",
+                    "parameter_gradient_cosine",
+                    "clip_rate",
+                    "quant_error_rms",
+                    "quant_error_ratio",
+                ):
+                    raw_value = probe_row.get(field)
+                    if raw_value in (None, ""):
+                        continue
+                    try:
+                        finite = math.isfinite(float(raw_value))
+                    except (TypeError, ValueError):
+                        finite = False
+                    if not finite:
+                        fields.append(field)
+                if fields:
+                    nonfinite_probe_rows.append(
+                        {
+                            "image_key": probe_row.get("image_key"),
+                            "source_group": probe_row.get("source_group"),
+                            "timestep_bin": probe_row.get("timestep_bin"),
+                            "noise_replica": probe_row.get("noise_replica"),
+                            "quant_repeat": probe_row.get("quant_repeat"),
+                            "fields": fields,
+                        }
+                    )
             raw_probe_metrics = aggregate_numeric(
                 probe_rows,
                 (
@@ -2314,6 +2347,23 @@ class DiagnosticProfileRuntime:
                     else "structural_dropout_off"
                 ),
             }
+            if candidate_name != "no_quant" and nonfinite_probe_rows:
+                merged.update(
+                    {
+                        "forced_safety_abort": True,
+                        "common_skip_matched": False,
+                        "invalid_reason": "candidate_nonfinite_probe_measurement",
+                        "nonfinite_probe_row_count": len(nonfinite_probe_rows),
+                        "nonfinite_probe_fields": sorted(
+                            {
+                                field
+                                for item in nonfinite_probe_rows
+                                for field in item["fields"]
+                            }
+                        ),
+                        "nonfinite_probe_examples": nonfinite_probe_rows[:8],
+                    }
+                )
             candidate_rows.append(merged)
 
         manifest_additional_files = [self.args.dataset_config]

--- a/dq_profile/trainer_runtime.py
+++ b/dq_profile/trainer_runtime.py
@@ -2595,6 +2595,19 @@ class DiagnosticProfileRuntime:
             "profile": {
                 "protocol": self.profile_protocol,
                 "level": self.args.dq_profile_level,
+                "execution_mode": str(
+                    getattr(self.args, "dq_profile_execution_mode", "strict")
+                ),
+                "qa_depth": str(
+                    getattr(self.args, "dq_profile_qa_depth", "strict_reference")
+                ),
+                "internal_profile_level": self.args.dq_profile_level,
+                "prefix_short_steps": int(
+                    getattr(self.args, "dq_profile_prefix_short_steps", 64)
+                ),
+                "prefix_long_steps": int(
+                    getattr(self.args, "dq_profile_prefix_long_steps", 128)
+                ),
                 "branch_steps": (
                     len(sequence)
                     if self.profile_protocol == "v1"

--- a/dq_profile/v24_acceptance.py
+++ b/dq_profile/v24_acceptance.py
@@ -255,7 +255,12 @@ def _winner_probabilities(
 
 def _candidate_contract(
     summary: Mapping[str, Any],
-) -> tuple[list[str], dict[str, float], dict[str, bool]]:
+) -> tuple[
+    list[str],
+    dict[str, float],
+    dict[str, bool],
+    dict[str, str | None],
+]:
     if str(summary.get("schema_version")) != "2.1.0":
         raise ValueError("v2.4 analysis requires a schema 2.1.0 runtime profile")
     protocol = str(summary.get("profile", {}).get("protocol"))
@@ -267,6 +272,7 @@ def _candidate_contract(
         raise ValueError("v2.4 analysis requires a v24 acceptance runtime profile")
     candidates: list[tuple[float, str]] = []
     hard_pass: dict[str, bool] = {}
+    invalid_reasons: dict[str, str | None] = {}
     for row in summary.get("candidates", ()):  # type: ignore[union-attr]
         candidate = str(row.get("candidate"))
         if candidate == "no_quant":
@@ -278,6 +284,13 @@ def _candidate_contract(
         hard_pass[candidate] = not bool(row.get("forced_safety_abort")) and not bool(
             row.get("invalid_reason")
         )
+        invalid_reasons[candidate] = (
+            str(row.get("invalid_reason"))
+            if row.get("invalid_reason")
+            else "forced_safety_abort"
+            if row.get("forced_safety_abort")
+            else None
+        )
     candidates.sort()
     if not candidates:
         raise ValueError("v2.4 profile has no fixed-mul candidate")
@@ -285,6 +298,7 @@ def _candidate_contract(
         [candidate for _, candidate in candidates],
         {candidate: value for value, candidate in candidates},
         hard_pass,
+        invalid_reasons,
     )
 
 
@@ -327,6 +341,7 @@ def analyze_natural_gradient_rows(
     if timestep_bins <= 0 or bootstrap_iterations <= 0:
         raise ValueError("natural-gradient analysis requires positive bins/iterations")
     normalized: list[dict[str, Any]] = []
+    nonfinite_events: list[dict[str, Any]] = []
     for raw in rows:
         row = dict(raw)
         if not bool(row.get("gradient_topology_matches", True)):
@@ -335,23 +350,53 @@ def analyze_natural_gradient_rows(
         source_group = str(row.get("source_group", "") or image_key)
         if not image_key or not source_group:
             raise ValueError("no-quant natural-gradient row lacks image/source key")
-        converted = {
-            **row,
-            "source_group": source_group,
-            "relative_gradient_distance": _finite(
-                row.get("relative_gradient_distance_a_to_b")
-            ),
-            "grad_norm_noquant": _finite(row.get("grad_norm_a")),
-            "grad_norm_candidate": _finite(row.get("grad_norm_b")),
+        numeric_fields = {
+            "relative_gradient_distance": "relative_gradient_distance_a_to_b",
+            "grad_norm_noquant": "grad_norm_a",
+            "grad_norm_candidate": "grad_norm_b",
+            "grad_diff_norm": "grad_diff_norm",
+            "symmetric_gradient_distance": "symmetric_gradient_distance",
+            "angular_gradient_distance": "angular_gradient_distance",
+            "gradient_gain_distance": "gradient_gain_distance",
         }
-        for field in (
-            "grad_diff_norm",
-            "symmetric_gradient_distance",
-            "angular_gradient_distance",
-            "gradient_gain_distance",
-        ):
-            converted[field] = _finite(row.get(field))
+        converted = {**row, "source_group": source_group}
+        nonfinite_fields: list[str] = []
+        for target, source in numeric_fields.items():
+            if source not in row:
+                raise ValueError(
+                    f"no-quant natural-gradient row is missing {source}: {row!r}"
+                )
+            try:
+                number = float(row.get(source))
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    f"no-quant natural-gradient row has malformed {source}: {row!r}"
+                ) from error
+            if not math.isfinite(number):
+                nonfinite_fields.append(source)
+            converted[target] = number
+        if nonfinite_fields:
+            nonfinite_events.append(
+                {
+                    "image_key": image_key,
+                    "source_group": source_group,
+                    "timestep_bin": row.get("timestep_bin"),
+                    "noise_replica_a": row.get("noise_replica_a"),
+                    "noise_replica_b": row.get("noise_replica_b"),
+                    "nonfinite_fields": nonfinite_fields,
+                }
+            )
+            continue
         normalized.append(converted)
+    if nonfinite_events:
+        return {
+            "valid": False,
+            "invalid_reason": "nonfinite_natural_gradient_measurement",
+            "nonfinite_event_count": len(nonfinite_events),
+            "nonfinite_events": nonfinite_events,
+            "finite_pair_count": len(normalized),
+            "selector_input": False,
+        }
     if not normalized:
         return {
             "valid": False,
@@ -439,11 +484,24 @@ def analyze_local_profile(
 ) -> dict[str, Any]:
     if bootstrap_iterations <= 0:
         raise ValueError("bootstrap_iterations must be positive")
-    candidates, range_by_candidate, hard_pass = _candidate_contract(summary)
+    candidates, range_by_candidate, hard_pass, invalid_reasons = _candidate_contract(
+        summary
+    )
     timestep_bins = int(summary.get("profile", {}).get("timestep_bins", 0))
     if timestep_bins <= 0:
         raise ValueError("profile timestep bin count must be positive")
-    samples: list[dict[str, Any]] = []
+    required_numeric_fields = (
+        "relative_gradient_distance",
+        "gradient_cosine",
+        "grad_norm_noquant",
+        "grad_norm_candidate",
+        "grad_diff_norm",
+        "symmetric_gradient_distance",
+        "angular_gradient_distance",
+        "gradient_gain_distance",
+    )
+    candidate_samples: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    nonfinite_events: list[dict[str, Any]] = []
     for raw in gradient_tail_rows:
         if str(raw.get("record_type")) != "sample":
             continue
@@ -456,45 +514,72 @@ def analyze_local_profile(
             raise ValueError("gradient-tail sample has no image_key")
         source_group = str(row.get("source_group", "") or image_key)
         row["source_group"] = source_group
-        for field in (
-            "relative_gradient_distance",
-            "gradient_cosine",
-            "grad_norm_noquant",
-            "grad_norm_candidate",
-            "grad_diff_norm",
-            "symmetric_gradient_distance",
-            "angular_gradient_distance",
-            "gradient_gain_distance",
-        ):
-            if _optional_finite(row.get(field)) is None:
-                if field == "gradient_gain_distance":
-                    continue
-                raise ValueError(f"v2.4 sample is missing finite {field}: {row!r}")
-        samples.append(row)
-    if not samples:
+        nonfinite_fields: list[str] = []
+        for field in required_numeric_fields:
+            if field not in row:
+                raise ValueError(f"v2.4 sample is missing required {field}: {row!r}")
+            try:
+                number = float(row.get(field))
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    f"v2.4 sample has a malformed {field}: {row!r}"
+                ) from error
+            if not math.isfinite(number):
+                nonfinite_fields.append(field)
+        if nonfinite_fields:
+            nonfinite_events.append(
+                {
+                    "candidate": candidate,
+                    "range_mul": range_by_candidate[candidate],
+                    "image_key": image_key,
+                    "source_group": source_group,
+                    "timestep_bin": row.get("timestep_bin"),
+                    "noise_replica": row.get("noise_replica"),
+                    "quant_repeat": row.get("quant_repeat"),
+                    "nonfinite_fields": nonfinite_fields,
+                }
+            )
+            continue
+        candidate_samples[candidate].append(row)
+    if not candidate_samples and not nonfinite_events:
         raise ValueError("gradient_tail.csv has no v2.4 candidate samples")
+
+    nonfinite_candidates = {
+        str(event["candidate"]) for event in nonfinite_events
+    }
+    for candidate in nonfinite_candidates:
+        hard_pass[candidate] = False
+        invalid_reasons[candidate] = "candidate_nonfinite_probe_measurement"
+    analysis_candidates = [
+        candidate for candidate in candidates if hard_pass[candidate]
+    ]
+    if not analysis_candidates:
+        raise ValueError(
+            "v2.4 local analysis has no finite hard-safety candidate; "
+            "all measured candidates are hard unsafe"
+        )
 
     by_candidate: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
     key_sets: dict[str, set[tuple[Any, ...]]] = defaultdict(set)
     image_to_source: dict[str, str] = {}
-    for row in samples:
-        candidate = str(row["candidate"])
-        by_candidate[candidate].append(row)
-        image_key = str(row["image_key"])
-        source_group = str(row["source_group"])
-        previous = image_to_source.setdefault(image_key, source_group)
-        if previous != source_group:
-            raise ValueError(f"image maps to multiple source groups: {image_key}")
-        key_sets[candidate].add(
-            (
-                image_key,
-                int(row["timestep_bin"]),
-                int(row["noise_replica"]),
-                int(row["quant_repeat"]),
+    for candidate in analysis_candidates:
+        for row in candidate_samples[candidate]:
+            by_candidate[candidate].append(row)
+            image_key = str(row["image_key"])
+            source_group = str(row["source_group"])
+            previous = image_to_source.setdefault(image_key, source_group)
+            if previous != source_group:
+                raise ValueError(f"image maps to multiple source groups: {image_key}")
+            key_sets[candidate].add(
+                (
+                    image_key,
+                    int(row["timestep_bin"]),
+                    int(row["noise_replica"]),
+                    int(row["quant_repeat"]),
+                )
             )
-        )
-    reference_keys = key_sets[candidates[0]]
-    for candidate in candidates:
+    reference_keys = key_sets[analysis_candidates[0]]
+    for candidate in analysis_candidates:
         if key_sets[candidate] != reference_keys:
             raise ValueError(f"candidate probe key mismatch for {candidate}")
 
@@ -517,7 +602,7 @@ def analyze_local_profile(
         ],
     ] = {
         candidate: _index_rows(by_candidate[candidate], timestep_bins=timestep_bins)
-        for candidate in candidates
+        for candidate in analysis_candidates
     }
     rng = np.random.default_rng(int(bootstrap_seed))
     source_draw_indices = rng.integers(
@@ -535,7 +620,7 @@ def analyze_local_profile(
         str,
         dict[int, dict[str, list[Mapping[str, Any]]]],
     ] = {}
-    for candidate in candidates:
+    for candidate in analysis_candidates:
         all_images: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
         bin_images: dict[int, dict[str, list[Mapping[str, Any]]]] = {
             index: defaultdict(list) for index in range(timestep_bins)
@@ -554,7 +639,7 @@ def analyze_local_profile(
     source_draws: dict[str, dict[str, np.ndarray]] = {}
     image_draws: dict[str, dict[str, np.ndarray]] = {}
     bootstrap_rows: list[dict[str, Any]] = []
-    for candidate in candidates:
+    for candidate in analysis_candidates:
         all_groups, by_bin = indexes[candidate]
         primary = _body_tail(
             all_groups,
@@ -684,33 +769,39 @@ def analyze_local_profile(
                 }
             )
 
-    body_draw_matrix = np.stack([source_draws[name]["body"] for name in candidates])
-    tail_draw_matrix = np.stack([source_draws[name]["tail"] for name in candidates])
+    body_draw_matrix = np.stack(
+        [source_draws[name]["body"] for name in analysis_candidates]
+    )
+    tail_draw_matrix = np.stack(
+        [source_draws[name]["tail"] for name in analysis_candidates]
+    )
     body_regret = body_draw_matrix - np.min(body_draw_matrix, axis=0, keepdims=True)
     tail_regret = tail_draw_matrix - np.min(tail_draw_matrix, axis=0, keepdims=True)
     body_probabilities = _winner_probabilities(
-        candidates, {name: source_draws[name]["body"] for name in candidates}
+        analysis_candidates,
+        {name: source_draws[name]["body"] for name in analysis_candidates},
     )
     tail_probabilities = _winner_probabilities(
-        candidates, {name: source_draws[name]["tail"] for name in candidates}
+        analysis_candidates,
+        {name: source_draws[name]["tail"] for name in analysis_candidates},
     )
     body_modal = max(
-        candidates,
+        analysis_candidates,
         key=lambda name: (body_probabilities[name], -range_by_candidate[name]),
     )
     tail_modal = max(
-        candidates,
+        analysis_candidates,
         key=lambda name: (tail_probabilities[name], -range_by_candidate[name]),
     )
     body_point = min(
-        candidates,
+        analysis_candidates,
         key=lambda name: (
             point_by_candidate[name]["primary"]["body"],
             range_by_candidate[name],
         ),
     )
     tail_point = min(
-        candidates,
+        analysis_candidates,
         key=lambda name: (
             point_by_candidate[name]["primary"]["tail"],
             range_by_candidate[name],
@@ -719,14 +810,14 @@ def analyze_local_profile(
 
     dominance_rows: list[dict[str, Any]] = []
     dominated_by: dict[str, tuple[str, float] | None] = {
-        candidate: None for candidate in candidates
+        candidate: None for candidate in analysis_candidates
     }
-    for left in candidates:
-        left_index = candidates.index(left)
-        for right in candidates:
+    for left in analysis_candidates:
+        left_index = analysis_candidates.index(left)
+        for right in analysis_candidates:
             if left == right:
                 continue
-            right_index = candidates.index(right)
+            right_index = analysis_candidates.index(right)
             dominates = (
                 (body_draw_matrix[left_index] <= body_draw_matrix[right_index])
                 & (tail_draw_matrix[left_index] <= tail_draw_matrix[right_index])
@@ -756,9 +847,8 @@ def analyze_local_profile(
     mandatory = {body_point, tail_point, body_modal, tail_modal}
     retained = [
         candidate
-        for candidate in candidates
-        if hard_pass[candidate]
-        and (dominated_by[candidate] is None or candidate in mandatory)
+        for candidate in analysis_candidates
+        if dominated_by[candidate] is None or candidate in mandatory
     ]
     retained.sort(key=lambda name: range_by_candidate[name])
     formal_selection_valid = bool(
@@ -801,7 +891,81 @@ def analyze_local_profile(
     timestep_rows: list[dict[str, Any]] = []
     regret_rows: list[dict[str, Any]] = []
     source_loo_rows: list[dict[str, Any]] = []
-    for candidate_index, candidate in enumerate(candidates):
+    nonfinite_events_by_candidate: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for event in nonfinite_events:
+        nonfinite_events_by_candidate[str(event["candidate"])].append(event)
+    for candidate in candidates:
+        role = (
+            "core_grid"
+            if candidate in core_candidates
+            else "edge_extension"
+        )
+        if candidate not in analysis_candidates:
+            events = nonfinite_events_by_candidate.get(candidate, [])
+            score_rows.append(
+                {
+                    "dataset_id": dataset_id,
+                    "candidate": candidate,
+                    "range_mul": range_by_candidate[candidate],
+                    "grid_role": role,
+                    "hard_safety_pass": False,
+                    "invalid_reason": invalid_reasons.get(candidate)
+                    or "hard_safety_failed",
+                    "nonfinite_sample_count": len(events),
+                    "nonfinite_fields": sorted(
+                        {
+                            field
+                            for event in events
+                            for field in event["nonfinite_fields"]
+                        }
+                    ),
+                    "local_body": None,
+                    "local_body_ci_low": None,
+                    "local_body_ci_high": None,
+                    "local_tail": None,
+                    "local_tail_ci_low": None,
+                    "local_tail_ci_high": None,
+                    "tail_amplification": None,
+                    "tail_amplification_ci_low": None,
+                    "tail_amplification_ci_high": None,
+                    "worst_timestep_bin": None,
+                    "d_gt_1_rate": None,
+                    "gradient_cosine_lt_0_rate": None,
+                    "grad_norm_noquant_q05": None,
+                    "grad_norm_noquant_median": None,
+                    "grad_norm_candidate_median": None,
+                    "grad_diff_norm_q95": None,
+                    "symmetric_body": None,
+                    "symmetric_tail": None,
+                    "angle_body": None,
+                    "angle_tail": None,
+                    "gain_body": None,
+                    "gain_tail": None,
+                    "source_bootstrap_body_min_probability": None,
+                    "source_bootstrap_tail_min_probability": None,
+                    "image_bootstrap_body_ci_low": None,
+                    "image_bootstrap_body_ci_high": None,
+                    "image_bootstrap_tail_ci_low": None,
+                    "image_bootstrap_tail_ci_high": None,
+                    "body_regret_median": None,
+                    "body_regret_ci_high": None,
+                    "tail_regret_median": None,
+                    "tail_regret_ci_high": None,
+                    "body_regret_within_own_sampling_sd_probability": None,
+                    "tail_regret_within_own_sampling_sd_probability": None,
+                    "robustly_dominated": False,
+                    "dominated_by": None,
+                    "dominance_probability": None,
+                    "mandatory_retention_role": [],
+                    "retained_for_formal": False,
+                    "trajectory_risk_T": None,
+                    "conservative_alarm_R": None,
+                    "perturbation_gauge": None,
+                    "not_quality_or_utility": True,
+                }
+            )
+            continue
+        candidate_index = analysis_candidates.index(candidate)
         point = point_by_candidate[candidate]
         primary = point["primary"]
         body_ci = _bootstrap_ci(source_draws[candidate]["body"])
@@ -812,17 +976,15 @@ def analyze_local_profile(
         body_floor = float(np.std(source_draws[candidate]["body"]))
         tail_floor = float(np.std(source_draws[candidate]["tail"]))
         dominated = dominated_by[candidate]
-        role = (
-            "core_grid"
-            if candidate in core_candidates
-            else "edge_extension"
-        )
         row = {
             "dataset_id": dataset_id,
             "candidate": candidate,
             "range_mul": range_by_candidate[candidate],
             "grid_role": role,
             "hard_safety_pass": hard_pass[candidate],
+            "invalid_reason": None,
+            "nonfinite_sample_count": 0,
+            "nonfinite_fields": [],
             "local_body": float(primary["body"]),
             "local_body_ci_low": body_ci["ci_low"],
             "local_body_ci_high": body_ci["ci_high"],
@@ -931,26 +1093,45 @@ def analyze_local_profile(
                 }
             )
 
-    core_rows = [row for row in score_rows if row["grid_role"] == "core_grid"]
-    core_body_matrix = np.stack(
-        [source_draws[row["candidate"]]["body"] for row in core_rows]
-    )
-    core_tail_matrix = np.stack(
-        [source_draws[row["candidate"]]["tail"] for row in core_rows]
-    )
-    core_envelope = {
-        "grid": list(core_values),
-        "candidate_count": len(core_rows),
-        "max_local_body": max(float(row["local_body"]) for row in core_rows),
-        "max_local_tail": max(float(row["local_tail"]) for row in core_rows),
-        "probability_all_core_body_below_anchor": float(
-            np.mean(np.max(core_body_matrix, axis=0) < 1.0)
-        ),
-        "probability_all_core_tail_below_anchor": float(
-            np.mean(np.max(core_tail_matrix, axis=0) < 1.0)
-        ),
-        "scope": "common_core_grid_only",
-    }
+    core_rows = [
+        row
+        for row in score_rows
+        if row["grid_role"] == "core_grid" and row["hard_safety_pass"]
+    ]
+    if core_rows:
+        core_body_matrix = np.stack(
+            [source_draws[row["candidate"]]["body"] for row in core_rows]
+        )
+        core_tail_matrix = np.stack(
+            [source_draws[row["candidate"]]["tail"] for row in core_rows]
+        )
+        core_envelope = {
+            "grid": list(core_values),
+            "candidate_count": len(core_rows),
+            "measured_candidate_count": len(core_candidates),
+            "hard_unsafe_candidate_count": len(core_candidates) - len(core_rows),
+            "max_local_body": max(float(row["local_body"]) for row in core_rows),
+            "max_local_tail": max(float(row["local_tail"]) for row in core_rows),
+            "probability_all_core_body_below_anchor": float(
+                np.mean(np.max(core_body_matrix, axis=0) < 1.0)
+            ),
+            "probability_all_core_tail_below_anchor": float(
+                np.mean(np.max(core_tail_matrix, axis=0) < 1.0)
+            ),
+            "scope": "hard_safe_common_core_grid_only",
+        }
+    else:
+        core_envelope = {
+            "grid": list(core_values),
+            "candidate_count": 0,
+            "measured_candidate_count": len(core_candidates),
+            "hard_unsafe_candidate_count": len(core_candidates),
+            "max_local_body": None,
+            "max_local_tail": None,
+            "probability_all_core_body_below_anchor": None,
+            "probability_all_core_tail_below_anchor": None,
+            "scope": "no_hard_safe_common_core_candidate",
+        }
     selection_reason = (
         "disabled_for_formal_reanalysis"
         if not selection_enabled
@@ -980,9 +1161,17 @@ def analyze_local_profile(
         "credible_candidate_count": len(retained),
         "robustly_dominated_candidates": [
             name
-            for name in candidates
+            for name in analysis_candidates
             if dominated_by[name] is not None and name not in mandatory
         ],
+        "hard_unsafe_candidates": [
+            name for name in candidates if not hard_pass[name]
+        ],
+        "hard_unsafe_reasons": {
+            name: invalid_reasons.get(name)
+            for name in candidates
+            if not hard_pass[name]
+        },
         "point_body_min_candidate": body_point,
         "point_tail_min_candidate": tail_point,
         "bootstrap_modal_body_candidate": body_modal,
@@ -1011,6 +1200,11 @@ def analyze_local_profile(
         "image_count": len(image_keys),
         "source_group_count": len(source_groups),
         "source_groups": source_groups,
+        "hard_unsafe_candidates": [
+            name for name in candidates if not hard_pass[name]
+        ],
+        "nonfinite_event_count": len(nonfinite_events),
+        "nonfinite_events": nonfinite_events,
         "timestep_bins": timestep_bins,
         "bootstrap_iterations": int(bootstrap_iterations),
         "bootstrap_seed": int(bootstrap_seed),

--- a/dq_profile/v24_beginner_report.py
+++ b/dq_profile/v24_beginner_report.py
@@ -1,0 +1,566 @@
+from __future__ import annotations
+
+"""Beginner-oriented, single-dataset report for SDXL DQ Profiler v2.4.
+
+This renderer consumes the already-built practical report model.  It does not
+change candidate selection, recompute measurements, or make a final image
+quality/Utility claim.
+"""
+
+import html
+import json
+import math
+from typing import Any, Mapping, Sequence
+
+from dq_profile.v24_practical_report import (
+    AFFINITY_FIXED_Y_MAX,
+    TIMESTEP_BIN_LABELS,
+    _candidate_role_matrix,
+    _curve_svg,
+    _dataset_behavior_table,
+    _fmt,
+    _mul_list,
+    _optional_float,
+    _pct,
+)
+
+
+BEGINNER_REPORT_SCHEMA_VERSION = "1.0.0-beta"
+
+# Frozen, anonymized Standard reference cohort.  Only the sorted metric values
+# are retained; dataset names and paths are deliberately excluded.  Positions
+# are descriptive, not population thresholds or selector evidence.
+STANDARD_REFERENCE_COHORT = {
+    "version": "standard-reference-cohort-20260901-v1",
+    "setting_count": 9,
+    "values": {
+        "natural_tail": [
+            3.3559883169323634,
+            3.4388637329410505,
+            4.007832695302965,
+            4.6616166026748855,
+            4.849127871516622,
+            5.962866214030089,
+            8.220509251499442,
+            10.79164303983912,
+            10.971045906299404,
+        ],
+        "minimum_tail": [
+            0.4904256093573765,
+            0.7004591509672242,
+            0.8989471320506843,
+            0.9752044732797807,
+            1.0035067600763246,
+            1.0433186807996206,
+            1.125773733891675,
+            1.3901657740941091,
+            1.4225208351550054,
+        ],
+        "mul_span": [
+            0.4517422077313522,
+            0.4925948024863251,
+            0.5028121173149882,
+            0.5735561549607451,
+            0.59463050584933,
+            0.6245126369995042,
+            0.7469280230193298,
+            0.9335902860600387,
+            1.2798496383289673,
+        ],
+        "source_share": [
+            0.36854811809072835,
+            0.44635793735717644,
+            0.526034223421293,
+            0.5357525064874519,
+            0.5766309459063204,
+            0.5912834791099346,
+            0.6297516827969767,
+            0.7624387022883875,
+            0.9327961821889018,
+        ],
+        "timestep_ratio": [
+            1.982947155690137,
+            2.292007648321076,
+            3.5140447802518278,
+            3.62263756327396,
+            3.7228274519496978,
+            3.8868696653826253,
+            4.019653522317842,
+            5.40684141363122,
+            13.930538497326394,
+        ],
+    },
+    "not_thresholds": True,
+    "not_quality_or_utility": True,
+}
+
+
+_MUL_RESPONSE_JA = {
+    "flat_within_descriptive_tolerance": "測定範囲ではほぼ平坦です",
+    "upper_range_reduces_deformation": "mulを上げるほど変形が減る傾向です",
+    "lower_range_reduces_deformation": "mulを下げるほど変形が減る傾向です",
+    "interior_valley": "中間のmulに谷がある形です",
+    "irregular_or_mixed": "単調ではなく、候補ごとに動きが混在します",
+    "insufficient_grid": "測定点が少なく、曲線形状は判定できません",
+}
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "pass", "passed"}
+
+
+def _require_single_dataset(model: Mapping[str, Any]) -> Mapping[str, Any]:
+    datasets = list(model.get("datasets") or [])
+    if len(datasets) != 1:
+        raise ValueError(
+            "beginner report requires exactly one dataset; "
+            f"received {len(datasets)}"
+        )
+    return datasets[0]
+
+
+def _curve_response(dataset: Mapping[str, Any]) -> tuple[str, Mapping[str, Any]]:
+    vector = dict(dataset.get("dataset_character_vector") or {})
+    channels = dict(vector.get("channels") or {})
+    response = dict(channels.get("mul_response") or {})
+    label = _MUL_RESPONSE_JA.get(
+        str(response.get("label")),
+        "曲線形状はまだ分類できません",
+    )
+    return label, response
+
+
+def _summary_lines(dataset: Mapping[str, Any]) -> list[str]:
+    cards = list(dataset.get("candidate_cards") or [])
+    hard_safe = int(dataset.get("hard_safety_pass_count", 0))
+    if hard_safe == len(cards) and cards:
+        safety = (
+            f"試した{len(cards)}候補はすべてHard-safetyを通過し、"
+            "重大な数値異常は検出されませんでした。"
+        )
+    else:
+        unsafe = [
+            float(card["range_mul"])
+            for card in cards
+            if not _as_bool(card.get("hard_safety_pass"))
+        ]
+        safety = (
+            "Hard-safetyを通過しなかった候補があります: "
+            f"{_mul_list(unsafe)}。該当候補は通常のBody/Tail順位と分けて見ます。"
+        )
+
+    curve_label, _ = _curve_response(dataset)
+    response = str(dataset.get("absolute_response_label") or "摂動帯は未分類")
+    retained = list(dataset.get("fidelity_retained_muls") or [])
+    behavior = (
+        f"測定結果は「{response}」で、{curve_label}。"
+        f"候補内比較で残ったmulは {_mul_list(retained)} です。"
+    )
+
+    selection_reason = str(dataset.get("representative_selection_reason") or "")
+    if not selection_reason:
+        selection_reason = (
+            "単一の代表mulを出せるだけの証拠がないため、候補集合として表示します。"
+        )
+    return [safety, behavior, selection_reason]
+
+
+def _body_tail_map_svg(cards: Sequence[Mapping[str, Any]]) -> str:
+    width, height = 720, 430
+    left, right, top, bottom = 76, 30, 34, 66
+    plot_w = width - left - right
+    plot_h = height - top - bottom
+    axis_max = AFFINITY_FIXED_Y_MAX
+
+    def sx(value: float) -> float:
+        return left + min(max(value, 0.0), axis_max) / axis_max * plot_w
+
+    def sy(value: float) -> float:
+        return top + plot_h - min(max(value, 0.0), axis_max) / axis_max * plot_h
+
+    ticks: list[str] = []
+    for value in (0.0, 1.0, 2.0, 3.0, 4.0):
+        x = sx(value)
+        y = sy(value)
+        ticks.extend(
+            [
+                f'<line x1="{x:.1f}" x2="{x:.1f}" y1="{top}" y2="{top+plot_h}" class="map-grid"/>',
+                f'<line x1="{left}" x2="{left+plot_w}" y1="{y:.1f}" y2="{y:.1f}" class="map-grid"/>',
+                f'<text x="{x:.1f}" y="{height-34}" text-anchor="middle" class="map-label">{value:.1f}</text>',
+                f'<text x="{left-12}" y="{y+4:.1f}" text-anchor="end" class="map-label">{value:.1f}</text>',
+            ]
+        )
+
+    points: list[str] = []
+    for index, card in enumerate(cards):
+        body = _optional_float(card.get("body"))
+        tail = _optional_float(card.get("tail"))
+        if body is None or tail is None:
+            continue
+        x, y = sx(body), sy(tail)
+        color = "#991b1b" if not _as_bool(card.get("hard_safety_pass")) else "#2563eb"
+        overflow = body > axis_max or tail > axis_max
+        label_y = y - 10 if index % 2 == 0 else y + 18
+        points.append(
+            f'<g><circle cx="{x:.1f}" cy="{y:.1f}" r="7" fill="{color}" '
+            'stroke="white" stroke-width="2"/>'
+            f'<text x="{x+9:.1f}" y="{label_y:.1f}" class="map-point">'
+            f'{float(card["range_mul"]):.2f}{" ↑" if overflow else ""}</text>'
+            f'<title>mul {float(card["range_mul"]):.2f}: Body {body:.3f}, Tail {tail:.3f}</title></g>'
+        )
+
+    reference_x, reference_y = sx(1.0), sy(1.0)
+    return f"""
+<svg class="body-tail-map" viewBox="0 0 {width} {height}" role="img" aria-label="BodyとTailの二次元マップ">
+  <style>
+    .map-grid{{stroke:#d9e1ec;stroke-width:1}}
+    .map-reference{{stroke:#b91c1c;stroke-width:1.8;stroke-dasharray:7 5}}
+    .map-label{{font:12px system-ui,sans-serif;fill:#64748b}}
+    .map-point{{font:12px system-ui,sans-serif;fill:#26364c;font-weight:800}}
+    .map-zone{{font:11px system-ui,sans-serif;fill:#65758c}}
+  </style>
+  <rect x="{left}" y="{reference_y:.1f}" width="{reference_x-left:.1f}" height="{top+plot_h-reference_y:.1f}" fill="#eaf7f3" opacity=".75"/>
+  <rect x="{left}" y="{top}" width="{reference_x-left:.1f}" height="{reference_y-top:.1f}" fill="#fff4e2" opacity=".68"/>
+  {''.join(ticks)}
+  <line x1="{reference_x:.1f}" x2="{reference_x:.1f}" y1="{top}" y2="{top+plot_h}" class="map-reference"/>
+  <line x1="{left}" x2="{left+plot_w}" y1="{reference_y:.1f}" y2="{reference_y:.1f}" class="map-reference"/>
+  <text x="{left+12}" y="{top+18}" class="map-zone">Bodyは穏やか／一部条件のTailが大きい</text>
+  <text x="{left+12}" y="{top+plot_h-12}" class="map-zone">今回の測定では比較的no_quantに近い</text>
+  {''.join(points)}
+  <text x="{left+plot_w/2}" y="{height-5}" text-anchor="middle" class="map-label">Body：左ほどno_quantに近い／右ほど変形が強い</text>
+  <text x="17" y="{top+plot_h/2}" transform="rotate(-90 17 {top+plot_h/2})" text-anchor="middle" class="map-label">Tail：下ほどno_quantに近い／上ほど難しい帯が強い</text>
+</svg>
+"""
+
+
+def _percentile_position(value: float | None, reference: Sequence[float]) -> float | None:
+    if value is None or not reference:
+        return None
+    less = sum(item < value for item in reference)
+    equal = sum(math.isclose(item, value, rel_tol=1e-9, abs_tol=1e-12) for item in reference)
+    return 100.0 * (less + 0.5 * equal) / len(reference)
+
+
+def _timestep_ratio(dataset: Mapping[str, Any]) -> float | None:
+    baseline = dict(dataset.get("no_quant_baseline_profile") or {})
+    values = [
+        value
+        for row in baseline.get("timestep_rows", [])
+        if (value := _optional_float(row.get("grad_norm_rms"))) is not None and value > 0.0
+    ]
+    if len(values) < 2:
+        return None
+    return max(values) / min(values)
+
+
+def _character_metrics(dataset: Mapping[str, Any]) -> list[dict[str, Any]]:
+    vector = dict(dataset.get("dataset_character_vector") or {})
+    channels = dict(vector.get("channels") or {})
+    acceptance = dict(channels.get("absolute_acceptance") or {})
+    response = dict(channels.get("mul_response") or {})
+    localization = dict(channels.get("source_localization") or {})
+    stability = dict(channels.get("no_quant_stability") or {})
+    natural = dict(stability.get("natural_variation") or {})
+    values = STANDARD_REFERENCE_COHORT["values"]
+    return [
+        {
+            "key": "natural_tail",
+            "label": "no-quant自然変動",
+            "value": _optional_float(natural.get("local_tail")),
+            "format": "number",
+            "meaning": "量子化しなくても短いprobe間でどれだけ勾配が揺れるか。高いほど元の学習信号自体の幅が大きい。",
+            "direction": "小さい＝信号が均一 ／ 大きい＝元々揺れやすい",
+            "reference": values["natural_tail"],
+        },
+        {
+            "key": "minimum_tail",
+            "label": "量子化変形（最小Tail）",
+            "value": _optional_float(acceptance.get("minimum_tail")),
+            "format": "number",
+            "meaning": "試したmulのうち最も小さかったTail。低いほど今回の局所probeではno_quantへ近い。",
+            "direction": "小さい＝no_quantに近い ／ 大きい＝最良mulでもTailが残る",
+            "reference": values["minimum_tail"],
+        },
+        {
+            "key": "mul_span",
+            "label": "mul感度",
+            "value": _optional_float(response.get("span")),
+            "format": "number",
+            "meaning": "mulを変えたときのBody/Tail曲線の振れ幅。高いほどmul選択で動きが変わりやすい。",
+            "direction": "小さい＝mulに頑健 ／ 大きい＝mul選びが重要",
+            "reference": values["mul_span"],
+        },
+        {
+            "key": "source_share",
+            "label": "source集中",
+            "value": _optional_float(localization.get("top_source_share")),
+            "format": "percent",
+            "meaning": "Tail側の負担が最大sourceへ集まる割合。高くても絶対Tailが低ければ直ちに危険とは限らない。",
+            "direction": "小さい＝複数sourceへ分散 ／ 大きい＝一部sourceへ集中",
+            "reference": values["source_share"],
+        },
+        {
+            "key": "timestep_ratio",
+            "label": "timestep偏り",
+            "value": _timestep_ratio(dataset),
+            "format": "ratio",
+            "meaning": "no_quant勾配RMSの最大bin÷最小bin。高いほどtimestep帯による信号差が大きい。",
+            "direction": "小さい＝timestep間で均一 ／ 大きい＝特定帯へ偏る",
+            "reference": values["timestep_ratio"],
+        },
+    ]
+
+
+def _character_profile_html(dataset: Mapping[str, Any]) -> str:
+    rows: list[str] = []
+    for metric in _character_metrics(dataset):
+        value = metric["value"]
+        position = _percentile_position(value, metric["reference"])
+        if value is None or position is None:
+            value_text = "未測定"
+            marker = ""
+            position_text = "参照位置なし"
+        else:
+            if metric["format"] == "percent":
+                value_text = f"{100.0 * value:.1f}%"
+            elif metric["format"] == "ratio":
+                value_text = f"{value:.2f}×"
+            else:
+                value_text = f"{value:.3f}"
+            marker = f'<span class="reference-dot" style="left:{position:.2f}%"></span>'
+            position_text = f"参照集団内 {position:.0f} / 100位置"
+        rows.append(
+            f"""
+<div class="character-row">
+  <div class="character-label"><strong>{html.escape(metric['label'])}</strong><span>{html.escape(metric['meaning'])}</span><span class="direction-note">{html.escape(metric['direction'])}</span></div>
+  <div class="character-visual">
+    <div class="reference-track"><span class="reference-median"></span>{marker}</div>
+    <div class="reference-axis"><span>参照内で小さい</span><span>中央値</span><span>参照内で大きい</span></div>
+  </div>
+  <div class="character-value"><strong>{html.escape(value_text)}</strong><span>{html.escape(position_text)}</span></div>
+</div>
+"""
+        )
+    return "".join(rows)
+
+
+def _source_focus_html(dataset: Mapping[str, Any]) -> str:
+    localization = dict(dataset.get("source_localization") or {})
+    profile = dict(localization.get("reference_profile") or {})
+    if not profile:
+        return '<p class="muted">source集中の追加集計はありません。</p>'
+    share = _optional_float(profile.get("top_source_share"))
+    loo = _optional_float(profile.get("loo_max_tail_reduction_fraction"))
+    share_pct = 100.0 * share if share is not None else 0.0
+    loo_pct = 100.0 * loo if loo is not None else 0.0
+    return f"""
+<div class="source-pair">
+  <div>
+    <div class="bar-title"><strong>最大sourceが占めるTail超過</strong><span>{_pct(share)}</span></div>
+    <div class="simple-bar"><span style="width:{min(max(share_pct, 0.0), 100.0):.2f}%"></span></div>
+    <p>最大負担source（{html.escape(str(profile.get('top_source_alias') or '—'))}）がTail超過全体に占める割合です。<span class="direction-note">小さい＝複数sourceへ分散 ／ 大きい＝一部sourceへ集中</span></p>
+  </div>
+  <div>
+    <div class="bar-title"><strong>1 sourceを計算上外したときの最大Tail低下</strong><span>{_pct(loo)}</span></div>
+    <div class="simple-bar impact"><span style="width:{min(max(loo_pct, 0.0), 100.0):.2f}%"></span></div>
+    <p>最も影響の大きいsource（{html.escape(str(profile.get('loo_most_actionable_source_alias') or '—'))}）を外して再集計した参考値です。<span class="direction-note">小さい＝1 sourceへの依存が弱い ／ 大きい＝特定sourceの影響が大きい</span></p>
+  </div>
+</div>
+<p class="micro">基準mul {_fmt(profile.get('range_mul'), 2)}、実効source数 {_fmt(profile.get('effective_source_count'), 2)} / {int(profile.get('source_group_count') or 0)}。source aliasは画像内容を出さない匿名記号です。高い＝画質不良やsource削除推奨ではありません。</p>
+"""
+
+
+def _heat_color(value: float | None) -> str:
+    if value is None:
+        return "background:#f1f5f9;color:#64748b"
+    if value < 1.0:
+        alpha = 0.12 + 0.30 * min(value, 1.0)
+        return f"background:rgba(37,99,235,{alpha:.3f});color:#123a78"
+    alpha = 0.16 + 0.45 * min((value - 1.0) / 2.0, 1.0)
+    return f"background:rgba(217,119,6,{alpha:.3f});color:#6f3600"
+
+
+def _timestep_heatmap(dataset: Mapping[str, Any]) -> str:
+    rows = list(dataset.get("timestep_rows") or [])
+    if not rows:
+        return '<p class="muted">timestep別の集計はありません。</p>'
+    bins = sorted({int(row["timestep_bin"]) for row in rows})
+    by_mul: dict[float, dict[int, float | None]] = {}
+    for row in rows:
+        mul = float(row["range_mul"])
+        by_mul.setdefault(mul, {})[int(row["timestep_bin"])] = _optional_float(
+            row.get("source_balanced_q95_relative_distance")
+        )
+    headers = "".join(
+        f"<th>bin {index}<span>{html.escape(TIMESTEP_BIN_LABELS.get(index, ('?', '?'))[0])}</span></th>"
+        for index in bins
+    )
+    body: list[str] = []
+    for mul in sorted(by_mul):
+        cells = "".join(
+            f'<td style="{_heat_color(by_mul[mul].get(index))}"><strong>{_fmt(by_mul[mul].get(index))}</strong></td>'
+            for index in bins
+        )
+        body.append(f'<tr><th scope="row">{mul:.2f}</th>{cells}</tr>')
+    return (
+        '<div class="table-wrap"><table class="heatmap"><thead><tr><th>mul</th>'
+        f'{headers}</tr></thead><tbody>{"".join(body)}</tbody></table></div>'
+    )
+
+
+def _uncertainty_table(dataset: Mapping[str, Any]) -> str:
+    rows = []
+    for card in dataset.get("candidate_cards", []):
+        rows.append(
+            "<tr>"
+            f'<th scope="row">{float(card["range_mul"]):.2f}</th>'
+            f'<td>{_fmt(card.get("body"))}<span>CI [{_fmt(card.get("body_ci_low"))}, {_fmt(card.get("body_ci_high"))}]</span></td>'
+            f'<td>{_fmt(card.get("tail"))}<span>CI [{_fmt(card.get("tail_ci_low"))}, {_fmt(card.get("tail_ci_high"))}]</span></td>'
+            "</tr>"
+        )
+    return (
+        '<div class="table-wrap"><table class="uncertainty-table"><thead><tr>'
+        '<th>mul</th><th>Body</th><th>Tail</th></tr></thead>'
+        f'<tbody>{"".join(rows)}</tbody></table></div>'
+    )
+
+
+def render_beginner_report(model: Mapping[str, Any]) -> str:
+    """Render a self-contained beginner-oriented report for one dataset."""
+
+    dataset = _require_single_dataset(model)
+    cards = list(dataset.get("candidate_cards") or [])
+    if not cards:
+        raise ValueError("beginner report requires candidate cards")
+    summary_items = "".join(
+        f'<li><span>{index}</span><p>{html.escape(line)}</p></li>'
+        for index, line in enumerate(_summary_lines(dataset), start=1)
+    )
+    measurement = dict(dataset.get("measurement_quality") or {})
+    confidence = dict(dataset.get("local_comparison_confidence") or {})
+    maturity = dict(dataset.get("recommendation_maturity") or {})
+    image_probed = int(dataset.get("image_count_probed", dataset.get("image_count", 0)))
+    image_total = int(dataset.get("image_count_total", dataset.get("image_count", 0)))
+    source_probed = int(dataset.get("source_group_count_probed", dataset.get("source_group_count", 0)))
+    source_total = int(dataset.get("source_group_count_total", dataset.get("source_group_count", 0)))
+    curve = _curve_svg(
+        cards,
+        fixed_y_max=AFFINITY_FIXED_Y_MAX,
+        edge_direction=str(dataset.get("edge_direction") or "resolved"),
+    )
+    payload = html.escape(
+        json.dumps(
+            {
+                "schema_version": BEGINNER_REPORT_SCHEMA_VERSION,
+                "source_schema_version": model.get("schema_version"),
+                "dataset_id": dataset.get("dataset_id"),
+                "reference_cohort": STANDARD_REFERENCE_COHORT["version"],
+                "not_quality_or_utility": True,
+            },
+            ensure_ascii=False,
+        )
+    )
+    qa_reasons = "".join(
+        f"<li>{html.escape(str(reason))}</li>"
+        for reason in measurement.get("reasons", [])
+    ) or "<li>追加理由なし</li>"
+    confidence_reasons = "".join(
+        f"<li>{html.escape(str(reason))}</li>"
+        for reason in confidence.get("reasons", [])
+    ) or "<li>追加理由なし</li>"
+    return f"""<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>SDXL DQ Dataset Profiler — 診断レポート（概要）</title>
+<style>
+:root{{--ink:#172033;--muted:#607086;--line:#d9e1ec;--paper:#f4f7fb;--card:#fff;--blue:#2563eb;--orange:#d97706;--purple:#7c3aed;--teal:#0f766e;--red:#b91c1c;--shadow:0 12px 32px rgba(25,38,70,.09)}}
+*{{box-sizing:border-box}}html{{scroll-behavior:smooth}}body{{margin:0;background:var(--paper);color:var(--ink);font:15px/1.65 system-ui,-apple-system,"Segoe UI","Yu Gothic UI",sans-serif}}
+header{{background:#13213e;color:white}}.header-inner{{max-width:1180px;margin:auto;padding:13px 22px;display:flex;justify-content:space-between;gap:18px;align-items:center}}.brand{{font-weight:850}}.brand small{{display:block;color:#c8d4ea;font-weight:500}}.header-links{{display:flex;gap:8px;flex-wrap:wrap}}.header-links a{{color:white;text-decoration:none;border:1px solid rgba(255,255,255,.35);border-radius:999px;padding:5px 10px;font-size:12px}}
+main{{max-width:1180px;margin:auto;padding:18px 22px 70px}}section{{margin:0 0 24px}}h1{{font-size:clamp(28px,4.5vw,50px);line-height:1.08;margin:5px 0 10px}}h2{{font-size:24px;margin:0 0 6px}}h3{{font-size:17px;margin:0 0 6px}}p{{margin:5px 0}}.eyebrow{{font-size:12px;letter-spacing:.12em;text-transform:uppercase;font-weight:850;color:#5d6d84}}.section-help,.muted,.micro{{color:var(--muted)}}.micro{{font-size:11px}}
+.hero{{background:linear-gradient(135deg,#fff,#eef4ff);border:1px solid var(--line);border-radius:20px;padding:24px;box-shadow:var(--shadow)}}.hero-top{{display:flex;justify-content:space-between;gap:18px;align-items:start}}.scope-badge{{background:#eef2ff;color:#4338ca;border:1px solid #c7d2fe;border-radius:999px;padding:6px 11px;font-size:12px;font-weight:800;white-space:nowrap}}.chart-card{{margin-top:14px;background:white;border:1px solid var(--line);border-radius:15px;padding:10px 16px 13px}}.chart-card .chart{{width:100%;height:340px;display:block}}.chart-explain{{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin-top:8px}}.chart-explain>div{{background:#f5f7fb;border-radius:9px;padding:9px 10px;font-size:12px}}.chart-explain strong{{display:block}}
+.quick-summary{{display:grid;grid-template-columns:minmax(0,1.5fr) minmax(280px,.65fr);gap:14px}}.summary-card,.card{{background:white;border:1px solid var(--line);border-radius:15px;padding:18px;box-shadow:0 5px 18px rgba(25,38,70,.04)}}.summary-list{{list-style:none;padding:0;margin:8px 0;display:grid;gap:10px}}.summary-list li{{display:grid;grid-template-columns:30px 1fr;gap:10px;align-items:start}}.summary-list li>span{{display:grid;place-items:center;width:28px;height:28px;border-radius:50%;background:#dbeafe;color:#17499f;font-weight:900}}.summary-list p{{margin:1px 0}}.qa-kpis{{display:grid;grid-template-columns:1fr 1fr;gap:8px}}.qa-kpis>div{{background:#f5f7fb;padding:10px;border-radius:9px}}.qa-kpis span{{display:block;font-size:11px;color:var(--muted)}}.qa-kpis strong{{font-size:18px}}
+.warning{{background:#fff4e2;border-left:5px solid var(--orange);padding:13px 15px;border-radius:8px}}.section-title{{display:flex;justify-content:space-between;gap:12px;align-items:end;margin-bottom:8px}}.section-title p{{max-width:75ch}}.table-wrap{{overflow:auto;border:1px solid var(--line);border-radius:12px;background:white}}table{{border-collapse:collapse;width:100%;font-size:13px}}th,td{{border-bottom:1px solid var(--line);padding:10px 9px;text-align:left;vertical-align:top}}thead th{{background:#edf2f8;white-space:nowrap}}.mark-cell{{text-align:center!important;vertical-align:middle}}.matrix-mark{{display:inline-grid;place-items:center;min-width:24px;height:24px;padding:0 6px;border-radius:999px;font-weight:900;font-size:12px}}.matrix-mark.pass{{background:#dcfce7;color:#166534}}.matrix-mark.retained{{background:#dbeafe;color:#17499f}}.matrix-mark.attention{{background:#ffedd5;color:#9a4700}}.matrix-mark.danger{{background:#fee2e2;color:#991b1b}}.matrix-mark.representative{{background:#f2ebff;color:#5b21b6}}.matrix-mark.pattern{{background:#e0e7ff;color:#3730a3}}.matrix-mark.off{{color:#a2acba;background:#f3f4f6}}.matrix-legend{{display:flex;flex-wrap:wrap;gap:8px 14px;align-items:center;margin-top:9px;color:var(--muted);font-size:11px}}.matrix-legend>span{{display:inline-flex;align-items:center;gap:5px}}.decision-table th[scope="row"]{{min-width:190px}}.decision-table td:last-child{{min-width:180px}}.role-matrix th:first-child{{min-width:245px}}.role-matrix td{{text-align:center;vertical-align:middle}}.row-help{{display:block;color:var(--muted);font-weight:400;font-size:10px;margin-top:2px}}
+.two-column{{display:grid;grid-template-columns:1.15fr .85fr;gap:14px}}.body-tail-map{{width:100%;height:auto;display:block}}.map-notes{{display:grid;gap:9px}}.map-notes>div{{padding:11px;border-radius:9px;background:#f5f7fb}}.map-notes strong{{display:block}}
+.character-panel{{background:white;border:1px solid var(--line);border-radius:15px;overflow:hidden}}.character-row{{display:grid;grid-template-columns:minmax(210px,.8fr) minmax(260px,1.45fr) minmax(130px,.45fr);gap:15px;align-items:center;padding:15px 17px;border-bottom:1px solid var(--line)}}.character-row:last-child{{border-bottom:0}}.character-label{{display:grid;gap:2px}}.character-label span,.character-value span{{font-size:11px;color:var(--muted)}}.direction-note{{display:block;color:#315b7d!important;font-weight:750;margin-top:3px}}.character-visual{{min-width:0}}.reference-track{{position:relative;height:13px;border-radius:999px;background:linear-gradient(90deg,#dbeafe,#eef2ff 50%,#ffedd5)}}.reference-median{{position:absolute;left:50%;top:-4px;width:2px;height:21px;background:#64748b}}.reference-dot{{position:absolute;top:50%;width:17px;height:17px;border-radius:50%;background:var(--purple);border:3px solid white;box-shadow:0 0 0 1px #6d28d9;transform:translate(-50%,-50%)}}.reference-axis{{display:flex;justify-content:space-between;font-size:10px;color:var(--muted);margin-top:4px}}.character-value{{display:grid;text-align:right}}.character-value strong{{font-size:19px}}
+.source-pair{{display:grid;grid-template-columns:1fr 1fr;gap:16px}}.source-pair>div{{padding:14px;background:#f8fafc;border:1px solid var(--line);border-radius:11px}}.bar-title{{display:flex;justify-content:space-between;gap:8px}}.simple-bar{{height:13px;background:#e2e8f0;border-radius:999px;overflow:hidden;margin:8px 0}}.simple-bar span{{display:block;height:100%;background:var(--purple);border-radius:999px}}.simple-bar.impact span{{background:var(--teal)}}.source-pair p{{font-size:12px;color:var(--muted)}}
+.heatmap th span{{display:block;font-size:10px;color:var(--muted);font-weight:500}}.heatmap td{{text-align:center;min-width:100px}}.uncertainty-table td>span{{display:block;font-size:10px;color:var(--muted)}}details{{background:white;border:1px solid var(--line);border-radius:12px;padding:12px 15px;margin:10px 0}}summary{{cursor:pointer;font-weight:800}}details>div,details>table,details>ul{{margin-top:10px}}.limits{{display:grid;grid-template-columns:1fr 1fr;gap:12px}}.limits>div{{padding:16px;border-radius:12px}}.limits .can{{background:#ecfdf5;border:1px solid #a7f3d0}}.limits .cannot{{background:#fff7ed;border:1px solid #fed7aa}}.limits ul{{margin:5px 0;padding-left:20px}}
+footer{{font-size:11px;color:var(--muted);padding-top:22px}}code{{font-family:ui-monospace,Consolas,monospace}}a{{color:#1d4ed8}}
+@media(max-width:850px){{.quick-summary,.two-column,.source-pair,.limits{{grid-template-columns:1fr}}.chart-explain{{grid-template-columns:1fr}}.character-row{{grid-template-columns:1fr}}.character-value{{text-align:left}}.hero-top{{display:block}}.scope-badge{{display:inline-block;margin-top:8px}}}}
+@media(max-width:560px){{main{{padding:12px 9px 50px}}.header-inner{{align-items:flex-start;flex-direction:column}}.hero{{padding:14px}}.chart-card{{padding:5px}}.chart-card .chart{{height:260px}}.qa-kpis{{grid-template-columns:1fr}}}}
+@media print{{body{{background:white}}header{{background:white;color:var(--ink);border-bottom:1px solid var(--line)}}.brand small{{color:var(--muted)}}.header-links{{display:none}}.card,.summary-card,.hero{{box-shadow:none}}}}
+</style>
+</head>
+<body>
+<header><div class="header-inner"><div class="brand">SDXL DQ Dataset Profiler <small>診断レポート（概要）・ Safety/Fidelity ≠ 最終画質Utility</small></div><nav class="header-links"><a href="report.html">詳細レポート</a><a href="technical_report.html">技術レポート</a></nav></div></header>
+<main>
+<section class="hero">
+  <div class="hero-top"><div><div class="eyebrow">Single dataset / fixed-mul local diagnostic</div><h1>{html.escape(str(dataset.get('label') or dataset.get('dataset_id')))}</h1><p>固定mulごとに、量子化した勾配がno_quantからどのように離れるかを可視化します。</p></div><span class="scope-badge">{html.escape(str(dataset.get('execution_mode') or 'unknown').title())} / Local-only</span></div>
+  <div class="chart-card">
+    {curve}
+    <div class="chart-explain">
+      <div><strong>Body</strong>全画像・timestepをまとめた、やや厳しめの代表値です。小さいほど幅広い条件でno_quantに近くなります。</div>
+      <div><strong>Tail</strong>各timestep帯の代表値のうち最大です。小さいほど厳しい帯でもno_quantに近くなります。</div>
+      <div><strong>ヒゲ（淡い縦棒）</strong>画像/sourceを再標本化したときの不確かさです。長いほど細かな順位を決めにくい状態です。</div>
+    </div>
+  </div>
+</section>
+
+<section class="quick-summary">
+  <div class="summary-card"><div class="eyebrow">まず読む3行</div><ol class="summary-list">{summary_items}</ol></div>
+  <aside class="summary-card"><div class="eyebrow">測定範囲</div><div class="qa-kpis"><div><span>Measurement QA</span><strong>{html.escape(str(measurement.get('level') or '—'))}</strong></div><div><span>比較confidence</span><strong>{html.escape(str(confidence.get('level') or '—'))}</strong></div><div><span>画像</span><strong>{image_probed} / {image_total}</strong></div><div><span>source</span><strong>{source_probed} / {source_total}</strong></div></div><p class="micro">QAは測定手順の正常性、confidenceは候補間比較の確かさです。画質評価ではありません。</p></aside>
+</section>
+
+<section class="warning"><strong>大切な読み方:</strong> 基準1.0未満は、今回測った勾配変形が基準帯の内側という意味です。良い画像になる保証でも、量子化なしと同一という意味でもありません。</section>
+
+<section class="card">
+  <div class="section-title"><div><h2>試したmulと役割</h2><p class="section-help">✓は通過・保持、橙の「注意」は安全だが相対的に強い摂動、★は数値上の代表です。記号は画質の合否ではありません。</p></div></div>
+  {_candidate_role_matrix(dataset)}
+</section>
+
+<section class="card">
+  <div class="section-title"><div><h2>今回見られた動き</h2><p class="section-help">定型パターンへ○を付けています。「候補内で強い」は同じdataset内の相対比較で、絶対的な危険とは限りません。</p></div></div>
+  {_dataset_behavior_table(dataset)}
+</section>
+
+<section class="two-column">
+  <div class="card"><h2>Body × Tail マップ</h2><p class="section-help">右ほど普段の変形が大きく、上ほど難しい条件の変形が大きい配置です。左下へ近いほど数値上no_quantへ近いだけで、最終画質順位ではありません。</p>{_body_tail_map_svg(cards)}</div>
+  <aside class="card map-notes"><h2>4つの見方</h2><div><strong>左下</strong>今回の局所probeではBody/Tailとも比較的穏やかです。</div><div><strong>左上</strong>普段は穏やかでも、一部の難しい条件で大きくずれます。</div><div><strong>右上</strong>普段と難しい条件の両方で変形が大きく見えます。</div><div><strong>基準線付近</strong>不確かさのヒゲも確認し、1.0を少し跨ぐだけで断定しません。</div></aside>
+</section>
+
+<section>
+  <div class="section-title"><div><h2>データセットの性格カルテ</h2><p class="section-help">5項目を合成せず、別々に表示します。紫の点は匿名化したStandard参照9設定内での位置です。中央線は参照集団の中央値で、理想値や良否の閾値ではありません。</p></div><span class="scope-badge">参照: {html.escape(str(STANDARD_REFERENCE_COHORT['version']))}</span></div>
+  <div class="character-panel">{_character_profile_html(dataset)}</div>
+</section>
+
+<section class="card">
+  <h2>Tailはどの画像グループに偏っているか</h2><p class="section-help">sourceはTOML内の画像グループ（通常はimage_dir／subset）です。Tail基準を超えた変形をsource別の箱に分け、左で最大の箱の割合、右で1箱を計算上外したときのTail低下を見ます。</p>
+  {_source_focus_html(dataset)}
+</section>
+
+<section class="card">
+  <h2>timestep帯ごとの変形</h2><p class="section-help">行はmul、列はtimestep帯（右ほど高ノイズ）です。値が小さいほどno_quantに近く、大きいほどその帯で量子化による変形が強くなります。青は1.0未満、橙は1.0以上の注意帯です。特定の列だけが高ければ影響がその帯へ集中しています。画質判定ではありません。</p>
+  {_timestep_heatmap(dataset)}
+</section>
+
+<section class="card">
+  <h2>測定のばらつきと信頼性</h2><p class="section-help">Body／Tailは上のグラフと同じ値です。CIはsourceを取り直して再集計した推定95%区間で、狭いほど安定し、広いほど細かな候補順位は不確かです。QA通過は測定が有効という意味で、画質保証ではありません。</p>
+  {_uncertainty_table(dataset)}
+  <details><summary>QAとconfidenceの理由</summary><div class="two-column"><div><h3>Measurement QA</h3><ul>{qa_reasons}</ul></div><div><h3>Local comparison confidence</h3><ul>{confidence_reasons}</ul></div></div><p class="micro">Recommendation maturity: {html.escape(str(maturity.get('level') or '—'))}。Trajectoryと40 epoch画質Utilityは、この概要の選択材料に含めていません。</p></details>
+</section>
+
+<section class="limits">
+  <div class="can"><h2>この診断で分かること</h2><ul><li>固定mulごとの局所的な勾配変形</li><li>BodyとTailの違い</li><li>候補内で残るmul集合</li><li>source・timestepへの偏り</li><li>測定の不確かさと未解決edge</li></ul></div>
+  <div class="cannot"><h2>この診断だけでは分からないこと</h2><ul><li>最終生成画質のbest mul</li><li>量子化がno_quantより有益か</li><li>auto presetの最終軌跡</li><li>測定範囲外のmulの挙動</li><li>長期学習の成功保証</li></ul></div>
+</section>
+
+<section class="card"><h2>さらに詳しく見る</h2><p><a href="report.html">詳細レポート</a>では候補表、bootstrap勝率、source LOOなどを確認できます。<a href="technical_report.html">技術レポート</a>には計測契約と技術的成果物への案内があります。</p></section>
+<footer>Beginner report schema {BEGINNER_REPORT_SCHEMA_VERSION} ・ source practical schema {html.escape(str(model.get('schema_version') or 'unknown'))} ・ fixed affinity scale 0–{AFFINITY_FIXED_Y_MAX:.1f} ・ no external CDN ・ numerical Safety/Fidelity only.</footer>
+</main>
+<script id="report-meta" type="application/json">{payload}</script>
+</body>
+</html>
+"""

--- a/dq_profile/v24_descriptive.py
+++ b/dq_profile/v24_descriptive.py
@@ -1,0 +1,753 @@
+from __future__ import annotations
+
+"""Descriptive dataset-character channels for the v2.4 Local profiler.
+
+These channels reuse already measured Local gradient rows.  They never vote
+in candidate selection and do not predict image quality or training utility.
+"""
+
+from collections import defaultdict
+import math
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+from dq_profile.v24_acceptance import _weighted_quantile
+
+
+DESCRIPTIVE_PROFILE_SCHEMA_VERSION = "1.0.0"
+DESCRIPTIVE_METRIC_DEFINITION_VERSION = "1.0.0"
+SOURCE_TAIL_QUANTILES = (0.85, 0.90, 0.95)
+PRIMARY_SOURCE_TAIL_QUANTILE = 0.90
+
+
+def _optional_finite(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _candidate_mul(row: Mapping[str, Any]) -> float | None:
+    value = _optional_finite(row.get("range_mul"))
+    if value is None:
+        value = _optional_finite(row.get("initial_range_mul"))
+    return value
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "pass", "passed"}
+
+
+def _source_aliases(source_groups: Sequence[str]) -> dict[str, str]:
+    return {
+        source_group: f"S{index:02d}"
+        for index, source_group in enumerate(sorted(set(source_groups)), start=1)
+    }
+
+
+def _source_equal_values(
+    rows_by_source: Mapping[str, Sequence[Mapping[str, Any]]],
+    field: str,
+) -> tuple[list[float], list[float]]:
+    values: list[float] = []
+    weights: list[float] = []
+    for source_group in sorted(rows_by_source):
+        finite = [
+            number
+            for row in rows_by_source[source_group]
+            if (number := _optional_finite(row.get(field))) is not None
+        ]
+        if not finite:
+            continue
+        per_row = 1.0 / len(finite)
+        values.extend(finite)
+        weights.extend([per_row] * len(finite))
+    return values, weights
+
+
+def _source_equal_quantile(
+    rows_by_source: Mapping[str, Sequence[Mapping[str, Any]]],
+    field: str,
+    quantile: float,
+) -> float:
+    values, weights = _source_equal_values(rows_by_source, field)
+    return _weighted_quantile(values, weights, quantile)
+
+
+def _effective_count(shares: Sequence[float]) -> float | None:
+    finite = [float(value) for value in shares if math.isfinite(float(value))]
+    denominator = sum(value * value for value in finite)
+    return 1.0 / denominator if denominator > 0.0 else None
+
+
+def _hard_safe_candidates(
+    score_rows: Sequence[Mapping[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for raw in score_rows:
+        candidate = str(raw.get("candidate", "")).strip()
+        if not candidate or not _as_bool(raw.get("hard_safety_pass", True)):
+            continue
+        local_tail = _optional_finite(raw.get("local_tail"))
+        range_mul = _candidate_mul(raw)
+        if local_tail is None or range_mul is None:
+            continue
+        result[candidate] = {
+            "candidate": candidate,
+            "range_mul": range_mul,
+            "local_body": _optional_finite(raw.get("local_body")),
+            "local_tail": local_tail,
+            "tail_amplification": _optional_finite(raw.get("tail_amplification")),
+            "worst_timestep_bin": (
+                int(float(raw["worst_timestep_bin"]))
+                if _optional_finite(raw.get("worst_timestep_bin")) is not None
+                else None
+            ),
+        }
+    return result
+
+
+def analyze_source_localization(
+    *,
+    gradient_tail_rows: Sequence[Mapping[str, Any]],
+    score_rows: Sequence[Mapping[str, Any]],
+    source_loo_rows: Sequence[Mapping[str, Any]],
+    tail_quantiles: Sequence[float] = SOURCE_TAIL_QUANTILES,
+    primary_tail_quantile: float = PRIMARY_SOURCE_TAIL_QUANTILE,
+) -> dict[str, Any]:
+    """Describe where the measured quantization Tail burden is localized.
+
+    The source-balanced threshold is computed independently for each fixed-mul
+    candidate.  Per-source burden is the source mean of ``max(d-threshold, 0)``.
+    Burden shares are explanatory proxies, not additive image-quality damage.
+    """
+
+    quantiles = tuple(sorted({float(value) for value in tail_quantiles}))
+    if not quantiles or any(not 0.0 < value < 1.0 for value in quantiles):
+        raise ValueError("source localization requires tail quantiles in (0, 1)")
+    if not any(
+        math.isclose(value, primary_tail_quantile, rel_tol=0.0, abs_tol=1e-12)
+        for value in quantiles
+    ):
+        raise ValueError("primary source tail quantile must be present")
+
+    score_by_candidate = _hard_safe_candidates(score_rows)
+    samples_by_candidate: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    source_groups: set[str] = set()
+    for raw in gradient_tail_rows:
+        if str(raw.get("record_type", "")) != "sample":
+            continue
+        candidate = str(raw.get("candidate", "")).strip()
+        if candidate not in score_by_candidate:
+            continue
+        worst_timestep_bin = score_by_candidate[candidate].get(
+            "worst_timestep_bin"
+        )
+        if (
+            worst_timestep_bin is not None
+            and int(raw.get("timestep_bin", 0)) != int(worst_timestep_bin)
+        ):
+            continue
+        distance = _optional_finite(raw.get("relative_gradient_distance"))
+        image_key = str(raw.get("image_key", "")).strip()
+        source_group = str(raw.get("source_group", "") or image_key).strip()
+        if distance is None or not image_key or not source_group:
+            continue
+        samples_by_candidate[candidate].append(
+            {
+                "candidate": candidate,
+                "image_key": image_key,
+                "source_group": source_group,
+                "relative_gradient_distance": distance,
+            }
+        )
+        source_groups.add(source_group)
+    if not samples_by_candidate:
+        return {
+            "schema_version": DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+            "metric_definition_version": DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+            "valid": False,
+            "invalid_reason": "no_finite_hard_safe_gradient_tail_samples",
+            "selector_input": False,
+            "not_quality_or_utility": True,
+        }
+
+    aliases = _source_aliases(sorted(source_groups))
+    loo_by_candidate: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for row in source_loo_rows:
+        candidate = str(row.get("candidate", "")).strip()
+        if candidate in score_by_candidate:
+            loo_by_candidate[candidate].append(row)
+
+    summary_rows: list[dict[str, Any]] = []
+    detail_rows: list[dict[str, Any]] = []
+    candidate_profiles: list[dict[str, Any]] = []
+    for candidate in sorted(
+        samples_by_candidate,
+        key=lambda name: (score_by_candidate[name]["range_mul"], name),
+    ):
+        rows_by_source: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+        for row in samples_by_candidate[candidate]:
+            rows_by_source[str(row["source_group"])].append(row)
+        candidate_threshold_rows: list[dict[str, Any]] = []
+        for quantile in quantiles:
+            threshold = _source_equal_quantile(
+                rows_by_source,
+                "relative_gradient_distance",
+                quantile,
+            )
+            burdens: dict[str, float] = {}
+            exceedance_rates: dict[str, float] = {}
+            for source_group, members in sorted(rows_by_source.items()):
+                distances = [
+                    float(row["relative_gradient_distance"]) for row in members
+                ]
+                burdens[source_group] = float(
+                    np.mean([max(value - threshold, 0.0) for value in distances])
+                )
+                exceedance_rates[source_group] = float(
+                    np.mean([value > threshold for value in distances])
+                )
+            total_burden = float(sum(burdens.values()))
+            shares = {
+                source_group: (
+                    burden / total_burden if total_burden > 0.0 else 0.0
+                )
+                for source_group, burden in burdens.items()
+            }
+            top_source = min(
+                shares,
+                key=lambda source_group: (-shares[source_group], source_group),
+            )
+            effective_count = _effective_count(shares.values())
+            active_count = sum(value > 0.0 for value in burdens.values())
+            summary_row = {
+                "candidate": candidate,
+                "range_mul": score_by_candidate[candidate]["range_mul"],
+                "timestep_bin": score_by_candidate[candidate].get(
+                    "worst_timestep_bin"
+                ),
+                "tail_quantile": quantile,
+                "source_balanced_threshold": threshold,
+                "source_group_count": len(rows_by_source),
+                "active_source_count": active_count,
+                "total_mean_excess": total_burden,
+                "top_source_group": top_source,
+                "top_source_alias": aliases[top_source],
+                "top_source_share": shares[top_source],
+                "effective_source_count": effective_count,
+                "effective_source_rate": (
+                    effective_count / len(rows_by_source)
+                    if effective_count is not None and rows_by_source
+                    else None
+                ),
+                "selector_input": False,
+                "not_quality_or_utility": True,
+            }
+            summary_rows.append(summary_row)
+            candidate_threshold_rows.append(summary_row)
+            for source_group in sorted(rows_by_source):
+                detail_rows.append(
+                    {
+                        "candidate": candidate,
+                        "range_mul": score_by_candidate[candidate]["range_mul"],
+                        "timestep_bin": score_by_candidate[candidate].get(
+                            "worst_timestep_bin"
+                        ),
+                        "tail_quantile": quantile,
+                        "source_balanced_threshold": threshold,
+                        "source_group": source_group,
+                        "source_alias": aliases[source_group],
+                        "sample_count": len(rows_by_source[source_group]),
+                        "mean_excess": burdens[source_group],
+                        "excess_share": shares[source_group],
+                        "exceedance_rate": exceedance_rates[source_group],
+                        "selector_input": False,
+                        "not_quality_or_utility": True,
+                    }
+                )
+
+        primary = next(
+            row
+            for row in candidate_threshold_rows
+            if math.isclose(
+                float(row["tail_quantile"]),
+                primary_tail_quantile,
+                rel_tol=0.0,
+                abs_tol=1e-12,
+            )
+        )
+        top_sources = [str(row["top_source_group"]) for row in candidate_threshold_rows]
+        effective_rates = [
+            float(row["effective_source_rate"])
+            for row in candidate_threshold_rows
+            if row.get("effective_source_rate") is not None
+        ]
+        full_tail = float(score_by_candidate[candidate]["local_tail"])
+        loo_candidates: list[tuple[float, str, float]] = []
+        for loo_row in loo_by_candidate.get(candidate, []):
+            loo_tail = _optional_finite(loo_row.get("local_tail"))
+            omitted = str(loo_row.get("omitted_source_group", "")).strip()
+            if loo_tail is not None and omitted:
+                loo_candidates.append((full_tail - loo_tail, omitted, loo_tail))
+        best_loo = (
+            min(loo_candidates, key=lambda item: (-item[0], item[1]))
+            if loo_candidates
+            else None
+        )
+        candidate_profiles.append(
+            {
+                **dict(primary),
+                "local_body": score_by_candidate[candidate].get("local_body"),
+                "local_tail": score_by_candidate[candidate].get("local_tail"),
+                "tail_amplification": score_by_candidate[candidate].get(
+                    "tail_amplification"
+                ),
+                "threshold_quantiles": list(quantiles),
+                "top_source_stable_across_thresholds": len(set(top_sources)) == 1,
+                "top_source_aliases_across_thresholds": [
+                    aliases[value] for value in top_sources
+                ],
+                "effective_source_rate_min": min(effective_rates) if effective_rates else None,
+                "effective_source_rate_max": max(effective_rates) if effective_rates else None,
+                "effective_source_rate_span": (
+                    max(effective_rates) - min(effective_rates)
+                    if effective_rates
+                    else None
+                ),
+                "loo_max_tail_reduction": best_loo[0] if best_loo else None,
+                "loo_max_tail_reduction_fraction": (
+                    best_loo[0] / full_tail
+                    if best_loo and full_tail > 0.0
+                    else None
+                ),
+                "loo_most_actionable_source_group": best_loo[1] if best_loo else None,
+                "loo_most_actionable_source_alias": (
+                    aliases.get(best_loo[1]) if best_loo else None
+                ),
+                "loo_tail_without_source": best_loo[2] if best_loo else None,
+                "loo_positive_reduction_observed": bool(best_loo and best_loo[0] > 0.0),
+            }
+        )
+
+    reference = min(
+        candidate_profiles,
+        key=lambda row: (
+            score_by_candidate[str(row["candidate"])]["local_tail"],
+            float(row["range_mul"]),
+        ),
+    )
+    return {
+        "schema_version": DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+        "metric_definition_version": DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+        "valid": True,
+        "diagnostic_channel": "quantization_tail_source_localization",
+        "definition": (
+            "per-source mean excess above a source-equal-weighted candidate "
+            "distance quantile within that candidate's worst timestep bin"
+        ),
+        "tail_quantiles": list(quantiles),
+        "primary_tail_quantile": primary_tail_quantile,
+        "reference_rule": "measured_point_tail_min_candidate_descriptive_only",
+        "reference_candidate": str(reference["candidate"]),
+        "reference_mul": float(reference["range_mul"]),
+        "reference_profile": dict(reference),
+        "candidate_profiles": candidate_profiles,
+        "summary_rows": summary_rows,
+        "detail_rows": detail_rows,
+        "source_alias_map": aliases,
+        "important_limit": (
+            "source burden is a localization proxy, not additive image-quality harm; "
+            "a high share with a low absolute Tail is not an alarm"
+        ),
+        "selector_input": False,
+        "not_quality_or_utility": True,
+    }
+
+
+def analyze_no_quant_baseline(
+    *,
+    gradient_tail_rows: Sequence[Mapping[str, Any]],
+    natural_baseline: Mapping[str, Any] | None,
+    timestep_bins: int,
+) -> dict[str, Any]:
+    """Describe the no-quant reference signal already used by Local probes."""
+
+    if timestep_bins <= 0:
+        raise ValueError("no-quant baseline requires a positive timestep bin count")
+    values_by_probe: dict[tuple[str, str, int, int], list[float]] = defaultdict(list)
+    for raw in gradient_tail_rows:
+        if str(raw.get("record_type", "")) != "sample":
+            continue
+        image_key = str(raw.get("image_key", "")).strip()
+        source_group = str(raw.get("source_group", "") or image_key).strip()
+        norm = _optional_finite(raw.get("grad_norm_noquant"))
+        if not image_key or not source_group or norm is None:
+            continue
+        key = (
+            image_key,
+            source_group,
+            int(raw.get("timestep_bin", 0)),
+            int(raw.get("noise_replica", 0)),
+        )
+        values_by_probe[key].append(norm)
+    if not values_by_probe:
+        return {
+            "schema_version": DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+            "metric_definition_version": DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+            "valid": False,
+            "invalid_reason": "no_finite_no_quant_reference_norms",
+            "selector_input": False,
+            "not_quality_or_utility": True,
+        }
+
+    probe_rows: list[dict[str, Any]] = []
+    inconsistent_reference_count = 0
+    for (image_key, source_group, timestep_bin, noise_replica), norms in sorted(
+        values_by_probe.items()
+    ):
+        median = float(np.median(norms))
+        tolerance = max(1e-12, abs(median) * 1e-7)
+        spread = max(norms) - min(norms)
+        if spread > tolerance:
+            inconsistent_reference_count += 1
+        probe_rows.append(
+            {
+                "image_key": image_key,
+                "source_group": source_group,
+                "timestep_bin": timestep_bin,
+                "noise_replica": noise_replica,
+                "grad_norm_noquant": median,
+                "duplicate_observation_count": len(norms),
+                "duplicate_spread": spread,
+            }
+        )
+
+    rows_by_source: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    rows_by_bin: dict[int, dict[str, list[Mapping[str, Any]]]] = {
+        index: defaultdict(list) for index in range(timestep_bins)
+    }
+    for row in probe_rows:
+        source_group = str(row["source_group"])
+        bin_index = int(row["timestep_bin"])
+        rows_by_source[source_group].append(row)
+        rows_by_bin[bin_index][source_group].append(row)
+    aliases = _source_aliases(sorted(rows_by_source))
+
+    def rms(source_rows: Mapping[str, Sequence[Mapping[str, Any]]]) -> float:
+        per_source_energy = [
+            float(
+                np.mean(
+                    [float(row["grad_norm_noquant"]) ** 2 for row in members]
+                )
+            )
+            for members in source_rows.values()
+            if members
+        ]
+        return float(math.sqrt(np.mean(per_source_energy)))
+
+    source_energy = {
+        source_group: float(
+            np.mean(
+                [float(row["grad_norm_noquant"]) ** 2 for row in members]
+            )
+        )
+        for source_group, members in rows_by_source.items()
+    }
+    total_energy = float(sum(source_energy.values()))
+    source_shares = {
+        source_group: (
+            value / total_energy if total_energy > 0.0 else 0.0
+        )
+        for source_group, value in source_energy.items()
+    }
+    top_source = min(
+        source_shares,
+        key=lambda source_group: (-source_shares[source_group], source_group),
+    )
+    effective_count = _effective_count(source_shares.values())
+    source_rows = [
+        {
+            "source_group": source_group,
+            "source_alias": aliases[source_group],
+            "probe_count": len(rows_by_source[source_group]),
+            "mean_gradient_energy": source_energy[source_group],
+            "energy_share": source_shares[source_group],
+            "selector_input": False,
+            "not_quality_or_utility": True,
+        }
+        for source_group in sorted(rows_by_source)
+    ]
+    timestep_rows: list[dict[str, Any]] = []
+    for bin_index in range(timestep_bins):
+        members = rows_by_bin[bin_index]
+        if not members:
+            timestep_rows.append(
+                {
+                    "timestep_bin": bin_index,
+                    "source_group_count": 0,
+                    "grad_norm_q05": None,
+                    "grad_norm_median": None,
+                    "grad_norm_q95": None,
+                    "grad_norm_rms": None,
+                    "selector_input": False,
+                    "not_quality_or_utility": True,
+                }
+            )
+            continue
+        timestep_rows.append(
+            {
+                "timestep_bin": bin_index,
+                "source_group_count": len(members),
+                "grad_norm_q05": _source_equal_quantile(
+                    members, "grad_norm_noquant", 0.05
+                ),
+                "grad_norm_median": _source_equal_quantile(
+                    members, "grad_norm_noquant", 0.50
+                ),
+                "grad_norm_q95": _source_equal_quantile(
+                    members, "grad_norm_noquant", 0.95
+                ),
+                "grad_norm_rms": rms(members),
+                "selector_input": False,
+                "not_quality_or_utility": True,
+            }
+        )
+    measured_timestep_rows = [
+        row for row in timestep_rows if row.get("grad_norm_rms") is not None
+    ]
+    dominant_bin = min(
+        measured_timestep_rows,
+        key=lambda row: (-float(row["grad_norm_rms"]), int(row["timestep_bin"])),
+    )
+    natural = dict(natural_baseline or {})
+    natural_valid = bool(natural.get("valid"))
+    return {
+        "schema_version": DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+        "metric_definition_version": DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+        "valid": True,
+        "diagnostic_channel": "no_quant_reference_signal_profile",
+        "probe_count": len(probe_rows),
+        "image_count": len({str(row["image_key"]) for row in probe_rows}),
+        "source_group_count": len(rows_by_source),
+        "reference_duplicate_consistency_pass": inconsistent_reference_count == 0,
+        "inconsistent_reference_probe_count": inconsistent_reference_count,
+        "signal_strength": {
+            "grad_norm_q05": _source_equal_quantile(
+                rows_by_source, "grad_norm_noquant", 0.05
+            ),
+            "grad_norm_median": _source_equal_quantile(
+                rows_by_source, "grad_norm_noquant", 0.50
+            ),
+            "grad_norm_q95": _source_equal_quantile(
+                rows_by_source, "grad_norm_noquant", 0.95
+            ),
+            "grad_norm_rms": rms(rows_by_source),
+            "cross_dataset_comparison_scope": (
+                "same canonical model/network/optimizer/precision contract only"
+            ),
+        },
+        "natural_variation": (
+            {
+                "valid": True,
+                "local_body": _optional_finite(natural.get("local_body")),
+                "local_tail": _optional_finite(natural.get("local_tail")),
+                "tail_amplification": _optional_finite(
+                    natural.get("tail_amplification")
+                ),
+                "worst_timestep_bin": natural.get("worst_timestep_bin"),
+            }
+            if natural_valid
+            else {
+                "valid": False,
+                "invalid_reason": natural.get(
+                    "invalid_reason", "natural_gradient_baseline_unavailable"
+                ),
+            }
+        ),
+        "source_load": {
+            "top_source_group": top_source,
+            "top_source_alias": aliases[top_source],
+            "top_source_energy_share": source_shares[top_source],
+            "effective_source_count": effective_count,
+            "effective_source_rate": (
+                effective_count / len(rows_by_source)
+                if effective_count is not None and rows_by_source
+                else None
+            ),
+        },
+        "dominant_timestep_bin_by_gradient_rms": int(dominant_bin["timestep_bin"]),
+        "source_rows": source_rows,
+        "timestep_rows": timestep_rows,
+        "source_alias_map": aliases,
+        "important_limit": (
+            "this describes short local no-quant gradient signals; it does not "
+            "predict convergence, final quality, optimal rank, LR, or epochs"
+        ),
+        "selector_input": False,
+        "not_quality_or_utility": True,
+    }
+
+
+def build_dataset_character_vector(
+    *,
+    score_rows: Sequence[Mapping[str, Any]],
+    local_phenotype: str,
+    source_localization: Mapping[str, Any] | None,
+    no_quant_baseline: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Build independent descriptive channels without a composite score."""
+
+    candidates = [
+        {
+            "candidate": str(row.get("candidate", "")),
+            "range_mul": _candidate_mul(row),
+            "body": _optional_finite(row.get("local_body")),
+            "tail": _optional_finite(row.get("local_tail")),
+            "amplification": _optional_finite(row.get("tail_amplification")),
+        }
+        for row in score_rows
+        if _as_bool(row.get("hard_safety_pass", True))
+    ]
+    candidates = [
+        row
+        for row in candidates
+        if row["range_mul"] is not None
+        and row["body"] is not None
+        and row["tail"] is not None
+    ]
+    candidates.sort(key=lambda row: (float(row["range_mul"]), str(row["candidate"])))
+    alarm_values = [max(float(row["body"]), float(row["tail"])) for row in candidates]
+    if len(candidates) < 2:
+        mul_response = {
+            "label": "insufficient_grid",
+            "endpoint_change": None,
+            "span": None,
+            "heuristic": True,
+        }
+    else:
+        span = max(alarm_values) - min(alarm_values)
+        median = float(np.median(alarm_values))
+        tolerance = max(0.03, 0.05 * median)
+        changes = [
+            alarm_values[index + 1] - alarm_values[index]
+            for index in range(len(alarm_values) - 1)
+        ]
+        minimum_index = min(
+            range(len(alarm_values)),
+            key=lambda index: (alarm_values[index], index),
+        )
+        endpoint_change = alarm_values[-1] - alarm_values[0]
+        if span <= tolerance:
+            label = "flat_within_descriptive_tolerance"
+        elif all(value <= tolerance for value in changes) and endpoint_change < -tolerance:
+            label = "upper_range_reduces_deformation"
+        elif all(value >= -tolerance for value in changes) and endpoint_change > tolerance:
+            label = "lower_range_reduces_deformation"
+        elif (
+            0 < minimum_index < len(alarm_values) - 1
+            and alarm_values[0] > alarm_values[minimum_index] + tolerance
+            and alarm_values[-1] > alarm_values[minimum_index] + tolerance
+        ):
+            label = "interior_valley"
+        else:
+            label = "irregular_or_mixed"
+        mul_response = {
+            "label": label,
+            "endpoint_change": endpoint_change,
+            "span": span,
+            "descriptive_tolerance": tolerance,
+            "minimum_observed_mul": float(candidates[minimum_index]["range_mul"]),
+            "heuristic": True,
+        }
+
+    tail_reference = (
+        min(candidates, key=lambda row: (float(row["tail"]), float(row["range_mul"])))
+        if candidates
+        else None
+    )
+    source_reference = (
+        dict(source_localization.get("reference_profile") or {})
+        if source_localization and source_localization.get("valid")
+        else None
+    )
+    no_quant = (
+        dict(no_quant_baseline)
+        if no_quant_baseline and no_quant_baseline.get("valid")
+        else None
+    )
+    return {
+        "schema_version": DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+        "metric_definition_version": DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+        "diagnostic_channel": "dataset_character_vector",
+        "channels": {
+            "absolute_acceptance": {
+                "local_phenotype": str(local_phenotype),
+                "minimum_body": (
+                    min(float(row["body"]) for row in candidates)
+                    if candidates
+                    else None
+                ),
+                "minimum_tail": (
+                    min(float(row["tail"]) for row in candidates)
+                    if candidates
+                    else None
+                ),
+            },
+            "mul_response": mul_response,
+            "tail_sensitivity": {
+                "reference_rule": "measured_point_tail_min_candidate",
+                "reference_mul": (
+                    float(tail_reference["range_mul"]) if tail_reference else None
+                ),
+                "tail_amplification": (
+                    float(tail_reference["amplification"])
+                    if tail_reference and tail_reference["amplification"] is not None
+                    else None
+                ),
+            },
+            "source_localization": (
+                {
+                    "reference_mul": source_reference.get("range_mul"),
+                    "top_source_share": source_reference.get("top_source_share"),
+                    "effective_source_count": source_reference.get(
+                        "effective_source_count"
+                    ),
+                    "effective_source_rate": source_reference.get(
+                        "effective_source_rate"
+                    ),
+                    "top_source_stable_across_thresholds": source_reference.get(
+                        "top_source_stable_across_thresholds"
+                    ),
+                    "loo_max_tail_reduction_fraction": source_reference.get(
+                        "loo_max_tail_reduction_fraction"
+                    ),
+                }
+                if source_reference
+                else {"available": False}
+            ),
+            "no_quant_stability": (
+                {
+                    "natural_variation": no_quant.get("natural_variation"),
+                    "signal_strength": no_quant.get("signal_strength"),
+                    "source_load": no_quant.get("source_load"),
+                    "dominant_timestep_bin": no_quant.get(
+                        "dominant_timestep_bin_by_gradient_rms"
+                    ),
+                }
+                if no_quant
+                else {"available": False}
+            ),
+        },
+        "single_composite_score": None,
+        "selector_input": False,
+        "not_quality_or_utility": True,
+        "important_limit": (
+            "channels remain separate; this vector is not a quality score, "
+            "training-success prediction, or automatic prescription"
+        ),
+    }

--- a/dq_profile/v24_practical_report.py
+++ b/dq_profile/v24_practical_report.py
@@ -425,6 +425,8 @@ def _local_comparison_confidence(
     loo: Mapping[str, Any] | None,
     detailed_bootstrap: bool,
     absolute_norm_available: bool,
+    source_group_count_total: int | None = None,
+    source_group_coverage_complete: bool = True,
 ) -> dict[str, Any]:
     reasons: list[str] = []
     loo_consistencies = [
@@ -460,6 +462,14 @@ def _local_comparison_confidence(
         reasons.append("測定範囲の端が未解決です")
     if not absolute_norm_available:
         reasons.append("旧runでは絶対gradient normが未記録です")
+    if not source_group_coverage_complete:
+        total = int(source_group_count_total or source_count)
+        if level == "High":
+            level = "Medium"
+        reasons.append(
+            f"全source group {total}群のうち{source_count}群を"
+            "決定的に部分抽出しており、未probe群があります"
+        )
     return {
         "level": level,
         "reasons": reasons,
@@ -557,7 +567,11 @@ def _candidate_explanation(card: Mapping[str, Any]) -> str:
     mul = float(card["range_mul"])
     parts: list[str] = []
     if absolute == "hard_unsafe":
-        return f"mul {mul:.2f}はhard safetyを通過していないため、数値比較の対象外です。"
+        reason = str(card.get("invalid_reason") or "hard_safety_failed")
+        return (
+            f"mul {mul:.2f}はhard safetyを通過していないため、"
+            f"数値比較の対象外です（{reason}）。"
+        )
     if absolute == "unmeasurable":
         parts.append("BodyまたはTailが未測定のため、絶対的な摂動量を分類できません。")
     elif absolute == "high_perturbation":
@@ -700,6 +714,10 @@ def build_dataset_card(
             "range_mul": _candidate_mul(row),
             "grid_role": str(row.get("grid_role", "measured")),
             "hard_safety_pass": hard_safety_pass,
+            "invalid_reason": str(row.get("invalid_reason") or "") or None,
+            "nonfinite_sample_count": int(
+                _optional_float(row.get("nonfinite_sample_count")) or 0
+            ),
             "body": body,
             "body_ci_low": _optional_float(row.get("local_body_ci_low")),
             "body_ci_high": _optional_float(row.get("local_body_ci_high")),
@@ -810,6 +828,28 @@ def build_dataset_card(
             evaluation.get("source_group_count", 0),
         )
     )
+    source_group_count_total = int(
+        detail_summary.get("source_group_count_total", source_count)
+    )
+    source_group_coverage_complete = _as_bool(
+        detail_summary.get(
+            "source_group_coverage_complete",
+            source_count == source_group_count_total,
+        )
+    )
+    source_group_coverage_fraction = _optional_float(
+        detail_summary.get("source_group_coverage_fraction")
+    )
+    if source_group_coverage_fraction is None:
+        source_group_coverage_fraction = source_count / max(
+            source_group_count_total, 1
+        )
+    source_group_selection_policy = str(
+        detail_summary.get(
+            "source_group_selection_policy",
+            "all_source_groups",
+        )
+    )
     image_count = int(
         detail_summary.get(
             "image_count",
@@ -830,6 +870,8 @@ def build_dataset_card(
         loo=loo,
         detailed_bootstrap=bool(bootstrap_rows),
         absolute_norm_available=absolute_norm_available,
+        source_group_count_total=source_group_count_total,
+        source_group_coverage_complete=source_group_coverage_complete,
     )
     if confidence_ceiling == "reduced_descriptive":
         if local_comparison_confidence["level"] == "High":
@@ -1070,6 +1112,11 @@ def build_dataset_card(
         "internal_profile_level": internal_profile_level,
         "metric_definition_version": METRIC_DEFINITION_VERSION,
         "source_group_count": source_count,
+        "source_group_count_probed": source_count,
+        "source_group_count_total": source_group_count_total,
+        "source_group_coverage_complete": source_group_coverage_complete,
+        "source_group_coverage_fraction": source_group_coverage_fraction,
+        "source_group_selection_policy": source_group_selection_policy,
         "image_count": image_count,
         "candidate_grid": [card["range_mul"] for card in cards],
         "candidate_count": len(cards),
@@ -1347,11 +1394,25 @@ def _curve_svg(
     def sy(value: float) -> float:
         return top + plot_h - min(value, y_max) / y_max * plot_h
 
-    def line_points(key: str) -> str:
-        return " ".join(
-            f"{sx(float(card['range_mul'])):.1f},{sy(float(card[key])):.1f}"
-            for card in cards
-            if _optional_float(card.get(key)) is not None
+    def line_segments(key: str, color: str) -> str:
+        segments: list[list[str]] = []
+        current: list[str] = []
+        for card in cards:
+            value = _optional_float(card.get(key))
+            if value is None:
+                if current:
+                    segments.append(current)
+                    current = []
+                continue
+            current.append(
+                f"{sx(float(card['range_mul'])):.1f},{sy(value):.1f}"
+            )
+        if current:
+            segments.append(current)
+        return "".join(
+            f'<polyline points="{" ".join(segment)}" fill="none" '
+            f'stroke="{color}" stroke-width="3"/>'
+            for segment in segments
         )
 
     body_errors = []
@@ -1387,6 +1448,20 @@ def _curve_svg(
         f'y1="{top}" y2="{top+plot_h}" stroke="#7c3aed" stroke-width="2" stroke-dasharray="5 5"/>'
         for card in cards
         if card.get("edge_endpoint")
+    ]
+    unsafe_markers = [
+        (
+            f'<g><line x1="{sx(float(card["range_mul"]))-5:.1f}" '
+            f'x2="{sx(float(card["range_mul"]))+5:.1f}" y1="{top+plot_h/2-5:.1f}" '
+            f'y2="{top+plot_h/2+5:.1f}" stroke="#991b1b" stroke-width="2"/>'
+            f'<line x1="{sx(float(card["range_mul"]))-5:.1f}" '
+            f'x2="{sx(float(card["range_mul"]))+5:.1f}" y1="{top+plot_h/2+5:.1f}" '
+            f'y2="{top+plot_h/2-5:.1f}" stroke="#991b1b" stroke-width="2">'
+            f'<title>mul {float(card["range_mul"]):.2f}: Hard unsafe / 数値比較対象外</title>'
+            "</line></g>"
+        )
+        for card in cards
+        if not card.get("hard_safety_pass")
     ]
     overflow_markers = []
     for card in cards:
@@ -1463,11 +1538,12 @@ def _curve_svg(
   {reference_line}
   {''.join(preset_lines)}
   {''.join(edge_lines)}
+  {''.join(unsafe_markers)}
   {''.join(overflow_markers)}
   {''.join(body_errors)}
   {''.join(tail_errors)}
-  <polyline points="{line_points('body')}" fill="none" stroke="#2563eb" stroke-width="3"/>
-  <polyline points="{line_points('tail')}" fill="none" stroke="#d97706" stroke-width="3"/>
+  {line_segments('body', '#2563eb')}
+  {line_segments('tail', '#d97706')}
   {''.join(f'<circle cx="{sx(float(card["range_mul"])):.1f}" cy="{sy(float(card["body"])):.1f}" r="4" fill="#2563eb"/>' for card in cards if card.get("body") is not None)}
   {''.join(f'<rect x="{sx(float(card["range_mul"]))-4:.1f}" y="{sy(float(card["tail"]))-4:.1f}" width="8" height="8" fill="#d97706"/>' for card in cards if card.get("tail") is not None)}
   {''.join(x_ticks)}
@@ -2069,7 +2145,7 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
         <div><span>Measurement contract</span><strong>{html.escape(dataset["measurement_contract"])}</strong></div>
         <div><span>Sampling depth</span><strong>{html.escape(sampling_depth_label)}</strong></div>
         <div><span>Internal profile level</span><strong>{html.escape(dataset["internal_profile_level"])}</strong></div>
-        <div><span>Source groups</span><strong>{dataset["source_group_count"]}</strong></div>
+        <div><span>Source groups (probe / total)</span><strong>{dataset["source_group_count_probed"]} / {dataset["source_group_count_total"]}</strong></div>
         <div><span>Images</span><strong>{dataset["image_count"]}</strong></div>
         <div><span>Hard safety</span><strong>{"PASS" if dataset["hard_safety_all_pass"] else "FAIL"}</strong></div>
         <div><span>Measurement QA</span><strong>{html.escape(dataset["measurement_quality"]["level"])}</strong></div>

--- a/dq_profile/v24_practical_report.py
+++ b/dq_profile/v24_practical_report.py
@@ -15,13 +15,13 @@ import math
 from typing import Any, Mapping, Sequence
 
 
-PRACTICAL_REPORT_SCHEMA_VERSION = "2.4.2-practical-report-prototype"
+PRACTICAL_REPORT_SCHEMA_VERSION = "2.4.3-practical-report-beta"
 LOCAL_ACCEPTANCE_METRIC_VERSION = "2.4.0"
 
 # Compatibility aliases retained for existing report readers.
 SCHEMA_VERSION = PRACTICAL_REPORT_SCHEMA_VERSION
 METRIC_DEFINITION_VERSION = LOCAL_ACCEPTANCE_METRIC_VERSION
-REPORT_CONTRACT_VERSION = "1.2.0-prototype"
+REPORT_CONTRACT_VERSION = "1.3.0-beta"
 ABSOLUTE_REFERENCE_DISTANCE = 1.0
 AFFINITY_FIXED_Y_MAX = 4.0
 AFFINITY_SCALE_CALIBRATION = {
@@ -195,6 +195,14 @@ def report_contract() -> dict[str, Any]:
             "natural_baseline": (
                 "scale context only; never used as selector evidence"
             ),
+        },
+        "execution_mode": {
+            "field": "execution_mode",
+            "qa_depth_field": "qa_depth",
+            "internal_profile_level_field": "internal_profile_level",
+            "standard": "daily fixed-grid run with short prefix smoke",
+            "strict": "reference-depth run with long prefix and bounded edge extension",
+            "mode_is_not_internal_profile_level": True,
         },
         "relative_statuses": [
             "near_best_plateau",
@@ -772,14 +780,20 @@ def build_dataset_card(
         if gates_required
         else None
     )
+    detail_summary = dict(detail.get("summary") or {})
+    execution_mode = str(detail_summary.get("execution_mode", "strict"))
+    qa_depth = str(detail_summary.get("qa_depth", "strict_reference"))
+    internal_profile_level = str(
+        detail_summary.get("internal_profile_level", "standard")
+    )
     source_count = int(
-        detail.get("summary", {}).get(
+        detail_summary.get(
             "source_group_count",
             evaluation.get("source_group_count", 0),
         )
     )
     image_count = int(
-        detail.get("summary", {}).get(
+        detail_summary.get(
             "image_count",
             evaluation.get("image_count", 0),
         )
@@ -804,7 +818,7 @@ def build_dataset_card(
         edge_unresolved=edge_unresolved,
     )
     phenotype = str(
-        detail.get("summary", {}).get(
+        detail_summary.get(
             "local_phenotype",
             evaluation.get("phenotype", "unknown"),
         )
@@ -899,6 +913,14 @@ def build_dataset_card(
         if stronger_perturbation
         else None
     )
+    preset_nearest_reference = (
+        min(
+            hard_safety_pass_candidates,
+            key=lambda card: (abs(card["range_mul"] - 3.205), card["range_mul"]),
+        )
+        if hard_safety_pass_candidates
+        else None
+    )
     absolute_levels = {
         card["absolute_perturbation"] for card in hard_safety_pass_candidates
     }
@@ -945,9 +967,13 @@ def build_dataset_card(
             "no_quant",
             f"mul {single_representative['range_mul']:.2f}（暫定代表）",
         ]
+    elif representative_selection_state == "no_single_edge_unresolved":
+        minimum_comparison_set = ["no_quant"] + [
+            f"mul {card['range_mul']:.2f}（Fidelity retained）"
+            for card in fidelity_retained
+        ]
     elif (
-        representative_selection_state
-        in {"no_single_body_tail_tradeoff", "no_single_edge_unresolved"}
+        representative_selection_state == "no_single_body_tail_tradeoff"
         and body_representative
         and tail_representative
     ):
@@ -1012,6 +1038,9 @@ def build_dataset_card(
             if detail
             else "common_core_summary_only"
         ),
+        "execution_mode": execution_mode,
+        "qa_depth": qa_depth,
+        "internal_profile_level": internal_profile_level,
         "metric_definition_version": METRIC_DEFINITION_VERSION,
         "source_group_count": source_count,
         "image_count": image_count,
@@ -1070,6 +1099,11 @@ def build_dataset_card(
         "stronger_representative_mul": (
             stronger_representative["range_mul"]
             if stronger_representative
+            else None
+        ),
+        "preset_nearest_reference_mul": (
+            preset_nearest_reference["range_mul"]
+            if preset_nearest_reference
             else None
         ),
         "actions": actions,
@@ -1850,16 +1884,29 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
         if max_measured_mul >= 3.7
         else ""
     )
+    execution_mode_label = {
+        "standard": "Standard",
+        "strict": "Strict",
+    }.get(str(dataset.get("execution_mode")), str(dataset.get("execution_mode", "unknown")))
+    qa_depth_label = {
+        "standard_smoke": "Standard smoke",
+        "strict_reference": "Strict reference",
+    }.get(str(dataset.get("qa_depth")), str(dataset.get("qa_depth", "unknown")))
     return f"""
 <article id="dataset-{html.escape(dataset["dataset_id"])}" class="view dataset-view"{hidden}>
   <section class="dataset-intro">
     <div class="dataset-intro-main">
-      <div class="eyebrow">Dataset diagnostic card ・ {html.escape(dataset["protocol_scope"])}</div>
+      <div class="eyebrow">Dataset diagnostic card ・ {html.escape(dataset["protocol_scope"])} ・ {html.escape(execution_mode_label)}</div>
       <h1>{html.escape(dataset["label"])}</h1>
       <div class="tag-row">{tag_html}</div>
       <p class="lead">{html.escape(edge_message)}</p>
     </div>
     <div class="evidence-strip" aria-label="証拠の状態">
+      <div class="evidence-chip">
+        <span>Execution / QA depth</span>
+        <strong>{html.escape(execution_mode_label)}</strong>
+        <span>{html.escape(qa_depth_label)}</span>
+      </div>
       <div class="evidence-chip">
         <span>Measurement QA</span>
         <strong>{html.escape(dataset["measurement_quality"]["level"])}</strong>
@@ -1977,6 +2024,9 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
       <summary>QA / provenance</summary>
       <div class="qa-grid">
         <div><span>Protocol</span><strong>{html.escape(dataset["metric_definition_version"])}</strong></div>
+        <div><span>Execution mode</span><strong>{html.escape(execution_mode_label)}</strong></div>
+        <div><span>QA depth</span><strong>{html.escape(qa_depth_label)}</strong></div>
+        <div><span>Internal profile level</span><strong>{html.escape(dataset["internal_profile_level"])}</strong></div>
         <div><span>Source groups</span><strong>{dataset["source_group_count"]}</strong></div>
         <div><span>Images</span><strong>{dataset["image_count"]}</strong></div>
         <div><span>Hard safety</span><strong>{"PASS" if dataset["hard_safety_all_pass"] else "FAIL"}</strong></div>
@@ -2068,7 +2118,7 @@ def render_report(model: Mapping[str, Any]) -> str:
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>SDXL DQ 診断カルテ v2.4.2 prototype</title>
+<title>SDXL DQ 診断カルテ v2.4.3 beta</title>
 <style>
 :root{{--ink:#172033;--muted:#607086;--line:#d9e1ec;--paper:#f5f7fb;--card:#fff;--blue:#2563eb;--blue-soft:#eaf1ff;--orange:#d97706;--orange-soft:#fff4e2;--purple:#7c3aed;--purple-soft:#f2ebff;--teal:#0f766e;--shadow:0 12px 34px rgba(25,38,70,.09)}}
 *{{box-sizing:border-box}} body{{margin:0;background:var(--paper);color:var(--ink);font:15px/1.65 system-ui,-apple-system,"Segoe UI","Yu Gothic UI",sans-serif}}
@@ -2082,7 +2132,7 @@ h1{{font-size:clamp(28px,4vw,48px);line-height:1.08;margin:5px 0 14px}} h2{{font
 .eyebrow{{font-size:12px;text-transform:uppercase;letter-spacing:.12em;color:#65758c;font-weight:800}} .lead{{font-size:17px;color:#3e4d62;max-width:72ch}}
 .dataset-intro{{display:grid;grid-template-columns:minmax(0,1.45fr) minmax(380px,1fr);gap:20px;align-items:center;background:linear-gradient(130deg,#fff 0%,#f2f6ff 100%);padding:17px 22px;border:1px solid var(--line);border-radius:16px;box-shadow:var(--shadow)}}
 .dataset-intro h1{{font-size:clamp(25px,3vw,36px);margin:3px 0 9px}} .dataset-intro .lead{{font-size:14px;margin:8px 0 0}}
-.evidence-strip{{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}} .evidence-chip{{display:grid;gap:2px;min-width:0;padding:10px 11px;background:white;border:1px solid var(--line);border-radius:10px}} .evidence-chip span{{font-size:10px;color:var(--muted);font-weight:750}} .evidence-chip strong{{font-size:17px;color:var(--purple);overflow-wrap:anywhere}}
+.evidence-strip{{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}} .evidence-chip{{display:grid;gap:2px;min-width:0;padding:10px 11px;background:white;border:1px solid var(--line);border-radius:10px}} .evidence-chip span{{font-size:10px;color:var(--muted);font-weight:750}} .evidence-chip strong{{font-size:17px;color:var(--purple);overflow-wrap:anywhere}}
 .section-heading-inline{{display:flex;justify-content:space-between;gap:16px;align-items:end;margin:0 0 8px}} .section-heading-inline h2{{margin:0}} .section-heading-inline p{{margin:3px 0 0}}
 .scale-badge{{white-space:nowrap;border-radius:999px;padding:6px 11px;background:#e8eef8;color:#334155;font-size:12px;font-weight:800}}
 .primary-chart{{padding:10px 18px 14px}} .primary-chart>.chart{{width:100%;height:315px;max-width:1040px;margin:0 auto}} .primary-chart details .chart{{max-height:390px}}
@@ -2112,16 +2162,16 @@ details{{background:white;border:1px solid var(--line);border-radius:12px;paddin
 .overview-hero{{background:linear-gradient(135deg,#172554,#1e3a8a);color:white;border-radius:18px;padding:32px}} .overview-hero .eyebrow,.overview-hero .lead{{color:#d8e5ff}} .overview-kpis{{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-top:20px}} .overview-kpis>div{{background:rgba(255,255,255,.1);padding:14px;border:1px solid rgba(255,255,255,.18);border-radius:11px}} .overview-kpis strong{{display:block;font-size:27px}}
 .link-button{{border:0;background:none;color:#1d4ed8;text-decoration:underline;cursor:pointer;padding:0;font:inherit}} .dataset-selector.is-single{{display:none}} footer{{color:var(--muted);font-size:12px;padding-top:30px}}
 @media(max-width:900px){{.hero,.dataset-intro,.chart-grid,.matrix-grid{{grid-template-columns:1fr}}.summary-grid,.callout-grid,.overview-kpis{{grid-template-columns:repeat(2,1fr)}}.dataset-grid{{grid-template-columns:1fr 1fr}}.dataset-intro{{gap:12px}}}}
-@media(max-width:580px){{main{{padding:12px 10px 55px}}.header-inner{{padding:9px 12px;align-items:flex-start;flex-direction:column}}.summary-grid,.callout-grid,.overview-kpis,.dataset-grid,.qa-grid,.qa-reason-grid,.representative-grid,.interpretation-strip{{grid-template-columns:1fr}}.evidence-strip{{grid-template-columns:repeat(3,minmax(0,1fr))}}.dataset-intro{{padding:13px}}.dataset-intro h1{{font-size:24px}}.evidence-chip{{padding:7px}}.evidence-chip strong{{font-size:13px}}.section-heading-inline{{align-items:flex-start;flex-direction:column;gap:6px}}.primary-chart{{padding:8px}}.primary-chart>.chart{{height:250px}}}}
+@media(max-width:580px){{main{{padding:12px 10px 55px}}.header-inner{{padding:9px 12px;align-items:flex-start;flex-direction:column}}.summary-grid,.callout-grid,.overview-kpis,.dataset-grid,.qa-grid,.qa-reason-grid,.representative-grid,.interpretation-strip{{grid-template-columns:1fr}}.evidence-strip{{grid-template-columns:repeat(2,minmax(0,1fr))}}.dataset-intro{{padding:13px}}.dataset-intro h1{{font-size:24px}}.evidence-chip{{padding:7px}}.evidence-chip strong{{font-size:13px}}.section-heading-inline{{align-items:flex-start;flex-direction:column;gap:6px}}.primary-chart{{padding:8px}}.primary-chart>.chart{{height:250px}}}}
 @media print{{header{{position:static}}.view[hidden]{{display:block!important;page-break-before:always}}button,select{{display:none}}body{{background:white}}main{{max-width:none}}}}
 </style>
 </head>
 <body>
-<header><div class="header-inner"><div class="brand">SDXL DQ 診断カルテ <small>v2.4.2 practical report prototype ・ Safety/Fidelity ≠ Utility</small></div><label class="{selector_class}">表示 <select id="dataset-select"><option value="overview"{overview_selected}>横断概要</option>{options}</select></label></div></header>
+<header><div class="header-inner"><div class="brand">SDXL DQ 診断カルテ <small>v2.4.3 practical report beta ・ Safety/Fidelity ≠ Utility</small></div><label class="{selector_class}">表示 <select id="dataset-select"><option value="overview"{overview_selected}>横断概要</option>{options}</select></label></div></header>
 <main>
 <section id="overview" class="view"{overview_hidden}>
   <div class="overview-hero">
-    <div class="eyebrow">Practical diagnostic report prototype</div>
+    <div class="eyebrow">Practical diagnostic report beta</div>
     <h1>結論から詳細へ潜れる、mul別の診断カルテ</h1>
     <p class="lead">数学基準1.0に対する絶対的な摂動帯と、同じdataset内の相対順位を分けて表示します。最終画質のbest mulや量子化採用可否は判定しません。</p>
     <div class="overview-kpis">
@@ -2141,7 +2191,7 @@ details{{background:white;border:1px solid var(--line);border-radius:12px;paddin
   <h2>同一mul 3.45の横断比較</h2>
   <p class="section-help">metric definition 2.4の共通coreだけを比較。同じmulでもTailがdatasetごとに大きく異なることを確認できます。</p>
   <div class="table-wrap"><table><thead><tr><th>Dataset</th><th>Body</th><th>Tail</th><th>Local gauge</th><th>絶対摂動</th><th>相対状態</th><th>Measurement QA</th><th>Local confidence</th></tr></thead><tbody>{common_rows}</tbody></table></div>
-  <h2>このprototypeで確認すること</h2>
+  <h2>このレポートで確認すること</h2>
   <div class="action-box"><ol><li>30秒で絶対摂動帯、Fidelity retained set、強い摂動候補、edgeが分かるか。</li><li>各mulの絶対値と相対状態を混同しないか。</li><li>Measurement QA・Local confidence・Recommendation maturityを混同しないか。</li><li>単一代表を選べない場合に、その理由が明示されるか。</li><li>初心者説明からbootstrap・source LOOまで段階的に潜れるか。</li></ol></div>
 </section>
 {dataset_sections}

--- a/dq_profile/v24_practical_report.py
+++ b/dq_profile/v24_practical_report.py
@@ -15,13 +15,13 @@ import math
 from typing import Any, Mapping, Sequence
 
 
-PRACTICAL_REPORT_SCHEMA_VERSION = "2.4.3-practical-report-beta"
+PRACTICAL_REPORT_SCHEMA_VERSION = "2.4.4-practical-report-beta"
 LOCAL_ACCEPTANCE_METRIC_VERSION = "2.4.0"
 
 # Compatibility aliases retained for existing report readers.
 SCHEMA_VERSION = PRACTICAL_REPORT_SCHEMA_VERSION
 METRIC_DEFINITION_VERSION = LOCAL_ACCEPTANCE_METRIC_VERSION
-REPORT_CONTRACT_VERSION = "1.3.0-beta"
+REPORT_CONTRACT_VERSION = "1.4.0-beta"
 ABSOLUTE_REFERENCE_DISTANCE = 1.0
 AFFINITY_FIXED_Y_MAX = 4.0
 AFFINITY_SCALE_CALIBRATION = {
@@ -194,6 +194,12 @@ def report_contract() -> dict[str, Any]:
             ),
             "natural_baseline": (
                 "scale context only; never used as selector evidence"
+            ),
+            "source_localization": (
+                "descriptive Tail localization only; never used as selector evidence"
+            ),
+            "dataset_character_vector": (
+                "independent descriptive channels with no composite score"
             ),
         },
         "execution_mode": {
@@ -860,6 +866,38 @@ def build_dataset_card(
             evaluation.get("image_count", 0),
         )
     )
+    image_count_probed = int(
+        detail_summary.get("image_count_probed", image_count)
+    )
+    image_count_total = int(
+        detail_summary.get("image_count_total", image_count_probed)
+    )
+    image_coverage_fraction = _optional_float(
+        detail_summary.get("image_coverage_fraction")
+    )
+    if image_coverage_fraction is None:
+        image_coverage_fraction = image_count_probed / max(image_count_total, 1)
+    image_coverage_complete = _as_bool(
+        detail_summary.get(
+            "image_coverage_complete",
+            image_count_probed == image_count_total,
+        )
+    )
+    source_localization = dict(
+        detail.get("source_localization")
+        or detail_summary.get("source_localization")
+        or {}
+    )
+    no_quant_baseline_profile = dict(
+        detail.get("no_quant_baseline_profile")
+        or detail_summary.get("no_quant_baseline_profile")
+        or {}
+    )
+    dataset_character_vector = dict(
+        detail.get("dataset_character_vector")
+        or detail_summary.get("dataset_character_vector")
+        or {}
+    )
     absolute_norm_available = _as_bool(
         evaluation.get("absolute_gradient_norm_available", True)
     )
@@ -1122,6 +1160,10 @@ def build_dataset_card(
         "source_group_coverage_fraction": source_group_coverage_fraction,
         "source_group_selection_policy": source_group_selection_policy,
         "image_count": image_count,
+        "image_count_probed": image_count_probed,
+        "image_count_total": image_count_total,
+        "image_coverage_fraction": image_coverage_fraction,
+        "image_coverage_complete": image_coverage_complete,
         "candidate_grid": [card["range_mul"] for card in cards],
         "candidate_count": len(cards),
         "hard_safety_pass_count": len(hard_safety_pass_candidates),
@@ -1186,6 +1228,9 @@ def build_dataset_card(
         ),
         "actions": actions,
         "natural_baseline": natural,
+        "source_localization": source_localization,
+        "no_quant_baseline_profile": no_quant_baseline_profile,
+        "dataset_character_vector": dataset_character_vector,
         "pairwise": pairwise,
         "source_loo": loo,
         "timestep_rows": list(detail.get("timestep_rows") or []),
@@ -1909,6 +1954,98 @@ def _overview_behavior_table(datasets: Sequence[Mapping[str, Any]]) -> str:
     )
 
 
+def _dataset_character_profile_html(dataset: Mapping[str, Any]) -> str:
+    vector = dict(dataset.get("dataset_character_vector") or {})
+    channels = dict(vector.get("channels") or {})
+    localization = dict(dataset.get("source_localization") or {})
+    no_quant = dict(dataset.get("no_quant_baseline_profile") or {})
+    if not channels and not localization.get("valid") and not no_quant.get("valid"):
+        return (
+            '<p class="muted">この保存済みrunには追加のdataset character '
+            'channelがありません。</p>'
+        )
+
+    mul_labels = {
+        "flat_within_descriptive_tolerance": "測定範囲ではほぼ平坦",
+        "upper_range_reduces_deformation": "mulを上げるほど摂動が減る傾向",
+        "lower_range_reduces_deformation": "mulを下げるほど摂動が減る傾向",
+        "interior_valley": "中間mulに谷がある",
+        "irregular_or_mixed": "単調でない／混合型",
+        "insufficient_grid": "grid不足",
+    }
+    response = dict(channels.get("mul_response") or {})
+    response_label = mul_labels.get(
+        str(response.get("label")),
+        str(response.get("label") or "未測定"),
+    )
+    source_ref = dict(localization.get("reference_profile") or {})
+    no_quant_signal = dict(no_quant.get("signal_strength") or {})
+    no_quant_load = dict(no_quant.get("source_load") or {})
+    natural = dict(no_quant.get("natural_variation") or {})
+    dominant_bin = no_quant.get("dominant_timestep_bin_by_gradient_rms")
+    dominant_label = "未測定"
+    if dominant_bin is not None:
+        bin_index = int(dominant_bin)
+        bin_text, noise_text = TIMESTEP_BIN_LABELS.get(
+            bin_index, (str(bin_index), "")
+        )
+        dominant_label = f"bin {bin_index} ({bin_text}, {noise_text})"
+
+    localization_rows = "".join(
+        "<tr>"
+        f'<th scope="row">{_fmt(row.get("range_mul"), 2)}</th>'
+        f'<td>{_fmt(row.get("local_tail"))}</td>'
+        f'<td>{html.escape(str(row.get("top_source_alias") or "—"))}</td>'
+        f'<td>{_pct(row.get("top_source_share"))}</td>'
+        f'<td>{_fmt(row.get("effective_source_count"), 2)}</td>'
+        f'<td>{"安定" if _as_bool(row.get("top_source_stable_across_thresholds")) else "変動"}</td>'
+        f'<td>{html.escape(str(row.get("loo_most_actionable_source_alias") or "—"))}</td>'
+        f'<td>{_pct(row.get("loo_max_tail_reduction_fraction"))}</td>'
+        "</tr>"
+        for row in localization.get("candidate_profiles", [])
+    )
+    localization_table = (
+        '<div class="table-wrap"><table><thead><tr><th>mul</th>'
+        '<th>絶対Tail</th><th>最大負担source</th><th>集中率</th><th>実効source数</th>'
+        '<th>q85/90/95</th><th>LOOで最も効くsource</th><th>Tail低下率</th>'
+        f'</tr></thead><tbody>{localization_rows}</tbody></table></div>'
+        if localization_rows
+        else '<p class="muted">source localizationは利用できません。</p>'
+    )
+    coverage_warning = (
+        "全画像をprobeしています。"
+        if dataset.get("image_coverage_complete")
+        else "未probe画像があるため、この体質記述は測定subsetの範囲です。"
+    )
+    return f"""
+<div class="callout-grid">
+  <div><strong>mul応答</strong><br>{html.escape(response_label)}<div class="micro">単一の合成点にはしません。</div></div>
+  <div><strong>Source集中度</strong><br>top {html.escape(str(source_ref.get('top_source_alias') or '—'))}: {_pct(source_ref.get('top_source_share'))}<br>実効source数 {_fmt(source_ref.get('effective_source_count'), 2)}</div>
+  <div><strong>no_quant信号</strong><br>norm中央値 {_fmt(no_quant_signal.get('grad_norm_median'))}<br>q05–q95 {_fmt(no_quant_signal.get('grad_norm_q05'))}–{_fmt(no_quant_signal.get('grad_norm_q95'))}</div>
+  <div><strong>画像カバレッジ</strong><br>{dataset.get('image_count_probed', dataset.get('image_count', 0))} / {dataset.get('image_count_total', dataset.get('image_count', 0))} ({_pct(dataset.get('image_coverage_fraction'))})<div class="micro">{html.escape(coverage_warning)}</div></div>
+</div>
+<details open>
+  <summary>量子化Tailのsource集中（説明専用）</summary>
+  <p class="section-help">各mulのTail負担が一部sourceへ寄るかを、source等重みのq85/q90/q95で確認します。Sxxは匿名aliasです。絶対Tailが小さい場合、高い集中率だけで危険とは判断しません。また「最大負担source」と「外すとTailが最も下がるsource」は別概念です。</p>
+  {localization_table}
+</details>
+<details>
+  <summary>no_quant自身の短期勾配プロファイル（説明専用）</summary>
+  <div class="qa-grid">
+    <div><span>Gradient norm q05</span><strong>{_fmt(no_quant_signal.get('grad_norm_q05'))}</strong></div>
+    <div><span>Gradient norm median</span><strong>{_fmt(no_quant_signal.get('grad_norm_median'))}</strong></div>
+    <div><span>Gradient norm q95</span><strong>{_fmt(no_quant_signal.get('grad_norm_q95'))}</strong></div>
+    <div><span>Gradient norm RMS</span><strong>{_fmt(no_quant_signal.get('grad_norm_rms'))}</strong></div>
+    <div><span>Top source energy</span><strong>{html.escape(str(no_quant_load.get('top_source_alias') or '—'))} / {_pct(no_quant_load.get('top_source_energy_share'))}</strong></div>
+    <div><span>Effective sources</span><strong>{_fmt(no_quant_load.get('effective_source_count'), 2)}</strong></div>
+    <div><span>Dominant timestep</span><strong>{html.escape(dominant_label)}</strong></div>
+    <div><span>Natural Body / Tail</span><strong>{_fmt(natural.get('local_body'))} / {_fmt(natural.get('local_tail'))}</strong></div>
+  </div>
+  <p class="micro">短いno_quant probeの信号規模と偏りです。収束速度、最終画質、rank、LR、epoch数は予測しません。同じmodel・network・precision契約のrun同士でのみ比較してください。</p>
+</details>
+"""
+
+
 def _dataset_section(
     dataset: Mapping[str, Any],
     *,
@@ -2103,7 +2240,13 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
   </section>
 
   <section>
-    <h2>3. 詳細診断</h2>
+    <h2>3. Dataset character profile</h2>
+    <p class="section-help">すでに測定した勾配から、dataset固有の偏りを複数の独立channelで記述します。候補選択への追加票や画質スコアには使いません。</p>
+    {_dataset_character_profile_html(dataset)}
+  </section>
+
+  <section>
+    <h2>4. 詳細診断</h2>
     <div class="chart-card">
       <h3>Tailの原因分解</h3>
       <p class="section-help">symmetric、方向回転（angle）、勾配gain変化を説明用に表示します。候補選定の追加票にはしません。</p>
@@ -2128,7 +2271,7 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
   </section>
 
   <section>
-    <h2>4. 推奨アクション</h2>
+    <h2>5. 推奨アクション</h2>
     <div class="action-box">
       <p><strong>安定性重視:</strong> no_quantを必ず残し、Fidelity retained setを比較対象にします。</p>
       <p><strong>正則化の違いを探索:</strong> hard-safeだが候補内でより強い摂動の点を、「画質的に良い」と断言せず比較へ追加できます。</p>
@@ -2139,7 +2282,7 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
   </section>
 
   <section>
-    <h2>5. 測定品質</h2>
+    <h2>6. 測定品質</h2>
     <details>
       <summary>QA / provenance</summary>
       <div class="qa-grid">
@@ -2150,7 +2293,8 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
         <div><span>Sampling depth</span><strong>{html.escape(sampling_depth_label)}</strong></div>
         <div><span>Internal profile level</span><strong>{html.escape(dataset["internal_profile_level"])}</strong></div>
         <div><span>Source groups (probe / total)</span><strong>{dataset["source_group_count_probed"]} / {dataset["source_group_count_total"]}</strong></div>
-        <div><span>Images</span><strong>{dataset["image_count"]}</strong></div>
+        <div><span>Images (probe / total)</span><strong>{dataset["image_count_probed"]} / {dataset["image_count_total"]}</strong></div>
+        <div><span>Image coverage</span><strong>{_pct(dataset["image_coverage_fraction"])}</strong></div>
         <div><span>Hard safety</span><strong>{"PASS" if dataset["hard_safety_all_pass"] else "FAIL"}</strong></div>
         <div><span>Measurement QA</span><strong>{html.escape(dataset["measurement_quality"]["level"])}</strong></div>
         <div><span>Local confidence</span><strong>{html.escape(dataset["local_comparison_confidence"]["level"])}</strong></div>

--- a/dq_profile/v24_practical_report.py
+++ b/dq_profile/v24_practical_report.py
@@ -200,6 +200,12 @@ def report_contract() -> dict[str, Any]:
             "field": "execution_mode",
             "qa_depth_field": "qa_depth",
             "internal_profile_level_field": "internal_profile_level",
+            "measurement_contract_field": "measurement_contract",
+            "sampling_depth_field": "sampling_depth",
+            "quick": (
+                "explicit reduced-sampling run with short prefix smoke, one "
+                "standalone snapshot, and the fixed five-point grid"
+            ),
             "standard": "daily fixed-grid run with short prefix smoke",
             "strict": "reference-depth run with long prefix and bounded edge extension",
             "mode_is_not_internal_profile_level": True,
@@ -783,6 +789,17 @@ def build_dataset_card(
     detail_summary = dict(detail.get("summary") or {})
     execution_mode = str(detail_summary.get("execution_mode", "strict"))
     qa_depth = str(detail_summary.get("qa_depth", "strict_reference"))
+    measurement_contract = str(
+        detail_summary.get("measurement_contract", "local-body-tail-v1")
+    )
+    sampling_depth = str(
+        detail_summary.get("sampling_depth", "reference_32_image")
+    )
+    confidence_ceiling = str(
+        detail_summary.get(
+            "confidence_ceiling", "data_driven_up_to_high"
+        )
+    )
     internal_profile_level = str(
         detail_summary.get("internal_profile_level", "standard")
     )
@@ -813,6 +830,12 @@ def build_dataset_card(
         detailed_bootstrap=bool(bootstrap_rows),
         absolute_norm_available=absolute_norm_available,
     )
+    if confidence_ceiling == "reduced_descriptive":
+        if local_comparison_confidence["level"] == "High":
+            local_comparison_confidence["level"] = "Medium"
+        local_comparison_confidence["reasons"].append(
+            "Quickは最大16画像の縮小samplingであり、Standardと同じ証拠量ではありません"
+        )
     recommendation_maturity = _recommendation_maturity(
         trajectory_available=trajectory_available,
         edge_unresolved=edge_unresolved,
@@ -1040,6 +1063,9 @@ def build_dataset_card(
         ),
         "execution_mode": execution_mode,
         "qa_depth": qa_depth,
+        "measurement_contract": measurement_contract,
+        "sampling_depth": sampling_depth,
+        "confidence_ceiling": confidence_ceiling,
         "internal_profile_level": internal_profile_level,
         "metric_definition_version": METRIC_DEFINITION_VERSION,
         "source_group_count": source_count,
@@ -1885,13 +1911,22 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
         else ""
     )
     execution_mode_label = {
+        "quick": "Quick",
         "standard": "Standard",
         "strict": "Strict",
     }.get(str(dataset.get("execution_mode")), str(dataset.get("execution_mode", "unknown")))
     qa_depth_label = {
+        "quick_smoke": "Quick smoke",
         "standard_smoke": "Standard smoke",
         "strict_reference": "Strict reference",
     }.get(str(dataset.get("qa_depth")), str(dataset.get("qa_depth", "unknown")))
+    sampling_depth_label = {
+        "reduced_16_image": "Reduced (max 16 images)",
+        "reference_32_image": "Reference (max 32 images)",
+    }.get(
+        str(dataset.get("sampling_depth")),
+        str(dataset.get("sampling_depth", "unknown")),
+    )
     return f"""
 <article id="dataset-{html.escape(dataset["dataset_id"])}" class="view dataset-view"{hidden}>
   <section class="dataset-intro">
@@ -1910,6 +1945,10 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
       <div class="evidence-chip">
         <span>Measurement QA</span>
         <strong>{html.escape(dataset["measurement_quality"]["level"])}</strong>
+      </div>
+      <div class="evidence-chip">
+        <span>Sampling depth</span>
+        <strong>{html.escape(sampling_depth_label)}</strong>
       </div>
       <div class="evidence-chip">
         <span>Local比較</span>
@@ -2026,6 +2065,8 @@ Tail {html.escape(str(loo["tail"]["modal_candidate"]))}（{loo["tail"]["modal_co
         <div><span>Protocol</span><strong>{html.escape(dataset["metric_definition_version"])}</strong></div>
         <div><span>Execution mode</span><strong>{html.escape(execution_mode_label)}</strong></div>
         <div><span>QA depth</span><strong>{html.escape(qa_depth_label)}</strong></div>
+        <div><span>Measurement contract</span><strong>{html.escape(dataset["measurement_contract"])}</strong></div>
+        <div><span>Sampling depth</span><strong>{html.escape(sampling_depth_label)}</strong></div>
         <div><span>Internal profile level</span><strong>{html.escape(dataset["internal_profile_level"])}</strong></div>
         <div><span>Source groups</span><strong>{dataset["source_group_count"]}</strong></div>
         <div><span>Images</span><strong>{dataset["image_count"]}</strong></div>

--- a/dq_profile/v24_practical_report.py
+++ b/dq_profile/v24_practical_report.py
@@ -202,6 +202,7 @@ def report_contract() -> dict[str, Any]:
             "internal_profile_level_field": "internal_profile_level",
             "measurement_contract_field": "measurement_contract",
             "sampling_depth_field": "sampling_depth",
+            "confidence_ceiling_field": "confidence_ceiling",
             "quick": (
                 "explicit reduced-sampling run with short prefix smoke, one "
                 "standalone snapshot, and the fixed five-point grid"

--- a/dq_profile/v24_practical_report.py
+++ b/dq_profile/v24_practical_report.py
@@ -1763,10 +1763,22 @@ def _candidate_table(dataset: Mapping[str, Any]) -> str:
     return "".join(rows)
 
 
-def _mark(active: bool) -> str:
-    if active:
-        return '<span class="matrix-mark on" aria-label="該当">○</span>'
-    return '<span class="matrix-mark off" aria-label="非該当">—</span>'
+def _mark(active: bool, *, kind: str = "pattern") -> str:
+    if not active:
+        return '<span class="matrix-mark off" aria-label="非該当">—</span>'
+    symbol, label = {
+        "pass": ("✓", "安全確認を通過"),
+        "retained": ("✓", "候補集合に保持"),
+        "attention": ("注意", "注意が必要な特徴に該当"),
+        "danger": ("!", "要確認の状態に該当"),
+        "representative": ("★", "数値上の代表"),
+        "pattern": ("●", "診断パターンに該当"),
+    }.get(kind, ("●", "診断パターンに該当"))
+    return (
+        f'<span class="matrix-mark {html.escape(kind)}" '
+        f'aria-label="{html.escape(label)}" title="{html.escape(label)}">'
+        f"{html.escape(symbol)}</span>"
+    )
 
 
 def _dataset_behavior_table(dataset: Mapping[str, Any]) -> str:
@@ -1793,6 +1805,7 @@ def _dataset_behavior_table(dataset: Mapping[str, Any]) -> str:
             "全候補が低摂動",
             "全候補でBody・Tailとも基準1.0未満。",
             "全測定mul",
+            "pattern",
         ),
         (
             "all_tail_attention",
@@ -1800,6 +1813,7 @@ def _dataset_behavior_table(dataset: Mapping[str, Any]) -> str:
             "全候補でTail注意",
             "通常域のBodyは1未満だが、厳しいtimestep帯のTailは1以上。",
             "全測定mul",
+            "attention",
         ),
         (
             "all_high_perturbation",
@@ -1807,6 +1821,7 @@ def _dataset_behavior_table(dataset: Mapping[str, Any]) -> str:
             "全候補が高摂動",
             "全候補でBodyが基準1.0以上。",
             "全測定mul",
+            "attention",
         ),
         (
             "mixed_absolute_response",
@@ -1814,6 +1829,7 @@ def _dataset_behavior_table(dataset: Mapping[str, Any]) -> str:
             "mulにより摂動帯が変化",
             "mulを変えると低摂動・Tail注意・高摂動の帯をまたぐ。",
             mixed_detail,
+            "pattern",
         ),
         (
             "includes_hard_unsafe",
@@ -1821,17 +1837,19 @@ def _dataset_behavior_table(dataset: Mapping[str, Any]) -> str:
             "Hard unsafeを含む",
             "nonfinite、強制安全停止など、数値比較より前の問題を含む。",
             _mul_list(unsafe_muls),
+            "danger",
         ),
         (
             "relatively_stronger",
             "相対",
-            "候補内でより強い摂動あり",
-            "hard-safeだが、同じdataset内でBody・Tailの両方が明瞭に大きい候補がある。",
+            "候補内でより強い摂動あり（注意）",
+            "Hard-safetyは通過しているが、同じdataset内の他候補よりBody・Tailの両方が明瞭に大きい。",
             _mul_list(dataset["relatively_stronger_muls"]),
+            "attention",
         ),
     ]
     rows = []
-    for code, channel, label, meaning, relevant in definitions:
+    for code, channel, label, meaning, relevant, mark_kind in definitions:
         active = (
             bool(dataset["relatively_stronger_muls"])
             if code == "relatively_stronger"
@@ -1839,7 +1857,7 @@ def _dataset_behavior_table(dataset: Mapping[str, Any]) -> str:
         )
         rows.append(
             "<tr>"
-            f'<td class="mark-cell">{_mark(active)}</td>'
+            f'<td class="mark-cell">{_mark(active, kind=mark_kind)}</td>'
             f"<td>{html.escape(channel)}</td>"
             f"<th scope=\"row\">{html.escape(label)}</th>"
             f"<td>{html.escape(meaning)}</td>"
@@ -1867,16 +1885,19 @@ def _candidate_role_matrix(dataset: Mapping[str, Any]) -> str:
             "Hard-safety pass",
             "nonfinite等の安全停止なし",
             hard_safe,
+            "pass",
         ),
         (
             "Fidelity retained",
             "候補内比較で明瞭には除外されない",
             set(float(value) for value in dataset["fidelity_retained_muls"]),
+            "retained",
         ),
         (
-            "候補内でより強い摂動",
-            "hard-safeだが相対的にBody/Tailが強い",
+            "候補内でより強い摂動（注意）",
+            "Hard-safetyは通過。ただし他候補よりno_quantから離れる",
             set(float(value) for value in dataset["relatively_stronger_muls"]),
+            "attention",
         ),
         (
             "Body代表",
@@ -1886,6 +1907,7 @@ def _candidate_role_matrix(dataset: Mapping[str, Any]) -> str:
                 if dataset["body_representative_mul"] is not None
                 else set()
             ),
+            "representative",
         ),
         (
             "Tail代表",
@@ -1895,6 +1917,7 @@ def _candidate_role_matrix(dataset: Mapping[str, Any]) -> str:
                 if dataset["tail_representative_mul"] is not None
                 else set()
             ),
+            "representative",
         ),
         (
             "単一代表",
@@ -1904,13 +1927,14 @@ def _candidate_role_matrix(dataset: Mapping[str, Any]) -> str:
                 if dataset["single_representative_mul"] is not None
                 else set()
             ),
+            "representative",
         ),
     ]
     header = "".join(f"<th>mul<br>{mul:.2f}</th>" for mul in muls)
     rows = []
-    for label, meaning, active_muls in role_rows:
+    for label, meaning, active_muls, mark_kind in role_rows:
         cells = "".join(
-            f'<td class="mark-cell">{_mark(any(_same_mul(mul, active) for active in active_muls))}</td>'
+            f'<td class="mark-cell">{_mark(any(_same_mul(mul, active) for active in active_muls), kind=mark_kind)}</td>'
             for mul in muls
         )
         rows.append(
@@ -1921,27 +1945,34 @@ def _candidate_role_matrix(dataset: Mapping[str, Any]) -> str:
         '<div class="table-wrap"><table class="role-matrix">'
         f'<thead><tr><th>役割</th>{header}</tr></thead>'
         f'<tbody>{"".join(rows)}</tbody></table></div>'
-        '<p class="micro">○ = 該当、— = 非該当。○がない行は「選べなかった」という診断結果です。</p>'
+        '<div class="matrix-legend">'
+        f'<span>{_mark(True, kind="pass")} 安全確認を通過</span>'
+        f'<span>{_mark(True, kind="retained")} 候補集合に保持</span>'
+        f'<span>{_mark(True, kind="attention")} 安全だが相対的に強い摂動</span>'
+        f'<span>{_mark(True, kind="representative")} 数値上の代表</span>'
+        '<span>— 非該当</span></div>'
+        '<p class="micro"><strong>記号は役割への該当を表します。</strong>'
+        'すべてが同じ意味の「合格」ではなく、「注意」は画質不良ではありません。</p>'
     )
 
 
 def _overview_behavior_table(datasets: Sequence[Mapping[str, Any]]) -> str:
     columns = [
-        ("all_low_perturbation", "全候補低"),
-        ("all_tail_attention", "全候補Tail注意"),
-        ("all_high_perturbation", "全候補高"),
-        ("mixed_absolute_response", "mulで帯が変化"),
-        ("includes_hard_unsafe", "Hard unsafe"),
+        ("all_low_perturbation", "全候補低", "pattern"),
+        ("all_tail_attention", "全候補Tail注意", "attention"),
+        ("all_high_perturbation", "全候補高", "attention"),
+        ("mixed_absolute_response", "mulで帯が変化", "pattern"),
+        ("includes_hard_unsafe", "Hard unsafe", "danger"),
     ]
-    header = "".join(f"<th>{html.escape(label)}</th>" for _, label in columns)
+    header = "".join(f"<th>{html.escape(label)}</th>" for _, label, _ in columns)
     rows = []
     for dataset in datasets:
         cells = "".join(
-            f'<td class="mark-cell">{_mark(dataset["absolute_response"] == code)}</td>'
-            for code, _ in columns
+            f'<td class="mark-cell">{_mark(dataset["absolute_response"] == code, kind=mark_kind)}</td>'
+            for code, _, mark_kind in columns
         )
         cells += (
-            f'<td class="mark-cell">{_mark(bool(dataset["relatively_stronger_muls"]))}</td>'
+            f'<td class="mark-cell">{_mark(bool(dataset["relatively_stronger_muls"]), kind="attention")}</td>'
         )
         rows.append(
             f'<tr><th scope="row"><button class="link-button" data-open="{html.escape(dataset["dataset_id"])}">'
@@ -2364,6 +2395,11 @@ def render_report(model: Mapping[str, Any]) -> str:
     overview_hidden = " hidden" if single_dataset else ""
     overview_selected = "" if single_dataset else " selected"
     selector_class = "dataset-selector is-single" if single_dataset else "dataset-selector"
+    beginner_link = (
+        '<a class="summary-link" href="beginner_report.html">概要レポート</a>'
+        if single_dataset
+        else ""
+    )
     behavior_overview = _overview_behavior_table(datasets)
     payload = html.escape(
         json.dumps(
@@ -2417,7 +2453,7 @@ h1{{font-size:clamp(28px,4vw,48px);line-height:1.08;margin:5px 0 14px}} h2{{font
 .representative-grid{{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin-top:12px}} .representative-grid>div{{display:grid;gap:3px;padding:13px;background:white;border:1px solid var(--line);border-radius:10px}} .representative-grid span,.representative-grid small{{color:var(--muted)}}
 .callout-grid{{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-top:12px}} .callout-grid>div{{padding:13px;background:#edf2f8;border-radius:10px}}
 .table-wrap{{overflow:auto;border:1px solid var(--line);border-radius:12px;background:white}} table{{border-collapse:collapse;width:100%;font-size:13px}} th,td{{border-bottom:1px solid var(--line);padding:10px 9px;text-align:left;vertical-align:top}} thead th{{position:sticky;top:0;background:#edf2f8;white-space:nowrap}} .explanation-row td{{background:#fafbfd;color:#4a596d;padding-top:7px;padding-bottom:12px}}
-.subheading{{margin-top:22px}} .mark-cell{{text-align:center!important;vertical-align:middle}} .matrix-mark{{display:inline-grid;place-items:center;width:24px;height:24px;border-radius:50%;font-weight:900}} .matrix-mark.on{{background:#dbeafe;color:#17499f}} .matrix-mark.off{{color:#a2acba;background:#f3f4f6}} .decision-table th[scope="row"]{{min-width:190px}} .decision-table td:last-child{{min-width:180px}} .role-matrix th:first-child{{min-width:245px}} .role-matrix td{{text-align:center;vertical-align:middle}} .row-help{{display:block;color:var(--muted);font-weight:400;font-size:10px;margin-top:2px}} .overview-behavior-table td{{text-align:center}}
+.subheading{{margin-top:22px}} .mark-cell{{text-align:center!important;vertical-align:middle}} .matrix-mark{{display:inline-grid;place-items:center;min-width:24px;height:24px;padding:0 6px;border-radius:999px;font-weight:900;font-size:12px}} .matrix-mark.pass{{background:#dcfce7;color:#166534}} .matrix-mark.retained{{background:#dbeafe;color:#17499f}} .matrix-mark.attention{{background:#ffedd5;color:#9a4700}} .matrix-mark.danger{{background:#fee2e2;color:#991b1b}} .matrix-mark.representative{{background:#f2ebff;color:#5b21b6}} .matrix-mark.pattern{{background:#e0e7ff;color:#3730a3}} .matrix-mark.off{{color:#a2acba;background:#f3f4f6}} .matrix-legend{{display:flex;flex-wrap:wrap;gap:8px 14px;align-items:center;margin-top:9px;color:var(--muted);font-size:11px}} .matrix-legend>span{{display:inline-flex;align-items:center;gap:5px}} .decision-table th[scope="row"]{{min-width:190px}} .decision-table td:last-child{{min-width:180px}} .role-matrix th:first-child{{min-width:245px}} .role-matrix td{{text-align:center;vertical-align:middle}} .row-help{{display:block;color:var(--muted);font-weight:400;font-size:10px;margin-top:2px}} .overview-behavior-table td{{text-align:center}}
 .micro{{font-size:11px;color:var(--muted);margin:3px 0}} .muted,.section-help{{color:var(--muted)}} .chart-grid{{display:grid;grid-template-columns:2fr 1fr;gap:15px}} .chart{{display:block;width:100%;height:auto}}
 .trajectory-empty{{display:grid;place-content:center;text-align:center;min-height:270px}} .empty-icon{{font-size:64px;color:#a4aec0}}
 details{{background:white;border:1px solid var(--line);border-radius:12px;padding:12px 15px;margin:10px 0}} summary{{cursor:pointer;font-weight:800}} details>table,details>.matrix-grid,details>p{{margin-top:12px}}
@@ -2426,14 +2462,14 @@ details{{background:white;border:1px solid var(--line);border-radius:12px;paddin
 .qa-reason-grid{{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;margin:12px 0}} .qa-reason-grid>div{{padding:12px;background:#f8fafc;border:1px solid var(--line);border-radius:8px}} .qa-reason-grid ul{{margin:5px 0 0;padding-left:18px;font-size:12px;color:var(--muted)}}
 .dataset-grid{{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}} .dataset-tile{{appearance:none;text-align:left;border:1px solid var(--line);background:white;border-radius:13px;padding:16px;display:grid;gap:5px;color:var(--ink);cursor:pointer;box-shadow:0 5px 16px rgba(25,38,70,.04)}} .dataset-tile:hover,.dataset-tile:focus{{border-color:#7fa5ed;transform:translateY(-1px)}} .dataset-tile strong{{font-size:16px}} .dataset-tile span:not(.eyebrow){{color:var(--muted);font-size:12px}}
 .overview-hero{{background:linear-gradient(135deg,#172554,#1e3a8a);color:white;border-radius:18px;padding:32px}} .overview-hero .eyebrow,.overview-hero .lead{{color:#d8e5ff}} .overview-kpis{{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin-top:20px}} .overview-kpis>div{{background:rgba(255,255,255,.1);padding:14px;border:1px solid rgba(255,255,255,.18);border-radius:11px}} .overview-kpis strong{{display:block;font-size:27px}}
-.link-button{{border:0;background:none;color:#1d4ed8;text-decoration:underline;cursor:pointer;padding:0;font:inherit}} .dataset-selector.is-single{{display:none}} footer{{color:var(--muted);font-size:12px;padding-top:30px}}
+.link-button{{border:0;background:none;color:#1d4ed8;text-decoration:underline;cursor:pointer;padding:0;font:inherit}} .header-actions{{display:flex;align-items:center;gap:10px}} .summary-link{{color:#1d4ed8;text-decoration:none;border:1px solid #b8c5d8;border-radius:999px;padding:6px 11px;font-size:12px;font-weight:750;background:white}} .dataset-selector.is-single{{display:none}} footer{{color:var(--muted);font-size:12px;padding-top:30px}}
 @media(max-width:900px){{.hero,.dataset-intro,.chart-grid,.matrix-grid{{grid-template-columns:1fr}}.summary-grid,.callout-grid,.overview-kpis{{grid-template-columns:repeat(2,1fr)}}.dataset-grid{{grid-template-columns:1fr 1fr}}.dataset-intro{{gap:12px}}}}
 @media(max-width:580px){{main{{padding:12px 10px 55px}}.header-inner{{padding:9px 12px;align-items:flex-start;flex-direction:column}}.summary-grid,.callout-grid,.overview-kpis,.dataset-grid,.qa-grid,.qa-reason-grid,.representative-grid,.interpretation-strip{{grid-template-columns:1fr}}.evidence-strip{{grid-template-columns:repeat(2,minmax(0,1fr))}}.dataset-intro{{padding:13px}}.dataset-intro h1{{font-size:24px}}.evidence-chip{{padding:7px}}.evidence-chip strong{{font-size:13px}}.section-heading-inline{{align-items:flex-start;flex-direction:column;gap:6px}}.primary-chart{{padding:8px}}.primary-chart>.chart{{height:250px}}}}
 @media print{{header{{position:static}}.view[hidden]{{display:block!important;page-break-before:always}}button,select{{display:none}}body{{background:white}}main{{max-width:none}}}}
 </style>
 </head>
 <body>
-<header><div class="header-inner"><div class="brand">SDXL DQ 診断カルテ <small>v2.4.3 practical report beta ・ Safety/Fidelity ≠ Utility</small></div><label class="{selector_class}">表示 <select id="dataset-select"><option value="overview"{overview_selected}>横断概要</option>{options}</select></label></div></header>
+<header><div class="header-inner"><div class="brand">SDXL DQ 診断カルテ <small>v2.4.3 practical report beta ・ Safety/Fidelity ≠ Utility</small></div><div class="header-actions">{beginner_link}<label class="{selector_class}">表示 <select id="dataset-select"><option value="overview"{overview_selected}>横断概要</option>{options}</select></label></div></div></header>
 <main>
 <section id="overview" class="view"{overview_hidden}>
   <div class="overview-hero">

--- a/dq_profile/v24_practical_report.py
+++ b/dq_profile/v24_practical_report.py
@@ -203,11 +203,15 @@ def report_contract() -> dict[str, Any]:
             "measurement_contract_field": "measurement_contract",
             "sampling_depth_field": "sampling_depth",
             "confidence_ceiling_field": "confidence_ceiling",
-            "quick": (
-                "explicit reduced-sampling run with short prefix smoke, one "
-                "standalone snapshot, and the fixed five-point grid"
+            "supported_new_runs": ["standard", "strict"],
+            "legacy_quick": (
+                "read-only report compatibility for historical reduced-sampling "
+                "Quick artifacts; Quick is not selectable for new runs"
             ),
-            "standard": "daily fixed-grid run with short prefix smoke",
+            "standard": (
+                "daily fixed-grid run with short prefix smoke and one standalone "
+                "snapshot"
+            ),
             "strict": "reference-depth run with long prefix and bounded edge extension",
             "mode_is_not_internal_profile_level": True,
         },
@@ -877,7 +881,7 @@ def build_dataset_card(
         if local_comparison_confidence["level"] == "High":
             local_comparison_confidence["level"] = "Medium"
         local_comparison_confidence["reasons"].append(
-            "Quickは最大16画像の縮小samplingであり、Standardと同じ証拠量ではありません"
+            "旧Quick成果物は最大16画像の縮小samplingであり、現Standardと同じ証拠量ではありません"
         )
     recommendation_maturity = _recommendation_maturity(
         trajectory_available=trajectory_available,

--- a/dq_profile/v2_calibration.py
+++ b/dq_profile/v2_calibration.py
@@ -273,6 +273,7 @@ def evaluate_prefix_pair(
     candidate_states: Mapping[int, Mapping[str, Any]],
     comparison: str,
     candidate_name: str,
+    required_checkpoints: Sequence[int] = (0, 1, 32, 64),
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     exact = len(reference_rows) == len(candidate_rows)
@@ -320,18 +321,22 @@ def evaluate_prefix_pair(
             }
         )
 
-    required_checkpoints = {0, 1, 32, 64}
+    required_checkpoint_set = {int(value) for value in required_checkpoints}
     reference_checkpoints = set(reference_states)
     candidate_checkpoints = set(candidate_states)
     checkpoint_topology_matches = (
         reference_checkpoints == candidate_checkpoints
-        and required_checkpoints.issubset(reference_checkpoints)
+        and required_checkpoint_set.issubset(reference_checkpoints)
     )
     state_components_exact = checkpoint_topology_matches
     state_numeric = checkpoint_topology_matches
     if not checkpoint_topology_matches and first_divergence is None:
         missing_or_extra = sorted(reference_checkpoints.symmetric_difference(candidate_checkpoints))
-        required_missing = sorted(required_checkpoints.difference(reference_checkpoints.intersection(candidate_checkpoints)))
+        required_missing = sorted(
+            required_checkpoint_set.difference(
+                reference_checkpoints.intersection(candidate_checkpoints)
+            )
+        )
         first_divergence = {
             "step": (missing_or_extra or required_missing or [0])[0],
             "component": "state:checkpoint_presence",
@@ -401,6 +406,7 @@ def evaluate_prefix_pair(
         "step_count_reference": len(reference_rows),
         "step_count_candidate": len(candidate_rows),
         "state_checkpoints": sorted(reference_checkpoints.intersection(candidate_checkpoints)),
+        "required_state_checkpoints": sorted(required_checkpoint_set),
         "state_checkpoint_topology_matches": checkpoint_topology_matches,
     }
 

--- a/dq_profile/v2_runtime.py
+++ b/dq_profile/v2_runtime.py
@@ -108,7 +108,10 @@ class V2ExperimentRunner:
         self._repeat_sequences: dict[int, ReplaySequence] = {}
         # Run length and cohort are identity, not cache reuse hints.  A freshly
         # restored 128-step execution must never replace a 64-step cohort.
-        self._executions: dict[tuple[str, str, str, int, str, int], BranchExecution] = {}
+        self._executions: dict[
+            tuple[str, str, str, int, str, int, tuple[int, ...]],
+            BranchExecution,
+        ] = {}
 
     @staticmethod
     def _execution_id(
@@ -219,11 +222,23 @@ class V2ExperimentRunner:
         quant_phase: str = "v2_core",
         cohort_id: Optional[str] = None,
         capture_prefix_state: bool = False,
+        prefix_state_checkpoints: Optional[Sequence[int]] = None,
     ) -> BranchExecution:
         if guardian_mode not in {"common_skip", "native_guardian"}:
             raise ValueError(f"unknown Guardian mode: {guardian_mode}")
         cohort_id = str(cohort_id or f"{quant_phase}.steps_{int(max_steps)}.repeat_{int(repeat)}")
-        key = (cohort_id, guardian_mode, candidate.name, int(repeat), quant_phase, int(max_steps))
+        prefix_checkpoint_key = tuple(
+            sorted({int(value) for value in (prefix_state_checkpoints or ())})
+        )
+        key = (
+            cohort_id,
+            guardian_mode,
+            candidate.name,
+            int(repeat),
+            quant_phase,
+            int(max_steps),
+            prefix_checkpoint_key,
+        )
         existing = self._executions.get(key)
         if existing is not None:
             return existing
@@ -263,6 +278,10 @@ class V2ExperimentRunner:
         )
         if capture_prefix_state:
             self._capture_prefix_state(execution, 0)
+        state_checkpoints = set(
+            prefix_checkpoint_key if prefix_checkpoint_key else (1, 32, 64)
+        )
+        state_checkpoints.discard(0)
         checkpoints = {value for value in (32, 64, 128, int(max_steps)) if 0 < value <= int(max_steps)}
         replay_sequence = self._repeat_sequence(int(repeat))
         for branch_step, replay in enumerate(replay_sequence):
@@ -340,7 +359,7 @@ class V2ExperimentRunner:
                     ),
                 )
 
-            if capture_prefix_state and branch_step + 1 in {1, 32, 64}:
+            if capture_prefix_state and branch_step + 1 in state_checkpoints:
                 self._capture_prefix_state(execution, branch_step + 1)
         if len(execution.rows) < int(max_steps) and not execution.forced_safety_abort:
             execution.forced_safety_abort = True
@@ -358,6 +377,7 @@ class V2ExperimentRunner:
         quant_phase: str = "v2_core",
         cohort_id: Optional[str] = None,
         capture_prefix_state: bool = False,
+        prefix_state_checkpoints: Optional[Sequence[int]] = None,
     ) -> BranchExecution:
         return self._execute(
             candidate=_no_quant_candidate(),
@@ -368,6 +388,7 @@ class V2ExperimentRunner:
             quant_phase=quant_phase,
             cohort_id=cohort_id,
             capture_prefix_state=capture_prefix_state,
+            prefix_state_checkpoints=prefix_state_checkpoints,
         )
 
     @staticmethod
@@ -1117,8 +1138,16 @@ class V2ExperimentRunner:
 
 
     def _run_prefix_smoke(self) -> dict[str, Any]:
-        if len(self.sequence) < 128:
-            raise ValueError("v2-prefix-smoke requires at least 128 materialized replay batches")
+        short_steps = int(getattr(self.args, "dq_profile_prefix_short_steps", 64))
+        long_steps = int(getattr(self.args, "dq_profile_prefix_long_steps", 128))
+        prefix_checkpoints = tuple(
+            sorted({0, 1, short_steps // 2, short_steps})
+        )
+        if len(self.sequence) < long_steps:
+            raise ValueError(
+                "v2-prefix-smoke requires at least "
+                f"{long_steps} materialized replay batches"
+            )
         candidate = _candidate_for_mul(3.15)
         cohorts: dict[str, tuple[BranchExecution, BranchExecution]] = {}
 
@@ -1130,6 +1159,7 @@ class V2ExperimentRunner:
                 quant_phase="v2_prefix_smoke",
                 cohort_id=cohort_id,
                 capture_prefix_state=True,
+                prefix_state_checkpoints=prefix_checkpoints,
             )
             execution = self._execute(
                 candidate=candidate,
@@ -1140,30 +1170,43 @@ class V2ExperimentRunner:
                 quant_phase="v2_prefix_smoke",
                 cohort_id=cohort_id,
                 capture_prefix_state=True,
+                prefix_state_checkpoints=prefix_checkpoints,
             )
             return reference, execution
 
-        # Keep the 64A baseline in memory, compare each challenger immediately,
+        baseline_label = f"{short_steps}A"
+        repeated_label = f"{short_steps}B"
+        long_label = str(long_steps)
+        # Keep the short-A baseline in memory, compare each challenger immediately,
         # then release its numeric state tensors. Fingerprint rows remain, but
         # the smoke test never retains all six optimizer snapshots at once.
-        cohorts["64A"] = execute_cohort("64A", 64)
+        cohorts[baseline_label] = execute_cohort(baseline_label, short_steps)
         parity_rows: list[dict[str, Any]] = []
         pair_summaries: list[dict[str, Any]] = []
         for label, max_steps, comparison in (
-            ("64B", 64, "64A_vs_64B"),
-            ("128", 128, "64A_vs_128_at64"),
+            (
+                repeated_label,
+                short_steps,
+                f"{baseline_label}_vs_{repeated_label}",
+            ),
+            (
+                long_label,
+                long_steps,
+                f"{baseline_label}_vs_{long_label}_at{short_steps}",
+            ),
         ):
             cohorts[label] = execute_cohort(label, max_steps)
             for candidate_index, candidate_name in ((0, "no_quant"), (1, candidate.name)):
-                baseline = cohorts["64A"][candidate_index]
+                baseline = cohorts[baseline_label][candidate_index]
                 challenger = cohorts[label][candidate_index]
                 rows, summary = evaluate_prefix_pair(
-                    reference_rows=baseline.rows[:64],
-                    candidate_rows=challenger.rows[:64],
+                    reference_rows=baseline.rows[:short_steps],
+                    candidate_rows=challenger.rows[:short_steps],
                     reference_states=baseline.state_values,
                     candidate_states=challenger.state_values,
                     comparison=comparison,
                     candidate_name=candidate_name,
+                    required_checkpoints=prefix_checkpoints,
                 )
                 parity_provenance = {
                     "reference_execution_id": baseline.execution_id,
@@ -1180,6 +1223,19 @@ class V2ExperimentRunner:
                 pair_summaries.append(summary)
                 challenger.state_values.clear()
         gate = aggregate_prefix_gate(pair_summaries)
+        gate["execution_mode"] = str(
+            getattr(self.args, "dq_profile_execution_mode", "strict")
+        )
+        gate["qa_depth"] = str(
+            getattr(self.args, "dq_profile_qa_depth", "strict_reference")
+        )
+        gate["prefix_contract"] = {
+            "short_steps": short_steps,
+            "long_steps": long_steps,
+            "checkpoints": list(prefix_checkpoints),
+            "anchor_mul": 3.15,
+            "branch_updates": 2 * (short_steps * 2 + long_steps),
+        }
         gate["kernel_policy"] = dict(
             getattr(
                 self.args,
@@ -1199,7 +1255,7 @@ class V2ExperimentRunner:
             for row in execution.rows:
                 row["result_scope"] = f"prefix_{label}"
 
-        baseline_reference, baseline_candidate = cohorts["64A"]
+        baseline_reference, baseline_candidate = cohorts[baseline_label]
         branch_summaries = self._summarize_candidates(
             [baseline_candidate],
             self._direction_rows(baseline_candidate, baseline_reference, guardian_mode="common_skip"),
@@ -1211,7 +1267,7 @@ class V2ExperimentRunner:
 
         executions = [item for pair in cohorts.values() for item in pair]
         state_rows = [row for execution in executions for row in execution.state_records]
-        for execution in cohorts["64A"]:
+        for execution in cohorts[baseline_label]:
             execution.state_values.clear()
         execution_manifest_rows = [
             {

--- a/sdxl_dq_dataset_profile.py
+++ b/sdxl_dq_dataset_profile.py
@@ -45,6 +45,18 @@ def setup_parser() -> argparse.ArgumentParser:
     group.add_argument("--dq_profile_name", type=str, default="dq_profile")
     group.add_argument("--dq_profile_level", choices=("standard", "full"), default="standard")
     group.add_argument(
+        "--dq_profile_execution_mode",
+        choices=("standard", "strict"),
+        default="strict",
+        help="production orchestration mode; distinct from --dq_profile_level",
+    )
+    group.add_argument(
+        "--dq_profile_qa_depth",
+        choices=("standard_smoke", "strict_reference"),
+        default="strict_reference",
+        help="production QA-depth provenance label",
+    )
+    group.add_argument(
         "--dq_profile_protocol",
         choices=(
             "v1",
@@ -68,6 +80,8 @@ def setup_parser() -> argparse.ArgumentParser:
     group.add_argument("--dq_profile_range_muls", type=str, default=",".join(str(value) for value in DEFAULT_V2_RANGE_MULS))
     group.add_argument("--dq_profile_sweep_steps", type=int, default=64)
     group.add_argument("--dq_profile_branch_repeats", type=int, default=2)
+    group.add_argument("--dq_profile_prefix_short_steps", type=int, default=64)
+    group.add_argument("--dq_profile_prefix_long_steps", type=int, default=128)
     group.add_argument("--dq_profile_guardian_ablation", choices=("common_then_native", "common_only", "native_only"), default="common_then_native")
     group.add_argument("--dq_profile_sketch_width", type=int, default=512)
     group.add_argument("--dq_profile_sketch_seeds", type=int, default=2)
@@ -141,6 +155,19 @@ def _resolved_candidate_definitions(args: argparse.Namespace) -> tuple[Candidate
 
 def _validate_and_isolate(args: argparse.Namespace) -> None:
     protocol = str(getattr(args, "dq_profile_protocol", "v1"))
+    # Preserve programmatic callers that construct an argparse.Namespace
+    # instead of going through setup_parser().  These are the historical
+    # strict-reference values and therefore do not silently opt into the
+    # shorter Standard QA contract.
+    compatibility_defaults = {
+        "dq_profile_execution_mode": "strict",
+        "dq_profile_qa_depth": "strict_reference",
+        "dq_profile_prefix_short_steps": 64,
+        "dq_profile_prefix_long_steps": 128,
+    }
+    for name, value in compatibility_defaults.items():
+        if not hasattr(args, name):
+            setattr(args, name, value)
     if bool(getattr(args, "dq_profile_snapshot_only", False)) and protocol != "v2-prefix-smoke":
         raise ValueError(
             "--dq_profile_snapshot_only is a diagnostic boundary check and "
@@ -172,6 +199,7 @@ def _validate_and_isolate(args: argparse.Namespace) -> None:
     for name in (
         "dq_profile_max_images", "dq_profile_timestep_bins", "dq_profile_stochastic_repeats",
         "dq_profile_sketch_width", "dq_profile_sketch_seeds", "dq_profile_sweep_steps", "dq_profile_branch_repeats",
+        "dq_profile_prefix_short_steps", "dq_profile_prefix_long_steps",
     ):
         if int(getattr(args, name)) <= 0:
             raise ValueError(f"--{name} must be positive")
@@ -180,6 +208,25 @@ def _validate_and_isolate(args: argparse.Namespace) -> None:
     profile_name = str(args.dq_profile_name).strip()
     if not profile_name or Path(profile_name).name != profile_name:
         raise ValueError("--dq_profile_name must be a single non-empty path component")
+    if protocol == "v2-prefix-smoke":
+        short_steps = int(args.dq_profile_prefix_short_steps)
+        long_steps = int(args.dq_profile_prefix_long_steps)
+        if short_steps < 2:
+            raise ValueError("--dq_profile_prefix_short_steps must be at least 2")
+        if long_steps != short_steps * 2:
+            raise ValueError(
+                "--dq_profile_prefix_long_steps must be exactly twice "
+                "--dq_profile_prefix_short_steps"
+            )
+        expected_qa_depth = {
+            "standard": "standard_smoke",
+            "strict": "strict_reference",
+        }[str(args.dq_profile_execution_mode)]
+        if str(args.dq_profile_qa_depth) != expected_qa_depth:
+            raise ValueError(
+                "--dq_profile_qa_depth does not match --dq_profile_execution_mode; "
+                f"expected {expected_qa_depth}"
+            )
     prefix_required_protocols = {
         "v2-tail-calibration",
         "v23-safety-local",
@@ -461,7 +508,7 @@ def _validate_and_isolate(args: argparse.Namespace) -> None:
     args.dq_profile_requested_range_muls = args.dq_profile_range_muls
     if protocol == "v2-prefix-smoke":
         args.dq_profile_range_muls_resolved = (3.15,)
-        args.dq_profile_sweep_steps = 128
+        args.dq_profile_sweep_steps = int(args.dq_profile_prefix_long_steps)
         args.dq_profile_branch_repeats = 1
         args.dq_profile_guardian_ablation = "common_only"
     elif protocol == "v2-tail-calibration":
@@ -606,7 +653,11 @@ def _validate_and_isolate(args: argparse.Namespace) -> None:
     }:
         args.dq_profile_capture_steps = max(
             int(args.dq_profile_branch_steps or 0),
-            128,
+            (
+                int(args.dq_profile_prefix_long_steps)
+                if protocol == "v2-prefix-smoke"
+                else 128
+            ),
         )
     else:
         args.dq_profile_capture_steps = max(
@@ -665,11 +716,13 @@ def _preflight(args: argparse.Namespace) -> dict[str, Any]:
     if args.dq_profile_protocol == "v2-prefix-smoke":
         args.dq_profile_probe_replicas_resolved = 0
         snapshot_only = bool(getattr(args, "dq_profile_snapshot_only", False))
-        branch_steps = 0 if snapshot_only else 2 * 64 * 2 + 2 * 128
+        short_steps = int(args.dq_profile_prefix_short_steps)
+        long_steps = int(args.dq_profile_prefix_long_steps)
+        branch_steps = 0 if snapshot_only else 2 * (short_steps * 2 + long_steps)
         estimated = int(summary.dq_begin_step) + branch_steps
         payload.update(
             {
-                "branch_steps": 0 if snapshot_only else 128,
+                "branch_steps": 0 if snapshot_only else long_steps,
                 "standard_probe_replicas": 0,
                 "full_probe_replicas": 0,
                 "estimated_standard_steps": estimated,
@@ -682,6 +735,13 @@ def _preflight(args: argparse.Namespace) -> dict[str, Any]:
             "warmup_steps": int(summary.dq_begin_step),
             "prefix_branch_steps": branch_steps,
             "structural_probe_steps": 0,
+        }
+        payload["v2"]["prefix_contract"] = {
+            "execution_mode": str(args.dq_profile_execution_mode),
+            "qa_depth": str(args.dq_profile_qa_depth),
+            "short_steps": short_steps,
+            "long_steps": long_steps,
+            "checkpoints": sorted({0, 1, short_steps // 2, short_steps}),
         }
         payload["v2"]["snapshot_only"] = snapshot_only
         args.dq_profile_preflight = payload

--- a/sdxl_dq_dataset_profile.py
+++ b/sdxl_dq_dataset_profile.py
@@ -46,15 +46,33 @@ def setup_parser() -> argparse.ArgumentParser:
     group.add_argument("--dq_profile_level", choices=("standard", "full"), default="standard")
     group.add_argument(
         "--dq_profile_execution_mode",
-        choices=("standard", "strict"),
+        choices=("quick", "standard", "strict"),
         default="strict",
         help="production orchestration mode; distinct from --dq_profile_level",
     )
     group.add_argument(
         "--dq_profile_qa_depth",
-        choices=("standard_smoke", "strict_reference"),
+        choices=("quick_smoke", "standard_smoke", "strict_reference"),
         default="strict_reference",
         help="production QA-depth provenance label",
+    )
+    group.add_argument(
+        "--dq_profile_measurement_contract",
+        type=str,
+        default="local-body-tail-v1",
+        help="versioned Local Body/Tail measurement-contract provenance",
+    )
+    group.add_argument(
+        "--dq_profile_sampling_depth",
+        type=str,
+        default="reference_32_image",
+        help="Local sampling-depth provenance label",
+    )
+    group.add_argument(
+        "--dq_profile_confidence_ceiling",
+        type=str,
+        default="data_driven_up_to_high",
+        help="descriptive confidence ceiling for the selected sampling contract",
     )
     group.add_argument(
         "--dq_profile_protocol",
@@ -219,6 +237,7 @@ def _validate_and_isolate(args: argparse.Namespace) -> None:
                 "--dq_profile_prefix_short_steps"
             )
         expected_qa_depth = {
+            "quick": "quick_smoke",
             "standard": "standard_smoke",
             "strict": "strict_reference",
         }[str(args.dq_profile_execution_mode)]

--- a/tests/test_dq_profile.py
+++ b/tests/test_dq_profile.py
@@ -17,6 +17,7 @@ from dq_profile.protocol import (
     canonical_sha256,
     default_candidates,
     deterministic_seed,
+    fixed_range_candidates,
     initial_range_mul,
     inspect_dataset_config,
 )
@@ -34,6 +35,51 @@ def test_stateless_seed_is_repeatable_and_candidate_free():
     assert deterministic_seed(39, **kwargs) != deterministic_seed(39, **{**kwargs, "repeat": 2})
     assert 0 <= deterministic_seed(39, **kwargs) < 2**64
     assert "candidate" not in deterministic_seed.__code__.co_varnames
+
+
+def test_local_quant_random_contract_is_grid_order_and_execution_mode_free():
+    grids = (
+        (2.70, 3.15, 3.45),
+        (2.70, 3.15, 3.45, 3.75, 4.05),
+        (4.05, 3.75, 3.45, 3.15, 2.70),
+    )
+    outputs = []
+    for execution_mode, grid in (
+        ("strict", grids[0]),
+        ("standard", grids[1]),
+        ("standard", grids[2]),
+    ):
+        candidates = fixed_range_candidates(grid)
+        assert any(candidate.name == "mul_3.150" for candidate in candidates)
+        context = ProfileQuantContext(39)
+        # execution_mode and the candidate collection are deliberately not
+        # accepted by begin_pass/rand_for.  Shared Local probes use the same
+        # phase and probe identity in Standard and Strict.
+        assert execution_mode in {"standard", "strict"}
+        context.begin_pass(
+            mode="candidate",
+            phase="v2_tail_probe",
+            probe_or_step="tail:0:3:1:image-a",
+            repeat=1,
+            dropout_enabled=False,
+        )
+        outputs.append(
+            context.rand_for(
+                torch.zeros(4, 4),
+                module_name="lora_unet.block.attn",
+                invocation=2,
+            )
+        )
+        context.finish_pass()
+    assert all(torch.equal(outputs[0], output) for output in outputs[1:])
+    excluded_seed_fields = {
+        "execution_mode",
+        "grid",
+        "candidate_index",
+        "candidate_name",
+        "range_mul",
+    }
+    assert excluded_seed_fields.isdisjoint(deterministic_seed.__code__.co_varnames)
 
 
 def test_band_initializers_and_boundary_match_production_values():

--- a/tests/test_dq_profile_production.py
+++ b/tests/test_dq_profile_production.py
@@ -64,27 +64,18 @@ def test_standard_mode_keeps_the_shared_local_ruler_and_shortens_only_qa() -> No
     assert standard.execution_mode.prefix_checkpoints == (0, 1, 4, 8)
     assert standard.execution_mode.prefix_branch_updates == 64
     assert standard.execution_mode.max_edge_extension_rounds == 0
+    assert standard.execution_mode.standalone_snapshot_count == 1
+    assert standard.execution_mode.gpu_process_count_range == (3, 3)
     assert strict.execution_mode.prefix_checkpoints == (0, 1, 32, 64)
     assert strict.execution_mode.prefix_branch_updates == 512
     assert strict.execution_mode.max_edge_extension_rounds == 2
+    assert strict.execution_mode.standalone_snapshot_count == 2
+    assert strict.execution_mode.gpu_process_count_range == (4, 6)
 
 
-def test_quick_mode_uses_a_separate_reduced_sampling_contract() -> None:
-    standard = resolve_training_cli(minimal_cli(), execution_mode_name="standard")
-    quick = resolve_training_cli(minimal_cli(), execution_mode_name="quick")
-    assert quick.preset.contract() == standard.preset.contract()
-    assert quick.local_measurement.name == "local-body-tail-quick-v1"
-    assert quick.local_measurement.metric_definition_version == "2.4.0"
-    assert quick.local_measurement.max_images == 16
-    assert quick.local_measurement.timestep_bins == 4
-    assert quick.local_measurement.no_quant_noise_replicas == 3
-    assert quick.local_measurement.candidate_noise_replicas == 2
-    assert quick.local_measurement.stochastic_quant_repeats == 2
-    assert quick.local_measurement.sampling_depth == "reduced_16_image"
-    assert quick.execution_mode.core_grid == standard.execution_mode.core_grid
-    assert quick.execution_mode.prefix_checkpoints == (0, 1, 4, 8)
-    assert quick.execution_mode.standalone_snapshot_count == 1
-    assert quick.execution_mode.gpu_process_count_range == (3, 3)
+def test_quick_mode_is_not_available_for_new_runs() -> None:
+    with pytest.raises(ValueError, match="supported: standard, strict"):
+        resolve_training_cli(minimal_cli(), execution_mode_name="quick")
 
 
 def test_cross_mode_fingerprints_split_shared_local_from_execution_qa(
@@ -113,17 +104,6 @@ def test_cross_mode_fingerprints_split_shared_local_from_execution_qa(
     assert strict_hashes["local_probe_contract_sha256"] == standard_hashes["local_probe_contract_sha256"]
     assert strict_hashes["execution_qa_contract_sha256"] != standard_hashes["execution_qa_contract_sha256"]
     assert strict["full_protocol_fingerprint_sha256"] != standard["full_protocol_fingerprint_sha256"]
-
-    quick = build_protocol_fingerprint(
-        resolve_training_cli(argv, execution_mode_name="quick"),
-        source_map_payload=({"source_group": "source-01"},),
-    )
-    quick_hashes = quick["contract_hashes"]
-    assert quick_hashes["training_contract_sha256"] == standard_hashes["training_contract_sha256"]
-    assert quick_hashes["dataset_contract_sha256"] == standard_hashes["dataset_contract_sha256"]
-    assert quick_hashes["local_measurement_contract_sha256"] != standard_hashes["local_measurement_contract_sha256"]
-    assert quick_hashes["local_probe_contract_sha256"] != standard_hashes["local_probe_contract_sha256"]
-    assert quick_hashes["execution_qa_contract_sha256"] != standard_hashes["execution_qa_contract_sha256"]
 
 
 def test_full_legacy_style_cli_is_explicit_about_overrides() -> None:
@@ -605,38 +585,17 @@ def test_standard_profile_command_carries_distinct_execution_and_internal_levels
         name="01_core",
         protocol="v24-acceptance-local",
         range_muls=request.execution_mode.core_grid,
-        max_images=16,
+        max_images=request.local_measurement.max_images,
     )
     assert "--dq_profile_execution_mode=standard" in command
     assert "--dq_profile_qa_depth=standard_smoke" in command
     assert "--dq_profile_level=standard" in command
     assert "--dq_profile_prefix_short_steps=8" in command
     assert "--dq_profile_prefix_long_steps=16" in command
+    assert "--dq_profile_measurement_contract=local-body-tail-v1" in command
+    assert "--dq_profile_sampling_depth=reference_32_image" in command
+    assert "--dq_profile_max_images=32" in command
     assert "--dq_profile_range_muls=2.70,3.15,3.45,3.75,4.05" in command
-
-
-def test_quick_profile_command_carries_reduced_sampling_provenance(
-    tmp_path: Path,
-) -> None:
-    request = resolve_training_cli(
-        minimal_cli("--output_name=quick"),
-        execution_mode_name="quick",
-    )
-    command = profile_command(
-        request,
-        run_dir=tmp_path,
-        source_map=tmp_path / "source.json",
-        name="01_core",
-        protocol="v24-acceptance-local",
-        range_muls=request.execution_mode.core_grid,
-        max_images=request.local_measurement.max_images,
-    )
-    assert "--dq_profile_execution_mode=quick" in command
-    assert "--dq_profile_qa_depth=quick_smoke" in command
-    assert "--dq_profile_measurement_contract=local-body-tail-quick-v1" in command
-    assert "--dq_profile_sampling_depth=reduced_16_image" in command
-    assert "--dq_profile_confidence_ceiling=reduced_descriptive" in command
-    assert "--dq_profile_max_images=16" in command
 
 
 def test_dry_run_serializes_the_required_prefix_gate(
@@ -702,7 +661,8 @@ def test_dry_run_serializes_the_required_prefix_gate(
     plan = json.loads((result.run_dir / "execution_plan.json").read_text(encoding="utf-8"))
     assert plan["execution_mode"] == "standard"
     assert plan["qa_depth"] == "standard_smoke"
-    assert plan["work_volume"]["gpu_process_count"] == 4
+    assert plan["work_volume"]["gpu_process_count"] == 3
+    assert plan["work_volume"]["standalone_snapshot_count"] == 1
     assert plan["work_volume"]["prefix"]["total_branch_updates"] == 64
     assert plan["work_volume"]["local"]["fixed_grid"] == [2.7, 3.15, 3.45, 3.75, 4.05]
     assert plan["work_volume"]["local"]["total_local_probes"] == 736
@@ -742,7 +702,9 @@ def test_execution_plan_matches_the_known_13_image_standard_work_volume(
     plan = build_execution_plan(request, image_count=13, probe_budget=13)
     work = plan["work_volume"]
     assert work["warmup_boundary_updates"] == 1040
-    assert work["total_warmup_updates"] == 4160
+    assert work["gpu_process_count"] == 3
+    assert work["standalone_snapshot_count"] == 1
+    assert work["total_warmup_updates"] == 3120
     assert work["prefix"]["checkpoints"] == [0, 1, 4, 8]
     assert work["prefix"]["total_branch_updates"] == 64
     assert work["local"]["no_quant_probes"] == 156
@@ -750,31 +712,11 @@ def test_execution_plan_matches_the_known_13_image_standard_work_volume(
     assert work["local"]["total_local_probes"] == 1196
     assert plan["reference_time_estimate"]["minutes"]["minimum"] > 0
 
-    quick_request = resolve_training_cli(
-        [
-            f"--pretrained_model_name_or_path={tmp_path / 'model.safetensors'}",
-            f"--dataset_config={dataset}",
-        ],
-        execution_mode_name="quick",
-    )
-    quick_plan = build_execution_plan(
-        quick_request,
-        image_count=13,
-        probe_budget=13,
-    )
-    quick_work = quick_plan["work_volume"]
-    assert quick_plan["measurement_contract"] == "local-body-tail-quick-v1"
-    assert quick_work["gpu_process_count"] == 3
-    assert quick_work["standalone_snapshot_count"] == 1
-    assert quick_work["total_warmup_updates"] == 3120
-    assert quick_work["prefix"]["total_branch_updates"] == 64
-
-
-def test_quick_pipeline_skips_the_redundant_second_snapshot(
+def test_standard_pipeline_skips_the_redundant_second_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    request = resolve_training_cli(minimal_cli(), execution_mode_name="quick")
+    request = resolve_training_cli(minimal_cli(), execution_mode_name="standard")
     run_dir = tmp_path / "run"
     run_dir.mkdir()
     profile_calls: list[tuple[str, bool]] = []
@@ -818,8 +760,8 @@ def test_quick_pipeline_skips_the_redundant_second_snapshot(
         FakeLauncher(),
         request,
         source_map=tmp_path / "source-map.json",
-        probe_budget=16,
-        dataset_id="quick",
+        probe_budget=32,
+        dataset_id="standard",
     )
     names = production_runner.stage_names()
     assert profile_calls == [
@@ -901,24 +843,20 @@ def test_direct_module_entry_selects_standard_execution_mode(
     assert captured["kwargs"]["execution_mode_name"] == "standard"
 
 
-def test_direct_module_entry_selects_quick_execution_mode(
-    monkeypatch: pytest.MonkeyPatch,
+def test_direct_module_entry_rejects_removed_quick_mode(
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    captured: dict[str, object] = {}
-
-    def fake_run_profile_mode(training_argv: list[str], **kwargs: object) -> int:
-        captured["training_argv"] = training_argv
-        captured["kwargs"] = kwargs
-        return 0
-
-    monkeypatch.setattr(production_main, "run_profile_mode", fake_run_profile_mode)
     training = [
         f"--dataset_config={DATASET}",
         f"--pretrained_model_name_or_path={MODEL}",
     ]
-    assert production_main.main(["--dq-profile-mode=quick", *training]) == 0
-    assert captured["training_argv"] == training
-    assert captured["kwargs"]["execution_mode_name"] == "quick"
+    with pytest.raises(SystemExit) as error:
+        production_main.main(["--dq-profile-mode=quick", *training])
+    assert error.value.code == 2
+    stderr = capsys.readouterr().err
+    assert "invalid choice" in stderr
+    assert "standard" in stderr
+    assert "strict" in stderr
 
 
 def test_profile_name_sanitization_is_windows_safe() -> None:

--- a/tests/test_dq_profile_production.py
+++ b/tests/test_dq_profile_production.py
@@ -23,6 +23,7 @@ from dq_profile.production_runner import (
     profile_command,
     promote_analysis,
     promote_profile_provenance,
+    run_local_pipeline,
     sanitize_profile_name,
     source_dirs_from_dataset_config,
     subprocess_text_environment,
@@ -68,6 +69,24 @@ def test_standard_mode_keeps_the_shared_local_ruler_and_shortens_only_qa() -> No
     assert strict.execution_mode.max_edge_extension_rounds == 2
 
 
+def test_quick_mode_uses_a_separate_reduced_sampling_contract() -> None:
+    standard = resolve_training_cli(minimal_cli(), execution_mode_name="standard")
+    quick = resolve_training_cli(minimal_cli(), execution_mode_name="quick")
+    assert quick.preset.contract() == standard.preset.contract()
+    assert quick.local_measurement.name == "local-body-tail-quick-v1"
+    assert quick.local_measurement.metric_definition_version == "2.4.0"
+    assert quick.local_measurement.max_images == 16
+    assert quick.local_measurement.timestep_bins == 4
+    assert quick.local_measurement.no_quant_noise_replicas == 3
+    assert quick.local_measurement.candidate_noise_replicas == 2
+    assert quick.local_measurement.stochastic_quant_repeats == 2
+    assert quick.local_measurement.sampling_depth == "reduced_16_image"
+    assert quick.execution_mode.core_grid == standard.execution_mode.core_grid
+    assert quick.execution_mode.prefix_checkpoints == (0, 1, 4, 8)
+    assert quick.execution_mode.standalone_snapshot_count == 1
+    assert quick.execution_mode.gpu_process_count_range == (3, 3)
+
+
 def test_cross_mode_fingerprints_split_shared_local_from_execution_qa(
     tmp_path: Path,
 ) -> None:
@@ -94,6 +113,17 @@ def test_cross_mode_fingerprints_split_shared_local_from_execution_qa(
     assert strict_hashes["local_probe_contract_sha256"] == standard_hashes["local_probe_contract_sha256"]
     assert strict_hashes["execution_qa_contract_sha256"] != standard_hashes["execution_qa_contract_sha256"]
     assert strict["full_protocol_fingerprint_sha256"] != standard["full_protocol_fingerprint_sha256"]
+
+    quick = build_protocol_fingerprint(
+        resolve_training_cli(argv, execution_mode_name="quick"),
+        source_map_payload=({"source_group": "source-01"},),
+    )
+    quick_hashes = quick["contract_hashes"]
+    assert quick_hashes["training_contract_sha256"] == standard_hashes["training_contract_sha256"]
+    assert quick_hashes["dataset_contract_sha256"] == standard_hashes["dataset_contract_sha256"]
+    assert quick_hashes["local_measurement_contract_sha256"] != standard_hashes["local_measurement_contract_sha256"]
+    assert quick_hashes["local_probe_contract_sha256"] != standard_hashes["local_probe_contract_sha256"]
+    assert quick_hashes["execution_qa_contract_sha256"] != standard_hashes["execution_qa_contract_sha256"]
 
 
 def test_full_legacy_style_cli_is_explicit_about_overrides() -> None:
@@ -539,6 +569,30 @@ def test_standard_profile_command_carries_distinct_execution_and_internal_levels
     assert "--dq_profile_range_muls=2.70,3.15,3.45,3.75,4.05" in command
 
 
+def test_quick_profile_command_carries_reduced_sampling_provenance(
+    tmp_path: Path,
+) -> None:
+    request = resolve_training_cli(
+        minimal_cli("--output_name=quick"),
+        execution_mode_name="quick",
+    )
+    command = profile_command(
+        request,
+        run_dir=tmp_path,
+        source_map=tmp_path / "source.json",
+        name="01_core",
+        protocol="v24-acceptance-local",
+        range_muls=request.execution_mode.core_grid,
+        max_images=request.local_measurement.max_images,
+    )
+    assert "--dq_profile_execution_mode=quick" in command
+    assert "--dq_profile_qa_depth=quick_smoke" in command
+    assert "--dq_profile_measurement_contract=local-body-tail-quick-v1" in command
+    assert "--dq_profile_sampling_depth=reduced_16_image" in command
+    assert "--dq_profile_confidence_ceiling=reduced_descriptive" in command
+    assert "--dq_profile_max_images=16" in command
+
+
 def test_dry_run_serializes_the_required_prefix_gate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -650,6 +704,89 @@ def test_execution_plan_matches_the_known_13_image_standard_work_volume(
     assert work["local"]["total_local_probes"] == 1196
     assert plan["reference_time_estimate"]["minutes"]["minimum"] > 0
 
+    quick_request = resolve_training_cli(
+        [
+            f"--pretrained_model_name_or_path={tmp_path / 'model.safetensors'}",
+            f"--dataset_config={dataset}",
+        ],
+        execution_mode_name="quick",
+    )
+    quick_plan = build_execution_plan(
+        quick_request,
+        image_count=13,
+        probe_budget=13,
+    )
+    quick_work = quick_plan["work_volume"]
+    assert quick_plan["measurement_contract"] == "local-body-tail-quick-v1"
+    assert quick_work["gpu_process_count"] == 3
+    assert quick_work["standalone_snapshot_count"] == 1
+    assert quick_work["total_warmup_updates"] == 3120
+    assert quick_work["prefix"]["total_branch_updates"] == 64
+
+
+def test_quick_pipeline_skips_the_redundant_second_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = resolve_training_cli(minimal_cli(), execution_mode_name="quick")
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    profile_calls: list[tuple[str, bool]] = []
+    parity_calls: list[tuple[str, str, str]] = []
+
+    def fake_run_profile(_launcher, _request, **kwargs):
+        name = str(kwargs["name"])
+        profile_calls.append((name, bool(kwargs.get("snapshot_only"))))
+        output = run_dir / name
+        output.mkdir()
+        if name == production_runner.stage_names()["prefix"]:
+            (output / "calibration_gate.json").write_text("{}", encoding="utf-8")
+        return output
+
+    def fake_snapshot_parity(_launcher, left, right, output_name):
+        parity_calls.append((left.name, right.name, output_name))
+        return run_dir / output_name
+
+    def fake_analysis(_launcher, **kwargs):
+        output = run_dir / str(kwargs["output_name"])
+        output.mkdir()
+        (output / "local_selection.json").write_text(
+            json.dumps({"selection_valid": True}),
+            encoding="utf-8",
+        )
+        return output
+
+    class FakeLauncher:
+        dry_run = False
+
+        def __init__(self) -> None:
+            self.run_dir = run_dir
+
+        def run(self, _command, *, label: str) -> None:
+            assert label == "prefix/source contract gate"
+
+    monkeypatch.setattr(production_runner, "run_profile", fake_run_profile)
+    monkeypatch.setattr(production_runner, "run_snapshot_parity", fake_snapshot_parity)
+    monkeypatch.setattr(production_runner, "run_local_analysis", fake_analysis)
+    run_local_pipeline(
+        FakeLauncher(),
+        request,
+        source_map=tmp_path / "source-map.json",
+        probe_budget=16,
+        dataset_id="quick",
+    )
+    names = production_runner.stage_names()
+    assert profile_calls == [
+        (names["snapshot_a"], True),
+        (names["prefix"], False),
+        (names["core_raw"], False),
+    ]
+    assert parity_calls == [
+        (names["snapshot_a"], names["prefix"], names["prefix_snapshot_parity"])
+    ]
+    assert not (run_dir / names["snapshot_b"]).exists()
+    assert not (run_dir / names["snapshot_parity"]).exists()
+
 
 def test_product_artifacts_are_promoted_to_run_root(tmp_path: Path) -> None:
     run_dir = tmp_path / "run"
@@ -716,6 +853,26 @@ def test_direct_module_entry_selects_standard_execution_mode(
     assert production_main.main(["--dq-profile-mode=standard", *training]) == 0
     assert captured["training_argv"] == training
     assert captured["kwargs"]["execution_mode_name"] == "standard"
+
+
+def test_direct_module_entry_selects_quick_execution_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_profile_mode(training_argv: list[str], **kwargs: object) -> int:
+        captured["training_argv"] = training_argv
+        captured["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(production_main, "run_profile_mode", fake_run_profile_mode)
+    training = [
+        f"--dataset_config={DATASET}",
+        f"--pretrained_model_name_or_path={MODEL}",
+    ]
+    assert production_main.main(["--dq-profile-mode=quick", *training]) == 0
+    assert captured["training_argv"] == training
+    assert captured["kwargs"]["execution_mode_name"] == "quick"
 
 
 def test_profile_name_sanitization_is_windows_safe() -> None:

--- a/tests/test_dq_profile_production.py
+++ b/tests/test_dq_profile_production.py
@@ -358,16 +358,62 @@ def test_source_inventory_revalidation_detects_same_size_caption_change(
         validate_source_map_inventory(source_map)
 
 
-def test_source_probe_capacity_rejects_partial_group_coverage() -> None:
-    with pytest.raises(ValueError, match="source_groups=33 exceeds probe_budget=32"):
-        production_runner._validate_source_probe_capacity(
-            source_group_count=33,
-            probe_budget=32,
-        )
-    production_runner._validate_source_probe_capacity(
-        source_group_count=32,
+def test_source_probe_selection_spans_full_order_without_dropping_inventory() -> None:
+    payload = [
+        {
+            "pattern": f"C:/dataset/source-{index:02d}/",
+            "source_group": f"source-{index:02d}",
+            "match": "prefix",
+            "directory": f"C:/dataset/source-{index:02d}",
+            "files": [{"name": "image.png", "size": 5, "sha256": "a" * 64}],
+            "image_count": 1,
+        }
+        for index in range(57)
+    ]
+    selected = production_runner._apply_source_probe_selection(
+        payload,
         probe_budget=32,
     )
+    selected_rows = [row for row in selected if row["probe_selected"]]
+    assert len(selected) == 57
+    assert len(selected_rows) == 32
+    assert selected_rows[0]["source_group"] == "source-00"
+    assert selected_rows[-1]["source_group"] == "source-56"
+    assert [row["probe_selection_rank"] for row in selected_rows] == list(range(32))
+    assert all(
+        row["probe_selection_policy"]
+        == "deterministic_evenly_spaced_source_groups_v1"
+        for row in selected
+    )
+    assert production_runner._apply_source_probe_selection(
+        payload,
+        probe_budget=32,
+    ) == selected
+    summary = production_runner._source_probe_selection_summary(selected)
+    assert summary == {
+        "source_group_count_total": 57,
+        "source_group_count_probed": 32,
+        "source_group_count_omitted": 25,
+        "source_group_coverage_complete": False,
+        "source_group_coverage_fraction": pytest.approx(32 / 57),
+        "source_group_selection_policy": "deterministic_evenly_spaced_source_groups_v1",
+    }
+
+
+def test_source_probe_selection_marks_complete_coverage_when_budget_is_sufficient() -> None:
+    payload = [
+        {"pattern": f"source-{index}", "source_group": f"group-{index}"}
+        for index in range(4)
+    ]
+    selected = production_runner._apply_source_probe_selection(
+        payload,
+        probe_budget=16,
+    )
+    assert all(row["probe_selected"] for row in selected)
+    assert [row["probe_selection_rank"] for row in selected] == list(range(4))
+    assert production_runner._source_probe_selection_summary(selected)[
+        "source_group_coverage_complete"
+    ] is True
 
 
 def test_output_base_policy_and_unique_run_ids(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_dq_profile_production.py
+++ b/tests/test_dq_profile_production.py
@@ -48,7 +48,7 @@ def test_minimal_cli_uses_versioned_preset_and_japanese_paths() -> None:
     request = resolve_training_cli(minimal_cli())
     assert request.preset.name == "canonical-v1"
     assert request.local_measurement.name == "local-body-tail-v1"
-    assert request.execution_mode.name == "strict"
+    assert request.execution_mode.name == "standard"
     assert request.dataset_config.name == "dataset.toml"
     assert request.output_name == "dataset"
     assert {row["action"] for row in request.dispositions} == {"consumed"}
@@ -689,7 +689,7 @@ def test_direct_module_entry_preserves_training_vector(monkeypatch: pytest.Monke
     assert captured["training_argv"] == training
     assert captured["kwargs"] == {
         "preset_name": "canonical-v1",
-        "execution_mode_name": "strict",
+        "execution_mode_name": "standard",
         "output_base": DEFAULT_OUTPUT_BASE,
         "profile_name": "test",
         "preflight_only": False,

--- a/tests/test_dq_profile_production.py
+++ b/tests/test_dq_profile_production.py
@@ -16,6 +16,8 @@ from dq_profile.production_runner import (
     ProductionRunOptions,
     _model_identity,
     allocate_run_directory,
+    build_execution_plan,
+    build_protocol_fingerprint,
     build_source_map,
     git_tracked_state,
     profile_command,
@@ -45,9 +47,53 @@ def minimal_cli(*extra: str) -> list[str]:
 def test_minimal_cli_uses_versioned_preset_and_japanese_paths() -> None:
     request = resolve_training_cli(minimal_cli())
     assert request.preset.name == "canonical-v1"
+    assert request.local_measurement.name == "local-body-tail-v1"
+    assert request.execution_mode.name == "strict"
     assert request.dataset_config.name == "dataset.toml"
     assert request.output_name == "dataset"
     assert {row["action"] for row in request.dispositions} == {"consumed"}
+
+
+def test_standard_mode_keeps_the_shared_local_ruler_and_shortens_only_qa() -> None:
+    strict = resolve_training_cli(minimal_cli(), execution_mode_name="strict")
+    standard = resolve_training_cli(minimal_cli(), execution_mode_name="standard")
+    assert standard.preset.contract() == strict.preset.contract()
+    assert standard.local_measurement.contract() == strict.local_measurement.contract()
+    assert standard.execution_mode.core_grid == (2.70, 3.15, 3.45, 3.75, 4.05)
+    assert standard.execution_mode.prefix_checkpoints == (0, 1, 4, 8)
+    assert standard.execution_mode.prefix_branch_updates == 64
+    assert standard.execution_mode.max_edge_extension_rounds == 0
+    assert strict.execution_mode.prefix_checkpoints == (0, 1, 32, 64)
+    assert strict.execution_mode.prefix_branch_updates == 512
+    assert strict.execution_mode.max_edge_extension_rounds == 2
+
+
+def test_cross_mode_fingerprints_split_shared_local_from_execution_qa(
+    tmp_path: Path,
+) -> None:
+    dataset = tmp_path / "dataset.toml"
+    dataset.write_text("[general]\nresolution=1024\n", encoding="utf-8")
+    model = tmp_path / "model.safetensors"
+    model.write_bytes(b"model")
+    argv = [
+        f"--pretrained_model_name_or_path={model}",
+        f"--dataset_config={dataset}",
+    ]
+    strict = build_protocol_fingerprint(
+        resolve_training_cli(argv, execution_mode_name="strict"),
+        source_map_payload=({"source_group": "source-01"},),
+    )
+    standard = build_protocol_fingerprint(
+        resolve_training_cli(argv, execution_mode_name="standard"),
+        source_map_payload=({"source_group": "source-01"},),
+    )
+    strict_hashes = strict["contract_hashes"]
+    standard_hashes = standard["contract_hashes"]
+    assert strict_hashes["training_contract_sha256"] == standard_hashes["training_contract_sha256"]
+    assert strict_hashes["dataset_contract_sha256"] == standard_hashes["dataset_contract_sha256"]
+    assert strict_hashes["local_probe_contract_sha256"] == standard_hashes["local_probe_contract_sha256"]
+    assert strict_hashes["execution_qa_contract_sha256"] != standard_hashes["execution_qa_contract_sha256"]
+    assert strict["full_protocol_fingerprint_sha256"] != standard["full_protocol_fingerprint_sha256"]
 
 
 def test_full_legacy_style_cli_is_explicit_about_overrides() -> None:
@@ -469,6 +515,30 @@ def test_profile_command_uses_request_paths_and_python_module(tmp_path: Path) ->
     assert "--dq_profile_protocol=v24-acceptance-local" in command
 
 
+def test_standard_profile_command_carries_distinct_execution_and_internal_levels(
+    tmp_path: Path,
+) -> None:
+    request = resolve_training_cli(
+        minimal_cli("--output_name=standard"),
+        execution_mode_name="standard",
+    )
+    command = profile_command(
+        request,
+        run_dir=tmp_path,
+        source_map=tmp_path / "source.json",
+        name="01_core",
+        protocol="v24-acceptance-local",
+        range_muls=request.execution_mode.core_grid,
+        max_images=16,
+    )
+    assert "--dq_profile_execution_mode=standard" in command
+    assert "--dq_profile_qa_depth=standard_smoke" in command
+    assert "--dq_profile_level=standard" in command
+    assert "--dq_profile_prefix_short_steps=8" in command
+    assert "--dq_profile_prefix_long_steps=16" in command
+    assert "--dq_profile_range_muls=2.70,3.15,3.45,3.75,4.05" in command
+
+
 def test_dry_run_serializes_the_required_prefix_gate(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -498,7 +568,8 @@ def test_dry_run_serializes_the_required_prefix_gate(
             f"--pretrained_model_name_or_path={model}",
             f"--dataset_config={dataset}",
             "--output_name=dry-run",
-        ]
+        ],
+        execution_mode_name="standard",
     )
     monkeypatch.setattr(production_runner, "preflight", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
@@ -528,6 +599,56 @@ def test_dry_run_serializes_the_required_prefix_gate(
     )
     assert payload["requires_prefix_gate"] == str(expected_gate)
     assert f"--dq_profile_prefix_gate_file={expected_gate}" in payload["argv"]
+    plan = json.loads((result.run_dir / "execution_plan.json").read_text(encoding="utf-8"))
+    assert plan["execution_mode"] == "standard"
+    assert plan["qa_depth"] == "standard_smoke"
+    assert plan["work_volume"]["gpu_process_count"] == 4
+    assert plan["work_volume"]["prefix"]["total_branch_updates"] == 64
+    assert plan["work_volume"]["local"]["fixed_grid"] == [2.7, 3.15, 3.45, 3.75, 4.05]
+    assert plan["work_volume"]["local"]["total_local_probes"] == 736
+    assert plan["reference_time_estimate"]["is_guarantee"] is False
+
+
+def test_execution_plan_matches_the_known_13_image_standard_work_volume(
+    tmp_path: Path,
+) -> None:
+    source_dirs = []
+    for source_index, image_total in enumerate((4, 3, 3, 3)):
+        source = tmp_path / f"source-{source_index}"
+        source.mkdir()
+        for image_index in range(image_total):
+            (source / f"image-{image_index}.png").write_bytes(b"image")
+        source_dirs.append(source)
+    dataset = tmp_path / "dataset.toml"
+    dataset.write_text(
+        "[general]\n"
+        "resolution=1024\n"
+        "[[datasets]]\n"
+        + "".join(
+            "[[datasets.subsets]]\n"
+            + f"image_dir = {json.dumps(str(source))}\n"
+            + "num_repeats = 40\n"
+            for source in source_dirs
+        ),
+        encoding="utf-8",
+    )
+    request = resolve_training_cli(
+        [
+            f"--pretrained_model_name_or_path={tmp_path / 'model.safetensors'}",
+            f"--dataset_config={dataset}",
+        ],
+        execution_mode_name="standard",
+    )
+    plan = build_execution_plan(request, image_count=13, probe_budget=13)
+    work = plan["work_volume"]
+    assert work["warmup_boundary_updates"] == 1040
+    assert work["total_warmup_updates"] == 4160
+    assert work["prefix"]["checkpoints"] == [0, 1, 4, 8]
+    assert work["prefix"]["total_branch_updates"] == 64
+    assert work["local"]["no_quant_probes"] == 156
+    assert work["local"]["candidate_probes"] == 1040
+    assert work["local"]["total_local_probes"] == 1196
+    assert plan["reference_time_estimate"]["minutes"]["minimum"] > 0
 
 
 def test_product_artifacts_are_promoted_to_run_root(tmp_path: Path) -> None:
@@ -568,12 +689,33 @@ def test_direct_module_entry_preserves_training_vector(monkeypatch: pytest.Monke
     assert captured["training_argv"] == training
     assert captured["kwargs"] == {
         "preset_name": "canonical-v1",
+        "execution_mode_name": "strict",
         "output_base": DEFAULT_OUTPUT_BASE,
         "profile_name": "test",
         "preflight_only": False,
         "dry_run": False,
         "open_report": False,
     }
+
+
+def test_direct_module_entry_selects_standard_execution_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_profile_mode(training_argv: list[str], **kwargs: object) -> int:
+        captured["training_argv"] = training_argv
+        captured["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(production_main, "run_profile_mode", fake_run_profile_mode)
+    training = [
+        f"--dataset_config={DATASET}",
+        f"--pretrained_model_name_or_path={MODEL}",
+    ]
+    assert production_main.main(["--dq-profile-mode=standard", *training]) == 0
+    assert captured["training_argv"] == training
+    assert captured["kwargs"]["execution_mode_name"] == "standard"
 
 
 def test_profile_name_sanitization_is_windows_safe() -> None:

--- a/tests/test_dq_profile_production.py
+++ b/tests/test_dq_profile_production.py
@@ -783,13 +783,20 @@ def test_product_artifacts_are_promoted_to_run_root(tmp_path: Path) -> None:
     run_dir.mkdir()
     analysis.mkdir()
     profile.mkdir()
-    for name in ("report.html", "technical_report.html", "summary.json", "practical_report.json"):
+    for name in (
+        "report.html",
+        "beginner_report.html",
+        "technical_report.html",
+        "summary.json",
+        "practical_report.json",
+    ):
         (analysis / name).write_text(name, encoding="utf-8")
     (profile / "source_manifest.json").write_text("{}", encoding="utf-8")
     (profile / "candidate_definitions.json").write_text("{}", encoding="utf-8")
     promoted = promote_analysis(run_dir, analysis)
     promoted.extend(promote_profile_provenance(run_dir, profile))
     assert (run_dir / "report.html").is_file()
+    assert (run_dir / "beginner_report.html").is_file()
     assert (run_dir / "source_manifest.json").is_file()
     assert "candidate_definitions.json" in promoted
 

--- a/tests/test_dq_profile_v21.py
+++ b/tests/test_dq_profile_v21.py
@@ -217,6 +217,32 @@ def test_prefix_pair_exact_numeric_and_control_failure():
     assert gate["passed"] is False
 
 
+def test_prefix_pair_accepts_standard_smoke_checkpoint_contract():
+    traces = [_trace_row(step) for step in range(8)]
+    checkpoints = (0, 1, 4, 8)
+    states = {
+        checkpoint: _state(float(checkpoint + 1), f"standard-{checkpoint}")
+        for checkpoint in checkpoints
+    }
+    rows, summary = evaluate_prefix_pair(
+        reference_rows=traces,
+        candidate_rows=[dict(row) for row in traces],
+        reference_states=states,
+        candidate_states=states,
+        comparison="8A_vs_16_at8",
+        candidate_name="mul_3.150",
+        required_checkpoints=checkpoints,
+    )
+    assert summary["status"] == "pass_exact"
+    assert summary["required_state_checkpoints"] == [0, 1, 4, 8]
+    assert {row["step"] for row in rows if row["record_type"] == "state"} == {
+        0,
+        1,
+        4,
+        8,
+    }
+
+
 def test_dropout_and_quant_digests_cover_sites_and_invocations_without_global_rng():
     context = ProfileQuantContext(39)
     context.begin_pass(

--- a/tests/test_dq_profile_v24_acceptance.py
+++ b/tests/test_dq_profile_v24_acceptance.py
@@ -237,6 +237,32 @@ def test_hard_safety_candidate_is_never_selected() -> None:
     assert result["selection"]["utility"] == "unknown"
 
 
+def test_nonfinite_candidate_is_hard_unsafe_while_other_candidates_complete() -> None:
+    summary, rows = _fixture(
+        {2.70: 0.55, 3.15: 0.35, 3.45: 0.75}
+    )
+    bad = next(row for row in rows if row["candidate"] == "mul_3.150")
+    bad["grad_norm_candidate"] = float("nan")
+    result = _analyze((summary, rows), iterations=60, seed=57)
+
+    score_by_mul = {row["range_mul"]: row for row in result["score_rows"]}
+    unsafe = score_by_mul[3.15]
+    assert unsafe["hard_safety_pass"] is False
+    assert unsafe["invalid_reason"] == "candidate_nonfinite_probe_measurement"
+    assert unsafe["nonfinite_sample_count"] == 1
+    assert unsafe["nonfinite_fields"] == ["grad_norm_candidate"]
+    assert unsafe["local_body"] is None
+    assert unsafe["retained_for_formal"] is False
+    assert score_by_mul[2.70]["local_body"] is not None
+    assert score_by_mul[3.45]["local_tail"] is not None
+    assert 3.15 not in result["selection"]["credible_muls"]
+    assert result["selection"]["hard_unsafe_candidates"] == ["mul_3.150"]
+    assert result["summary"]["nonfinite_event_count"] == 1
+    assert {
+        row["candidate"] for row in result["bootstrap_rows"]
+    } == {"mul_2.700", "mul_3.450"}
+
+
 def test_no_quant_natural_gradient_baseline_uses_source_clusters() -> None:
     rows = []
     for image in range(13):
@@ -272,4 +298,33 @@ def test_no_quant_natural_gradient_baseline_uses_source_clusters() -> None:
     assert result["source_group_count"] == 6
     assert result["pair_count"] == 13 * 4 * 3
     assert result["local_tail"] >= result["local_body"]
+    assert result["selector_input"] is False
+
+
+def test_nonfinite_natural_gradient_invalidates_only_descriptive_baseline() -> None:
+    row = {
+        "image_key": "image-00",
+        "source_group": "source-00",
+        "timestep_bin": 0,
+        "noise_replica_a": 0,
+        "noise_replica_b": 1,
+        "grad_norm_a": 1.0,
+        "grad_norm_b": float("nan"),
+        "grad_diff_norm": float("nan"),
+        "gradient_cosine": float("nan"),
+        "relative_gradient_distance_a_to_b": float("nan"),
+        "symmetric_gradient_distance": float("nan"),
+        "angular_gradient_distance": 2.0,
+        "gradient_gain_distance": float("nan"),
+        "gradient_topology_matches": True,
+    }
+    result = analyze_natural_gradient_rows(
+        [row],
+        timestep_bins=4,
+        bootstrap_iterations=20,
+        bootstrap_seed=61,
+    )
+    assert result["valid"] is False
+    assert result["invalid_reason"] == "nonfinite_natural_gradient_measurement"
+    assert result["nonfinite_event_count"] == 1
     assert result["selector_input"] is False

--- a/tests/test_dq_profile_v24_beginner_report.py
+++ b/tests/test_dq_profile_v24_beginner_report.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dq_profile.v24_beginner_report import render_beginner_report
+from tools.render_dq_beginner_report import render_existing_run
+
+
+def _model() -> dict:
+    cards = [
+        {
+            "range_mul": 2.70,
+            "body": 0.82,
+            "body_ci_low": 0.70,
+            "body_ci_high": 0.95,
+            "tail": 1.28,
+            "tail_ci_low": 1.02,
+            "tail_ci_high": 1.60,
+            "hard_safety_pass": True,
+            "absolute_perturbation": "tail_attention",
+            "edge_endpoint": False,
+        },
+        {
+            "range_mul": 3.15,
+            "body": 0.69,
+            "body_ci_low": 0.61,
+            "body_ci_high": 0.78,
+            "tail": 0.88,
+            "tail_ci_low": 0.72,
+            "tail_ci_high": 1.05,
+            "hard_safety_pass": True,
+            "absolute_perturbation": "low_perturbation",
+            "edge_endpoint": False,
+        },
+        {
+            "range_mul": 3.45,
+            "body": 0.73,
+            "body_ci_low": 0.64,
+            "body_ci_high": 0.84,
+            "tail": 0.91,
+            "tail_ci_low": 0.77,
+            "tail_ci_high": 1.08,
+            "hard_safety_pass": True,
+            "absolute_perturbation": "low_perturbation",
+            "edge_endpoint": True,
+        },
+    ]
+    dataset = {
+        "dataset_id": "SYN",
+        "label": "Example dataset",
+        "execution_mode": "standard",
+        "candidate_cards": cards,
+        "hard_safety_pass_count": 3,
+        "fidelity_retained_muls": [3.15, 3.45],
+        "relatively_stronger_muls": [2.70],
+        "body_representative_mul": 3.15,
+        "tail_representative_mul": 3.15,
+        "single_representative_mul": 3.15,
+        "representative_selection_reason": "BodyとTailの代表が一致しました。",
+        "absolute_response": "mixed_absolute_response",
+        "absolute_response_label": "mulにより摂動帯が変化",
+        "edge_direction": "upper",
+        "measurement_quality": {
+            "level": "PASS",
+            "reasons": ["必須gateを通過しました。"],
+        },
+        "local_comparison_confidence": {
+            "level": "Medium",
+            "reasons": ["候補のCIが一部重なります。"],
+        },
+        "recommendation_maturity": {"level": "Local-only"},
+        "image_count": 32,
+        "image_count_probed": 32,
+        "image_count_total": 40,
+        "source_group_count": 6,
+        "source_group_count_probed": 6,
+        "source_group_count_total": 6,
+        "dataset_character_vector": {
+            "channels": {
+                "no_quant_stability": {
+                    "natural_variation": {"local_tail": 4.2}
+                },
+                "absolute_acceptance": {"minimum_tail": 0.88},
+                "mul_response": {
+                    "label": "interior_valley",
+                    "span": 0.40,
+                },
+                "source_localization": {"top_source_share": 0.56},
+            }
+        },
+        "no_quant_baseline_profile": {
+            "timestep_rows": [
+                {"timestep_bin": 0, "grad_norm_rms": 1.0},
+                {"timestep_bin": 3, "grad_norm_rms": 3.2},
+            ]
+        },
+        "source_localization": {
+            "reference_profile": {
+                "range_mul": 3.15,
+                "top_source_share": 0.56,
+                "top_source_alias": "source-03",
+                "loo_max_tail_reduction_fraction": 0.22,
+                "loo_most_actionable_source_alias": "source-03",
+                "effective_source_count": 4.1,
+                "source_group_count": 6,
+            }
+        },
+        "timestep_rows": [
+            {
+                "range_mul": mul,
+                "timestep_bin": bin_index,
+                "source_balanced_q95_relative_distance": value,
+            }
+            for mul, values in {
+                2.70: (0.70, 0.84, 1.06, 1.28),
+                3.15: (0.62, 0.69, 0.77, 0.88),
+                3.45: (0.65, 0.73, 0.82, 0.91),
+            }.items()
+            for bin_index, value in enumerate(values)
+        ],
+    }
+    return {
+        "schema_version": "2.4.3",
+        "not_quality_or_utility": True,
+        "dataset_count": 1,
+        "datasets": [dataset],
+    }
+
+
+def test_beginner_report_leads_with_curve_and_explains_each_channel() -> None:
+    rendered = render_beginner_report(_model())
+    assert "診断レポート（概要）" in rendered
+    assert rendered.index('class="chart-card"') < rendered.index("まず読む3行")
+    assert 'data-scale-mode="fixed" data-y-max="4.000000"' in rendered
+    assert "<strong>Body</strong>" in rendered
+    assert "<strong>Tail</strong>" in rendered
+    assert "全画像・timestepをまとめた、やや厳しめの代表値" in rendered
+    assert "各timestep帯の代表値のうち最大" in rendered
+    assert "ヒゲ（淡い縦棒）" in rendered
+    assert "試したmulと役割" in rendered
+    assert "橙の「注意」は安全だが相対的に強い摂動" in rendered
+    assert 'class="matrix-mark attention"' in rendered
+    assert 'class="matrix-mark representative"' in rendered
+    assert "今回見られた動き" in rendered
+    assert "Body × Tail マップ" in rendered
+    assert "Body：左ほどno_quantに近い／右ほど変形が強い" in rendered
+    assert "Tail：下ほどno_quantに近い／上ほど難しい帯が強い" in rendered
+    assert "データセットの性格カルテ" in rendered
+    assert "中央線は参照集団の中央値で、理想値や良否の閾値ではありません" in rendered
+    for label in (
+        "no-quant自然変動",
+        "量子化変形（最小Tail）",
+        "mul感度",
+        "source集中",
+        "timestep偏り",
+    ):
+        assert label in rendered
+    assert "小さい＝信号が均一 ／ 大きい＝元々揺れやすい" in rendered
+    assert "小さい＝no_quantに近い ／ 大きい＝最良mulでもTailが残る" in rendered
+    assert "小さい＝mulに頑健 ／ 大きい＝mul選びが重要" in rendered
+    assert "小さい＝複数sourceへ分散 ／ 大きい＝一部sourceへ集中" in rendered
+    assert "小さい＝timestep間で均一 ／ 大きい＝特定帯へ偏る" in rendered
+    assert "Tailはどの画像グループに偏っているか" in rendered
+    assert "sourceはTOML内の画像グループ" in rendered
+    assert "1 sourceを計算上外したときの最大Tail低下" in rendered
+    assert "高い＝画質不良やsource削除推奨ではありません" in rendered
+    assert "timestep帯ごとの変形" in rendered
+    assert "値が小さいほどno_quantに近く、大きいほどその帯で量子化による変形が強くなります" in rendered
+    assert "Body／Tailは上のグラフと同じ値です" in rendered
+    assert "QA通過は測定が有効という意味で、画質保証ではありません" in rendered
+    assert "この診断で分かること" in rendered
+    assert "この診断だけでは分からないこと" in rendered
+    assert 'href="report.html"' in rendered
+    assert 'href="technical_report.html"' in rendered
+    assert "最終生成画質のbest mul" in rendered
+    assert "固定mulごとの局所的な勾配変形" in rendered
+
+
+def test_beginner_report_refuses_cross_dataset_input() -> None:
+    model = _model()
+    model["datasets"] = [model["datasets"][0], dict(model["datasets"][0])]
+    with pytest.raises(ValueError, match="exactly one dataset"):
+        render_beginner_report(model)
+
+
+def test_backfill_tool_writes_beginner_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    run_dir = tmp_path / "completed-run"
+    run_dir.mkdir()
+    (run_dir / "practical_report.json").write_text(
+        json.dumps(_model(), ensure_ascii=False),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "tools.render_dq_beginner_report.render_practical_report",
+        lambda _model: "<html>refreshed practical report</html>",
+    )
+    output = render_existing_run(run_dir, refresh_practical_report=True)
+    assert output == (run_dir / "beginner_report.html").resolve()
+    assert output.is_file()
+    assert (run_dir / "report.html").is_file()
+    rendered = output.read_text(encoding="utf-8")
+    assert "Example dataset" in rendered
+    assert "Safety/Fidelity ≠ 最終画質Utility" in rendered
+    assert "refreshed practical report" in (run_dir / "report.html").read_text(
+        encoding="utf-8"
+    )

--- a/tests/test_dq_profile_v24_descriptive.py
+++ b/tests/test_dq_profile_v24_descriptive.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import pytest
+
+from dq_profile.v24_descriptive import (
+    analyze_no_quant_baseline,
+    analyze_source_localization,
+    build_dataset_character_vector,
+)
+
+
+def _score_rows() -> list[dict]:
+    return [
+        {
+            "candidate": "mul_2.700",
+            "range_mul": 2.70,
+            "hard_safety_pass": True,
+            "local_body": 0.80,
+            "local_tail": 1.00,
+            "tail_amplification": 1.25,
+        },
+        {
+            "candidate": "mul_3.150",
+            "range_mul": 3.15,
+            "hard_safety_pass": True,
+            "local_body": 0.50,
+            "local_tail": 0.60,
+            "tail_amplification": 1.20,
+        },
+    ]
+
+
+def _tail_rows() -> list[dict]:
+    rows: list[dict] = []
+    candidates = ("mul_2.700", "mul_3.150")
+    for candidate in candidates:
+        for source_index, source in enumerate(("source-a", "source-b", "source-c")):
+            for sample in range(20):
+                if candidate == "mul_2.700":
+                    distance = 5.0 if source == "source-a" and sample >= 18 else 0.0
+                else:
+                    distance = 1.0 if sample >= 18 else 0.0
+                rows.append(
+                    {
+                        "record_type": "sample",
+                        "candidate": candidate,
+                        "image_key": f"{source}-image-{sample:02d}",
+                        "source_group": source,
+                        "timestep_bin": sample % 4,
+                        "noise_replica": 0,
+                        "quant_repeat": 0,
+                        "relative_gradient_distance": distance,
+                        "grad_norm_noquant": float(source_index + 1),
+                    }
+                )
+    return rows
+
+
+def test_source_localization_separates_concentrated_and_diffuse_tail() -> None:
+    result = analyze_source_localization(
+        gradient_tail_rows=_tail_rows(),
+        score_rows=_score_rows(),
+        source_loo_rows=[
+            {
+                "candidate": "mul_2.700",
+                "omitted_source_group": "source-a",
+                "local_tail": 0.90,
+            },
+            {
+                "candidate": "mul_2.700",
+                "omitted_source_group": "source-b",
+                "local_tail": 0.20,
+            },
+        ],
+    )
+
+    profiles = {row["candidate"]: row for row in result["candidate_profiles"]}
+    concentrated = profiles["mul_2.700"]
+    diffuse = profiles["mul_3.150"]
+    assert concentrated["top_source_alias"] == "S01"
+    assert concentrated["top_source_share"] == pytest.approx(1.0)
+    assert concentrated["effective_source_count"] == pytest.approx(1.0)
+    assert diffuse["top_source_share"] == pytest.approx(1.0 / 3.0)
+    assert diffuse["effective_source_count"] == pytest.approx(3.0)
+    assert concentrated["top_source_stable_across_thresholds"] is True
+
+    # The source with the largest local burden need not be the source whose
+    # leave-one-out removal changes the dataset Tail most.
+    assert concentrated["loo_most_actionable_source_alias"] == "S02"
+    assert concentrated["loo_max_tail_reduction"] == pytest.approx(0.8)
+    assert result["selector_input"] is False
+    assert result["not_quality_or_utility"] is True
+
+
+def test_source_localization_uses_each_candidates_worst_timestep_bin() -> None:
+    rows: list[dict] = []
+    for source in ("source-a", "source-b"):
+        for sample in range(20):
+            rows.append(
+                {
+                    "record_type": "sample",
+                    "candidate": "mul_3.150",
+                    "image_key": f"{source}-tail-{sample}",
+                    "source_group": source,
+                    "timestep_bin": 3,
+                    "noise_replica": 0,
+                    "quant_repeat": 0,
+                    "relative_gradient_distance": (
+                        5.0 if source == "source-a" and sample >= 18 else 0.0
+                    ),
+                }
+            )
+            rows.append(
+                {
+                    "record_type": "sample",
+                    "candidate": "mul_3.150",
+                    "image_key": f"{source}-body-{sample}",
+                    "source_group": source,
+                    "timestep_bin": 0,
+                    "noise_replica": 0,
+                    "quant_repeat": 0,
+                    "relative_gradient_distance": (
+                        100.0 if source == "source-b" else 0.0
+                    ),
+                }
+            )
+    result = analyze_source_localization(
+        gradient_tail_rows=rows,
+        score_rows=[
+            {
+                "candidate": "mul_3.150",
+                "range_mul": 3.15,
+                "hard_safety_pass": True,
+                "local_body": 0.5,
+                "local_tail": 1.0,
+                "tail_amplification": 2.0,
+                "worst_timestep_bin": 3,
+            }
+        ],
+        source_loo_rows=[],
+    )
+    reference = result["reference_profile"]
+    assert reference["timestep_bin"] == 3
+    assert reference["top_source_alias"] == "S01"
+    assert reference["local_tail"] == pytest.approx(1.0)
+
+
+def test_no_quant_profile_deduplicates_candidate_and_quant_repeat_rows() -> None:
+    rows: list[dict] = []
+    for candidate in ("mul_2.700", "mul_3.150"):
+        for quant_repeat in (0, 1):
+            for source, norm in (("source-a", 2.0), ("source-b", 1.0)):
+                for timestep_bin in range(4):
+                    rows.append(
+                        {
+                            "record_type": "sample",
+                            "candidate": candidate,
+                            "image_key": f"{source}-image-{timestep_bin}",
+                            "source_group": source,
+                            "timestep_bin": timestep_bin,
+                            "noise_replica": 0,
+                            "quant_repeat": quant_repeat,
+                            "grad_norm_noquant": norm,
+                        }
+                    )
+    result = analyze_no_quant_baseline(
+        gradient_tail_rows=rows,
+        natural_baseline={
+            "valid": True,
+            "local_body": 0.10,
+            "local_tail": 0.20,
+            "tail_amplification": 2.0,
+            "worst_timestep_bin": 3,
+        },
+        timestep_bins=4,
+    )
+
+    assert result["probe_count"] == 8
+    assert result["reference_duplicate_consistency_pass"] is True
+    assert result["source_load"]["top_source_alias"] == "S01"
+    assert result["source_load"]["top_source_energy_share"] == pytest.approx(0.8)
+    assert result["source_load"]["effective_source_count"] == pytest.approx(
+        1.0 / (0.8**2 + 0.2**2)
+    )
+    assert len(result["timestep_rows"]) == 4
+    assert result["selector_input"] is False
+
+
+def test_dataset_character_vector_keeps_channels_separate() -> None:
+    source = analyze_source_localization(
+        gradient_tail_rows=_tail_rows(),
+        score_rows=_score_rows(),
+        source_loo_rows=[],
+    )
+    no_quant = analyze_no_quant_baseline(
+        gradient_tail_rows=_tail_rows(),
+        natural_baseline={"valid": False, "invalid_reason": "synthetic"},
+        timestep_bins=4,
+    )
+    vector = build_dataset_character_vector(
+        score_rows=_score_rows(),
+        local_phenotype="selective_window",
+        source_localization=source,
+        no_quant_baseline=no_quant,
+    )
+
+    assert vector["channels"]["mul_response"]["label"] == (
+        "upper_range_reduces_deformation"
+    )
+    assert vector["single_composite_score"] is None
+    assert vector["selector_input"] is False
+    assert vector["not_quality_or_utility"] is True

--- a/tests/test_dq_profile_v24_practical_report.py
+++ b/tests/test_dq_profile_v24_practical_report.py
@@ -211,13 +211,16 @@ def test_dataset_card_keeps_local_only_and_edge_uncertainty() -> None:
     assert by_mul[3.15]["overall_fidelity_gauge"] is None
     assert "TRAJECTORY_NOT_MEASURED" in by_mul[3.15]["reason_codes"]
     assert card["measurement_quality"]["level"] == "PASS"
+    assert card["execution_mode"] == "strict"
+    assert card["qa_depth"] == "strict_reference"
     assert card["local_comparison_confidence"]["level"] == "Medium"
     assert card["recommendation_maturity"]["level"] == "Local-only"
     assert card["single_representative_mul"] is None
     assert card["representative_selection_state"] == "no_single_edge_unresolved"
     assert card["actions"]["minimum_comparison_set"] == [
         "no_quant",
-        "mul 3.15（観測上のBody／Tail代表）",
+        "mul 3.15（Fidelity retained）",
+        "mul 3.45（Fidelity retained）",
     ]
     assert card["not_quality_or_utility"] is True
 
@@ -243,6 +246,8 @@ def test_single_dataset_report_is_local_only_and_hides_trajectory_from_selection
     html = render_report(model)
     assert "dataset-selector is-single" in html
     assert "Safety/Fidelity ≠ Utility" in html
+    assert "Strict reference" in html
+    assert "v2.4.3 practical report beta" in html
 
 def test_all_retained_candidates_do_not_force_a_single_representative() -> None:
     rows = [
@@ -305,7 +310,7 @@ def test_edge_unresolved_with_one_retained_candidate_still_abstains() -> None:
     assert card["representative_selection_state"] == "no_single_edge_unresolved"
     assert card["actions"]["minimum_comparison_set"] == [
         "no_quant",
-        "mul 3.45（観測上のBody／Tail代表）",
+        "mul 3.45（Fidelity retained）",
     ]
 
 

--- a/tests/test_dq_profile_v24_practical_report.py
+++ b/tests/test_dq_profile_v24_practical_report.py
@@ -144,7 +144,8 @@ def test_fidelity_gauge_is_descriptive_worst_channel() -> None:
         contract["affinity_curve_scale"]["mode"]
         == "fixed_primary_with_dataset_auto_zoom"
     )
-    assert "quick" in contract["execution_mode"]
+    assert contract["execution_mode"]["supported_new_runs"] == ["standard", "strict"]
+    assert "legacy_quick" in contract["execution_mode"]
     assert contract["execution_mode"]["sampling_depth_field"] == "sampling_depth"
 
 
@@ -252,7 +253,7 @@ def test_single_dataset_report_is_local_only_and_hides_trajectory_from_selection
     assert "v2.4.3 practical report beta" in html
 
 
-def test_quick_report_exposes_reduced_sampling_and_confidence_ceiling() -> None:
+def test_legacy_quick_report_exposes_reduced_sampling_and_confidence_ceiling() -> None:
     rows = [
         _candidate(2.70, 1.2, 1.3, dominated_by=3.15),
         _candidate(3.15, 0.7, 0.8),

--- a/tests/test_dq_profile_v24_practical_report.py
+++ b/tests/test_dq_profile_v24_practical_report.py
@@ -288,6 +288,89 @@ def test_quick_report_exposes_reduced_sampling_and_confidence_ceiling() -> None:
     assert "Reduced (max 16 images)" in html
     assert "local-body-tail-quick-v1" in html
 
+
+def test_partial_source_coverage_is_visible_and_caps_high_confidence() -> None:
+    rows = [
+        _candidate(2.70, 1.2, 1.3, dominated_by=3.15),
+        _candidate(3.15, 0.7, 0.8),
+        _candidate(3.45, 0.8, 0.9),
+    ]
+    detail = _detail()
+    detail["summary"].update(
+        {
+            "source_group_count": 32,
+            "source_group_count_probed": 32,
+            "source_group_count_total": 57,
+            "source_group_coverage_complete": False,
+            "source_group_coverage_fraction": 32 / 57,
+            "source_group_selection_policy": (
+                "deterministic_evenly_spaced_source_groups_v1"
+            ),
+        }
+    )
+    model = build_single_dataset_report_model(
+        dataset_id="SYN",
+        candidate_rows=rows,
+        detail=detail,
+    )
+    dataset = model["datasets"][0]
+    assert dataset["source_group_count_probed"] == 32
+    assert dataset["source_group_count_total"] == 57
+    assert dataset["source_group_coverage_complete"] is False
+    assert dataset["local_comparison_confidence"]["level"] == "Medium"
+    assert any(
+        "57群のうち32群" in reason
+        for reason in dataset["local_comparison_confidence"]["reasons"]
+    )
+    html = render_report(model)
+    assert "32 / 57" in html
+
+
+def test_hard_unsafe_candidate_with_null_metrics_still_renders() -> None:
+    rows = [
+        _candidate(2.70, 0.8, 0.9),
+        _candidate(3.15, 0.7, 0.8),
+        _candidate(3.45, 0.9, 1.0),
+    ]
+    unsafe = rows[1]
+    unsafe.update(
+        {
+            "hard_safety_pass": False,
+            "invalid_reason": "candidate_nonfinite_probe_measurement",
+            "nonfinite_sample_count": 1,
+            "local_body": None,
+            "local_body_ci_low": None,
+            "local_body_ci_high": None,
+            "local_tail": None,
+            "local_tail_ci_low": None,
+            "local_tail_ci_high": None,
+            "tail_amplification": None,
+        }
+    )
+    detail = _detail()
+    detail["selection"].update(
+        {
+            "credible_muls": [2.70, 3.45],
+            "point_body_min_candidate": "mul_2.700",
+            "point_tail_min_candidate": "mul_2.700",
+        }
+    )
+    model = build_single_dataset_report_model(
+        dataset_id="SYN",
+        candidate_rows=rows,
+        detail=detail,
+    )
+    card = next(
+        item
+        for item in model["datasets"][0]["candidate_cards"]
+        if item["range_mul"] == 3.15
+    )
+    assert card["absolute_perturbation"] == "hard_unsafe"
+    assert card["invalid_reason"] == "candidate_nonfinite_probe_measurement"
+    assert "candidate_nonfinite_probe_measurement" in card["explanation_ja"]
+    assert "Hard unsafe" in render_report(model)
+
+
 def test_all_retained_candidates_do_not_force_a_single_representative() -> None:
     rows = [
         _candidate(2.70, 0.85, 0.95),

--- a/tests/test_dq_profile_v24_practical_report.py
+++ b/tests/test_dq_profile_v24_practical_report.py
@@ -144,6 +144,8 @@ def test_fidelity_gauge_is_descriptive_worst_channel() -> None:
         contract["affinity_curve_scale"]["mode"]
         == "fixed_primary_with_dataset_auto_zoom"
     )
+    assert "quick" in contract["execution_mode"]
+    assert contract["execution_mode"]["sampling_depth_field"] == "sampling_depth"
 
 
 def test_absolute_perturbation_is_independent_of_relative_rank() -> None:
@@ -248,6 +250,43 @@ def test_single_dataset_report_is_local_only_and_hides_trajectory_from_selection
     assert "Safety/Fidelity ≠ Utility" in html
     assert "Strict reference" in html
     assert "v2.4.3 practical report beta" in html
+
+
+def test_quick_report_exposes_reduced_sampling_and_confidence_ceiling() -> None:
+    rows = [
+        _candidate(2.70, 1.2, 1.3, dominated_by=3.15),
+        _candidate(3.15, 0.7, 0.8),
+        _candidate(3.45, 0.8, 0.9),
+    ]
+    detail = _detail()
+    detail["summary"].update(
+        {
+            "execution_mode": "quick",
+            "qa_depth": "quick_smoke",
+            "measurement_contract": "local-body-tail-quick-v1",
+            "sampling_depth": "reduced_16_image",
+            "confidence_ceiling": "reduced_descriptive",
+        }
+    )
+    model = build_single_dataset_report_model(
+        dataset_id="SYN",
+        candidate_rows=rows,
+        detail=detail,
+    )
+    dataset = model["datasets"][0]
+    assert dataset["execution_mode"] == "quick"
+    assert dataset["qa_depth"] == "quick_smoke"
+    assert dataset["measurement_contract"] == "local-body-tail-quick-v1"
+    assert dataset["sampling_depth"] == "reduced_16_image"
+    assert dataset["confidence_ceiling"] == "reduced_descriptive"
+    assert any(
+        "最大16画像" in reason
+        for reason in dataset["local_comparison_confidence"]["reasons"]
+    )
+    html = render_report(model)
+    assert "Quick smoke" in html
+    assert "Reduced (max 16 images)" in html
+    assert "local-body-tail-quick-v1" in html
 
 def test_all_retained_candidates_do_not_force_a_single_representative() -> None:
     rows = [

--- a/tests/test_dq_profile_v24_practical_report.py
+++ b/tests/test_dq_profile_v24_practical_report.py
@@ -251,6 +251,7 @@ def test_single_dataset_report_is_local_only_and_hides_trajectory_from_selection
     assert "Safety/Fidelity ≠ Utility" in html
     assert "Strict reference" in html
     assert "v2.4.3 practical report beta" in html
+    assert 'href="beginner_report.html"' in html
 
 
 def test_legacy_quick_report_exposes_reduced_sampling_and_confidence_ceiling() -> None:
@@ -524,7 +525,11 @@ def test_rendered_report_states_scope_and_does_not_force_overall() -> None:
     assert "試したmulと役割" in rendered
     assert "Hard-safety pass" in rendered
     assert "Fidelity retained" in rendered
-    assert '<span class="matrix-mark on" aria-label="該当">○</span>' in rendered
+    assert 'class="matrix-mark pass"' in rendered
+    assert 'class="matrix-mark retained"' in rendered
+    assert 'class="matrix-mark attention"' in rendered
+    assert 'class="matrix-mark representative"' in rendered
+    assert "すべてが同じ意味の「合格」ではなく" in rendered
     assert '<article id="dataset-SYN" class="view dataset-view">' in rendered
     assert '<section id="overview" class="view" hidden>' in rendered
     assert "dataset-selector is-single" in rendered

--- a/tests/test_dq_profile_v2_runtime.py
+++ b/tests/test_dq_profile_v2_runtime.py
@@ -113,6 +113,51 @@ def test_source_group_map_supports_exact_and_longest_prefix(tmp_path):
     assert mapping.resolve(r"D:\images\c\crop3.png") == "all"
 
 
+def test_source_group_map_keeps_full_resolution_but_limits_probe_order(tmp_path):
+    source = tmp_path / "sources.json"
+    source.write_text(
+        json.dumps(
+            [
+                {
+                    "pattern": "D:/images/a/",
+                    "source_group": "source-a",
+                    "match": "prefix",
+                    "probe_selected": True,
+                    "probe_selection_rank": 0,
+                },
+                {
+                    "pattern": "D:/images/b/",
+                    "source_group": "source-b",
+                    "match": "prefix",
+                    "probe_selected": False,
+                    "probe_selection_rank": None,
+                },
+                {
+                    "pattern": "D:/images/c/",
+                    "source_group": "source-c",
+                    "match": "prefix",
+                    "probe_selected": True,
+                    "probe_selection_rank": 1,
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    mapping = SourceGroupMap.load(source)
+    assert mapping.resolve("D:/images/b/image.png") == "source-b"
+    assert DiagnosticProfileRuntime._source_group_order(mapping) == (
+        "source-a",
+        "source-c",
+    )
+    manifest = mapping.manifest()
+    assert manifest["source_group_count_total"] == 3
+    assert manifest["source_group_count_probed"] == 2
+    assert manifest["source_group_coverage_complete"] is False
+    assert manifest["source_group_selection_policy"] == (
+        "deterministic_evenly_spaced_source_groups_v1"
+    )
+
+
 class _ReplayLoader:
     def __init__(self, batches):
         self.batches = tuple(batches)

--- a/tools/analyze_dq_v24_local.py
+++ b/tools/analyze_dq_v24_local.py
@@ -43,6 +43,14 @@ def _interval(low: Any, high: Any) -> str:
     return f"[{_number(low)}, {_number(high)}]"
 
 
+def _percent(value: Any, digits: int = 1) -> str:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    return f"{100.0 * number:.{digits}f}%" if math.isfinite(number) else "—"
+
+
 def _read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8-sig"))
 
@@ -73,8 +81,8 @@ def render_report(
             f"<td>{_number(row['symmetric_body'])} / {_number(row['symmetric_tail'])}</td>"
             f"<td>{_number(row['angle_body'])} / {_number(row['angle_tail'])}</td>"
             f"<td>{_number(row['gain_body'])} / {_number(row['gain_tail'])}</td>"
-            f"<td>{100*float(row['source_bootstrap_body_min_probability']):.1f}%</td>"
-            f"<td>{100*float(row['source_bootstrap_tail_min_probability']):.1f}%</td>"
+            f"<td>{_percent(row['source_bootstrap_body_min_probability'])}</td>"
+            f"<td>{_percent(row['source_bootstrap_tail_min_probability'])}</td>"
             f"<td>{'yes' if row['robustly_dominated'] else 'no'}</td>"
             f"<td>{'retain' if row['retained_for_formal'] else 'drop'}</td>"
             f"<td>{html.escape(roles)}</td>"
@@ -93,6 +101,12 @@ def render_report(
         else f"invalid: {html.escape(str(natural.get('invalid_reason')))}"
     )
     envelope = summary["core_grid_envelope"]
+    probed_sources = int(
+        summary.get("source_group_count_probed", summary["source_group_count"])
+    )
+    total_sources = int(
+        summary.get("source_group_count_total", probed_sources)
+    )
     return f"""<!doctype html>
 <html lang="ja"><head><meta charset="utf-8"><title>DQ v2.4 Acceptance — {html.escape(summary['dataset_id'])}</title>
 <style>
@@ -106,7 +120,7 @@ code{{background:#f3f5f6;padding:2px 4px}}
 </style></head><body>
 <h1>DQ Profiler v2.4 — Local numerical acceptance</h1>
 <div class="grid">
-<div class="card"><b>Dataset</b><br>{html.escape(summary['dataset_id'])}<br>{summary['image_count']} images / {summary['source_group_count']} source groups</div>
+<div class="card"><b>Dataset</b><br>{html.escape(summary['dataset_id'])}<br>{summary['image_count']} images / {probed_sources} of {total_sources} source groups probed</div>
 <div class="card"><b>Execution mode</b><br>{html.escape(str(summary.get('execution_mode', 'strict')))}<br><b>QA depth</b>: {html.escape(str(summary.get('qa_depth', 'strict_reference')))}</div>
 <div class="card"><b>Phenotype (local only)</b><br>{html.escape(summary['local_phenotype'])}</div>
 <div class="card"><b>Credible set</b><br>{credible}<br><b>Formal selection</b>: {selected}</div>
@@ -116,8 +130,8 @@ code{{background:#f3f5f6;padding:2px 4px}}
 Bodyは通常範囲、Tailは最悪timestep帯、AはTail増幅です。候補はsource-cluster bootstrapでBody/Tailの両方が80%以上の確率でPareto劣位な場合だけ除外します。
 Trajectoryは128-step formalで別軸として測り、ここでは未測定です。</div>
 <div class="card info"><b>No-quant natural local baseline</b><br>{natural_text}<br>候補選択票には使いません。</div>
-<div class="card"><b>Common core envelope</b><br>grid {html.escape(str(envelope['grid']))}; max Body {_number(envelope['max_local_body'])}; max Tail {_number(envelope['max_local_tail'])}<br>
-P(all core Body&lt;1) {100*float(envelope['probability_all_core_body_below_anchor']):.1f}% / P(all core Tail&lt;1) {100*float(envelope['probability_all_core_tail_below_anchor']):.1f}%</div>
+  <div class="card"><b>Common core envelope</b><br>grid {html.escape(str(envelope['grid']))}; max Body {_number(envelope['max_local_body'])}; max Tail {_number(envelope['max_local_tail'])}<br>
+  P(all hard-safe core Body&lt;1) {_percent(envelope['probability_all_core_body_below_anchor'])} / P(all hard-safe core Tail&lt;1) {_percent(envelope['probability_all_core_tail_below_anchor'])}</div>
 <h2>候補別カルテ</h2>
 <table><thead><tr><th>mul</th><th>role</th><th>Body</th><th>Body CI</th><th>Tail</th><th>Tail CI</th><th>A</th><th>sym B/T</th><th>angle B/T</th><th>gain B/T</th><th>P body min</th><th>P tail min</th><th>dominated</th><th>formal</th><th>mandatory role</th></tr></thead><tbody>{''.join(table_rows)}</tbody></table>
 <h2>読み方</h2><p><code>d=||g_mul-g_noquant||/||g_noquant||</code>を主距離として残し、対称距離・方向回転・gainを原因分解として併記します。1.0は元勾配と同程度の差という数学的anchorですが「失敗」を意味しません。edge未解決中は最良mulを確定しません。</p>
@@ -155,11 +169,17 @@ def main() -> int:
         tail_path = profile_dir / "gradient_tail.csv"
         natural_path = profile_dir / "local_natural_gradient.csv"
         manifest_path = profile_dir / "source_manifest.json"
+        probe_manifest_path = profile_dir / "probe_manifest.json"
         for path in (summary_path, tail_path, natural_path, manifest_path):
             if not path.is_file():
                 raise FileNotFoundError(f"required v2.4 local input is missing: {path}")
         raw_summary = _read_json(summary_path)
         source_manifest = _read_json(manifest_path)
+        probe_manifest = (
+            _read_json(probe_manifest_path)
+            if probe_manifest_path.is_file()
+            else {}
+        )
         source_contract = str(source_manifest.get("source_contract", {}).get("sha256", ""))
         if not source_contract:
             raise ValueError("local profile source_manifest has no source contract")
@@ -178,6 +198,21 @@ def main() -> int:
         )
         profile_metadata = dict(raw_summary.get("profile") or {})
         analysis_summary = result["summary"]
+        source_group_metadata = dict(
+            probe_manifest.get("source_group_map") or {}
+        )
+        probed_source_groups = int(
+            source_group_metadata.get(
+                "source_group_count_probed",
+                analysis_summary["source_group_count"],
+            )
+        )
+        total_source_groups = int(
+            source_group_metadata.get(
+                "source_group_count_total",
+                probed_source_groups,
+            )
+        )
         analysis_summary.update(
             {
                 "source_profile": str(profile_dir),
@@ -186,6 +221,27 @@ def main() -> int:
                 "local_gradient_tail_sha256": sha256_file(tail_path),
                 "local_natural_gradient_sha256": sha256_file(natural_path),
                 "no_quant_natural_local_baseline": natural,
+                "source_group_count": probed_source_groups,
+                "source_group_count_probed": probed_source_groups,
+                "source_group_count_total": total_source_groups,
+                "source_group_coverage_complete": bool(
+                    source_group_metadata.get(
+                        "source_group_coverage_complete",
+                        probed_source_groups == total_source_groups,
+                    )
+                ),
+                "source_group_coverage_fraction": float(
+                    source_group_metadata.get(
+                        "source_group_coverage_fraction",
+                        probed_source_groups / max(total_source_groups, 1),
+                    )
+                ),
+                "source_group_selection_policy": str(
+                    source_group_metadata.get(
+                        "source_group_selection_policy",
+                        "all_source_groups",
+                    )
+                ),
                 "execution_mode": str(
                     profile_metadata.get("execution_mode", "strict")
                 ),
@@ -315,7 +371,17 @@ def main() -> int:
                 "metric_definition_version": METRIC_DEFINITION_VERSION,
                 "inputs": {
                     path.name: {"path": str(path), "sha256": sha256_file(path)}
-                    for path in (summary_path, tail_path, natural_path, manifest_path)
+                    for path in (
+                        summary_path,
+                        tail_path,
+                        natural_path,
+                        manifest_path,
+                        *(
+                            (probe_manifest_path,)
+                            if probe_manifest_path.is_file()
+                            else ()
+                        ),
+                    )
                 },
                 "source_contract_sha256": source_contract,
                 "selection_rule_sha256": rule_sha,

--- a/tools/analyze_dq_v24_local.py
+++ b/tools/analyze_dq_v24_local.py
@@ -192,6 +192,21 @@ def main() -> int:
                 "qa_depth": str(
                     profile_metadata.get("qa_depth", "strict_reference")
                 ),
+                "measurement_contract": str(
+                    profile_metadata.get(
+                        "measurement_contract", "local-body-tail-v1"
+                    )
+                ),
+                "sampling_depth": str(
+                    profile_metadata.get(
+                        "sampling_depth", "reference_32_image"
+                    )
+                ),
+                "confidence_ceiling": str(
+                    profile_metadata.get(
+                        "confidence_ceiling", "data_driven_up_to_high"
+                    )
+                ),
                 "internal_profile_level": str(
                     profile_metadata.get(
                         "internal_profile_level",
@@ -231,6 +246,9 @@ def main() -> int:
             "local_profile_protocol": "v24-acceptance-local",
             "execution_mode": analysis_summary["execution_mode"],
             "qa_depth": analysis_summary["qa_depth"],
+            "measurement_contract": analysis_summary["measurement_contract"],
+            "sampling_depth": analysis_summary["sampling_depth"],
+            "confidence_ceiling": analysis_summary["confidence_ceiling"],
             "local_profile_dir": str(profile_dir),
             "local_summary_path": str(summary_path),
             "local_summary_sha256": sha256_file(summary_path),

--- a/tools/analyze_dq_v24_local.py
+++ b/tools/analyze_dq_v24_local.py
@@ -28,6 +28,7 @@ from dq_profile.v24_descriptive import (
     analyze_source_localization,
     build_dataset_character_vector,
 )
+from dq_profile.v24_beginner_report import render_beginner_report
 from dq_profile.v24_practical_report import (
     build_single_dataset_report_model,
     render_report as render_practical_report,
@@ -462,6 +463,10 @@ def main() -> int:
             render_practical_report(practical_model),
             encoding="utf-8",
         )
+        (output_dir / "beginner_report.html").write_text(
+            render_beginner_report(practical_model),
+            encoding="utf-8",
+        )
         write_json(
             output_dir / "analysis_manifest.json",
             {
@@ -500,6 +505,11 @@ def main() -> int:
                         "path": str(output_dir / "technical_report.html"),
                         "sha256": sha256_file(output_dir / "technical_report.html"),
                     },
+                    "beginner": {
+                        "path": str(output_dir / "beginner_report.html"),
+                        "sha256": sha256_file(output_dir / "beginner_report.html"),
+                        "scope": "single_dataset_beginner_overview",
+                    },
                     "contract": {
                         "path": str(output_dir / "report_contract.json"),
                         "sha256": sha256_file(output_dir / "report_contract.json"),
@@ -517,6 +527,7 @@ def main() -> int:
                 "selection_valid": selection["selection_valid"],
                 "edge_unresolved": selection["edge_unresolved"],
                 "primary_report": "report.html",
+                "beginner_report": "beginner_report.html",
                 "technical_report": "technical_report.html",
                 "report_scope": "single_dataset_local_only",
                 "trajectory_product_role": "research_only_keep_product_local_only",

--- a/tools/analyze_dq_v24_local.py
+++ b/tools/analyze_dq_v24_local.py
@@ -21,6 +21,13 @@ from dq_profile.v24_acceptance import (
     analyze_local_profile,
     analyze_natural_gradient_rows,
 )
+from dq_profile.v24_descriptive import (
+    DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+    DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+    analyze_no_quant_baseline,
+    analyze_source_localization,
+    build_dataset_character_vector,
+)
 from dq_profile.v24_practical_report import (
     build_single_dataset_report_model,
     render_report as render_practical_report,
@@ -64,6 +71,8 @@ def render_report(
     summary: dict[str, Any],
     rows: list[dict[str, Any]],
     natural: dict[str, Any],
+    source_localization: dict[str, Any],
+    no_quant_profile: dict[str, Any],
 ) -> str:
     selection = summary["selection"]
     table_rows: list[str] = []
@@ -107,6 +116,13 @@ def render_report(
     total_sources = int(
         summary.get("source_group_count_total", probed_sources)
     )
+    localization_reference = dict(
+        source_localization.get("reference_profile") or {}
+    )
+    no_quant_signal = dict(no_quant_profile.get("signal_strength") or {})
+    no_quant_load = dict(no_quant_profile.get("source_load") or {})
+    probed_images = int(summary.get("image_count_probed", summary["image_count"]))
+    total_images = int(summary.get("image_count_total", probed_images))
     return f"""<!doctype html>
 <html lang="ja"><head><meta charset="utf-8"><title>DQ v2.4 Acceptance — {html.escape(summary['dataset_id'])}</title>
 <style>
@@ -130,6 +146,16 @@ code{{background:#f3f5f6;padding:2px 4px}}
 Bodyは通常範囲、Tailは最悪timestep帯、AはTail増幅です。候補はsource-cluster bootstrapでBody/Tailの両方が80%以上の確率でPareto劣位な場合だけ除外します。
 Trajectoryは128-step formalで別軸として測り、ここでは未測定です。</div>
 <div class="card info"><b>No-quant natural local baseline</b><br>{natural_text}<br>候補選択票には使いません。</div>
+<div class="grid">
+<div class="card info"><b>Source localization (descriptive only)</b><br>
+reference mul {_number(source_localization.get('reference_mul'), 2)}; top source {html.escape(str(localization_reference.get('top_source_alias', '—')))} / {_percent(localization_reference.get('top_source_share'))}; effective sources {_number(localization_reference.get('effective_source_count'), 2)}<br>
+絶対Tailが小さい場合の高集中率は、それだけで警告ではありません。</div>
+<div class="card info"><b>No-quant reference signal (descriptive only)</b><br>
+gradient norm q05 / median / q95 = {_number(no_quant_signal.get('grad_norm_q05'))} / {_number(no_quant_signal.get('grad_norm_median'))} / {_number(no_quant_signal.get('grad_norm_q95'))}<br>
+top source energy {_percent(no_quant_load.get('top_source_energy_share'))}; effective sources {_number(no_quant_load.get('effective_source_count'), 2)}</div>
+<div class="card"><b>Image coverage</b><br>{probed_images} / {total_images} images ({_percent(summary.get('image_coverage_fraction'))})<br>
+未probe画像がある場合、結果は測定subsetの記述です。</div>
+</div>
   <div class="card"><b>Common core envelope</b><br>grid {html.escape(str(envelope['grid']))}; max Body {_number(envelope['max_local_body'])}; max Tail {_number(envelope['max_local_tail'])}<br>
   P(all hard-safe core Body&lt;1) {_percent(envelope['probability_all_core_body_below_anchor'])} / P(all hard-safe core Tail&lt;1) {_percent(envelope['probability_all_core_tail_below_anchor'])}</div>
 <h2>候補別カルテ</h2>
@@ -183,9 +209,10 @@ def main() -> int:
         source_contract = str(source_manifest.get("source_contract", {}).get("sha256", ""))
         if not source_contract:
             raise ValueError("local profile source_manifest has no source contract")
+        gradient_tail_rows = _read_csv(tail_path)
         result = analyze_local_profile(
             summary=raw_summary,
-            gradient_tail_rows=_read_csv(tail_path),
+            gradient_tail_rows=gradient_tail_rows,
             dataset_id=str(args.dataset_id),
             bootstrap_iterations=int(args.iterations),
             bootstrap_seed=int(args.seed),
@@ -198,6 +225,22 @@ def main() -> int:
         )
         profile_metadata = dict(raw_summary.get("profile") or {})
         analysis_summary = result["summary"]
+        source_localization = analyze_source_localization(
+            gradient_tail_rows=gradient_tail_rows,
+            score_rows=result["score_rows"],
+            source_loo_rows=result["source_loo_rows"],
+        )
+        no_quant_profile = analyze_no_quant_baseline(
+            gradient_tail_rows=gradient_tail_rows,
+            natural_baseline=natural,
+            timestep_bins=int(raw_summary["profile"]["timestep_bins"]),
+        )
+        dataset_character_vector = build_dataset_character_vector(
+            score_rows=result["score_rows"],
+            local_phenotype=str(analysis_summary["local_phenotype"]),
+            source_localization=source_localization,
+            no_quant_baseline=no_quant_profile,
+        )
         source_group_metadata = dict(
             probe_manifest.get("source_group_map") or {}
         )
@@ -213,6 +256,16 @@ def main() -> int:
                 probed_source_groups,
             )
         )
+        raw_dataset = dict(raw_summary.get("dataset") or {})
+        probed_images = int(analysis_summary["image_count"])
+        total_images = int(
+            raw_dataset.get(
+                "unique_images",
+                raw_dataset.get("image_count", probed_images),
+            )
+        )
+        total_images = max(total_images, probed_images)
+        image_coverage_fraction = probed_images / max(total_images, 1)
         analysis_summary.update(
             {
                 "source_profile": str(profile_dir),
@@ -221,6 +274,20 @@ def main() -> int:
                 "local_gradient_tail_sha256": sha256_file(tail_path),
                 "local_natural_gradient_sha256": sha256_file(natural_path),
                 "no_quant_natural_local_baseline": natural,
+                "descriptive_profile_schema_version": DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+                "descriptive_metric_definition_version": DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+                "source_localization": source_localization,
+                "no_quant_baseline_profile": no_quant_profile,
+                "dataset_character_vector": dataset_character_vector,
+                "image_count_probed": probed_images,
+                "image_count_total": total_images,
+                "image_coverage_fraction": image_coverage_fraction,
+                "image_coverage_complete": probed_images == total_images,
+                "unmeasured_image_risk": (
+                    "none_within_resolved_dataset"
+                    if probed_images == total_images
+                    else "descriptive_results_cover_only_the_measured_subset"
+                ),
                 "source_group_count": probed_source_groups,
                 "source_group_count_probed": probed_source_groups,
                 "source_group_count_total": total_source_groups,
@@ -280,14 +347,42 @@ def main() -> int:
         write_json(output_dir / "acceptance_contract.json", result["contract"])
         write_json(output_dir / "summary.json", analysis_summary)
         write_json(output_dir / "natural_gradient_baseline.json", natural)
+        write_json(output_dir / "source_localization.json", source_localization)
+        write_json(output_dir / "no_quant_baseline_profile.json", no_quant_profile)
+        write_json(
+            output_dir / "dataset_character_vector.json",
+            dataset_character_vector,
+        )
         write_csv(output_dir / "local_acceptance.csv", result["score_rows"])
         write_csv(output_dir / "local_timestep.csv", result["timestep_rows"])
         write_csv(output_dir / "source_bootstrap.csv", result["bootstrap_rows"])
         write_csv(output_dir / "bootstrap_regret.csv", result["regret_rows"])
         write_csv(output_dir / "robust_dominance.csv", result["dominance_rows"])
         write_csv(output_dir / "source_loo.csv", result["source_loo_rows"])
+        write_csv(
+            output_dir / "source_localization.csv",
+            source_localization.get("summary_rows") or [],
+        )
+        write_csv(
+            output_dir / "source_localization_detail.csv",
+            source_localization.get("detail_rows") or [],
+        )
+        write_csv(
+            output_dir / "no_quant_source_load.csv",
+            no_quant_profile.get("source_rows") or [],
+        )
+        write_csv(
+            output_dir / "no_quant_timestep_profile.csv",
+            no_quant_profile.get("timestep_rows") or [],
+        )
         (output_dir / "technical_report.html").write_text(
-            render_report(analysis_summary, result["score_rows"], natural),
+            render_report(
+                analysis_summary,
+                result["score_rows"],
+                natural,
+                source_localization,
+                no_quant_profile,
+            ),
             encoding="utf-8",
         )
 
@@ -348,6 +443,9 @@ def main() -> int:
                 "source_loo_rows": result["source_loo_rows"],
                 "timestep_rows": result["timestep_rows"],
                 "natural_baseline": natural,
+                "source_localization": source_localization,
+                "no_quant_baseline_profile": no_quant_profile,
+                "dataset_character_vector": dataset_character_vector,
             },
             gate_rows=gate_rows,
             provenance={
@@ -386,6 +484,12 @@ def main() -> int:
                 "source_contract_sha256": source_contract,
                 "selection_rule_sha256": rule_sha,
                 "acceptance_contract_sha256": analysis_summary["acceptance_contract_sha256"],
+                "descriptive_channels": {
+                    "schema_version": DESCRIPTIVE_PROFILE_SCHEMA_VERSION,
+                    "metric_definition_version": DESCRIPTIVE_METRIC_DEFINITION_VERSION,
+                    "selector_input": False,
+                    "not_quality_or_utility": True,
+                },
                 "reports": {
                     "primary": {
                         "path": str(output_dir / "report.html"),

--- a/tools/analyze_dq_v24_local.py
+++ b/tools/analyze_dq_v24_local.py
@@ -107,6 +107,7 @@ code{{background:#f3f5f6;padding:2px 4px}}
 <h1>DQ Profiler v2.4 — Local numerical acceptance</h1>
 <div class="grid">
 <div class="card"><b>Dataset</b><br>{html.escape(summary['dataset_id'])}<br>{summary['image_count']} images / {summary['source_group_count']} source groups</div>
+<div class="card"><b>Execution mode</b><br>{html.escape(str(summary.get('execution_mode', 'strict')))}<br><b>QA depth</b>: {html.escape(str(summary.get('qa_depth', 'strict_reference')))}</div>
 <div class="card"><b>Phenotype (local only)</b><br>{html.escape(summary['local_phenotype'])}</div>
 <div class="card"><b>Credible set</b><br>{credible}<br><b>Formal selection</b>: {selected}</div>
 <div class="card"><b>Edge</b><br>{html.escape(selection['selection_status'])}<br>next local-only: {edge}</div>
@@ -175,6 +176,7 @@ def main() -> int:
             bootstrap_iterations=int(args.iterations),
             bootstrap_seed=int(args.seed) + 1,
         )
+        profile_metadata = dict(raw_summary.get("profile") or {})
         analysis_summary = result["summary"]
         analysis_summary.update(
             {
@@ -184,6 +186,24 @@ def main() -> int:
                 "local_gradient_tail_sha256": sha256_file(tail_path),
                 "local_natural_gradient_sha256": sha256_file(natural_path),
                 "no_quant_natural_local_baseline": natural,
+                "execution_mode": str(
+                    profile_metadata.get("execution_mode", "strict")
+                ),
+                "qa_depth": str(
+                    profile_metadata.get("qa_depth", "strict_reference")
+                ),
+                "internal_profile_level": str(
+                    profile_metadata.get(
+                        "internal_profile_level",
+                        profile_metadata.get("level", "standard"),
+                    )
+                ),
+                "prefix_short_steps": int(
+                    profile_metadata.get("prefix_short_steps", 64)
+                ),
+                "prefix_long_steps": int(
+                    profile_metadata.get("prefix_long_steps", 128)
+                ),
             }
         )
         write_json(output_dir / "acceptance_contract.json", result["contract"])
@@ -209,6 +229,8 @@ def main() -> int:
             "not_quality_or_utility": True,
             "source_contract_sha256": source_contract,
             "local_profile_protocol": "v24-acceptance-local",
+            "execution_mode": analysis_summary["execution_mode"],
+            "qa_depth": analysis_summary["qa_depth"],
             "local_profile_dir": str(profile_dir),
             "local_summary_path": str(summary_path),
             "local_summary_sha256": sha256_file(summary_path),

--- a/tools/render_dq_beginner_report.py
+++ b/tools/render_dq_beginner_report.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Render a beginner report from an existing practical report artifact."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from dq_profile.v24_beginner_report import render_beginner_report
+from dq_profile.v24_practical_report import render_report as render_practical_report
+
+
+def render_existing_run(
+    run_dir: Path,
+    output: Path | None = None,
+    *,
+    refresh_practical_report: bool = False,
+) -> Path:
+    run_dir = run_dir.resolve()
+    practical_path = run_dir / "practical_report.json"
+    if not practical_path.is_file():
+        raise FileNotFoundError(f"practical report was not found: {practical_path}")
+    model = json.loads(practical_path.read_text(encoding="utf-8"))
+    destination = (output or run_dir / "beginner_report.html").resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(render_beginner_report(model), encoding="utf-8")
+    if refresh_practical_report:
+        (run_dir / "report.html").write_text(
+            render_practical_report(model),
+            encoding="utf-8",
+        )
+    return destination
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate beginner_report.html from an existing DQ Profiler run."
+    )
+    parser.add_argument("run_dir", type=Path, help="completed profile run directory")
+    parser.add_argument("--output", type=Path, help="optional output HTML path")
+    parser.add_argument(
+        "--refresh-practical-report",
+        action="store_true",
+        help="also re-render report.html from the same practical_report.json",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    print(
+        render_existing_run(
+            args.run_dir,
+            args.output,
+            refresh_practical_report=args.refresh_practical_report,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 概要

Experimental SDXL DQ Dataset Profilerを、反復利用しやすいStandard診断と、結果を読み取りやすいレポート構成へ拡張します。

この診断が扱うのは短期probe上のSafety / Fidelityです。最終画質Utilityや「最良mul」を直接保証する機能ではありません。

## 主な変更

- `standard`を既定の実用診断モードとして追加し、研究・厳密検算用の`strict`を明示的に選択可能にしました
- Local probeの観測量を保ちながら、独立snapshotなどの検算工程をStandard向けに整理しました
- sourceの一部欠損やnonfinite probeを、レポート生成不能にせず明示的な観測結果として扱うよう改善しました
- no-quant自然変動、mul感度、source集中、timestep偏りなど、データセットの性格を表す説明channelを追加しました
- 実用レポートに加え、Body / Tailや各指標の意味を短く説明する`beginner_report.html`を追加しました
- Hard-safety、Fidelity retained、注意候補、代表候補の表示を意味別の記号・色へ整理しました
- 既存の診断成果物へ初心者向けレポートを追加生成できる補助ツールを追加しました
- CLI仕様、固定条件、処理工程、所要時間の考え方をドキュメントへ追記しました
- Standard / Strict、レポート生成、部分source、nonfinite処理に対応する回帰テストを追加しました

## 最終的なモード構成

- `standard`: 通常利用向けの既定モード
- `strict`: prefix・snapshotなどをより厳密に検算する研究／確認用モード

過去に試作したQuickモードは最終仕様には含めず、画像側の観測量を減らさない構成へ統一しています。

## 出力

診断runのトップ階層へ、用途別に次を生成します。

- `beginner_report.html`: 初見でも読み進めやすい要約
- `report.html`: 実用判断向けレポート
- `technical_report.html`: 詳細な技術情報
- `summary.json`ほか、再現性・契約確認用のメタデータ

## 検証

- DQ Profiler関連テスト: `212 passed, 1 skipped`
- `git diff --check`: pass
- ブランチ差分と履歴を、実データ名、ローカルユーザー情報、実環境パス、認証情報について監査済み

実測データ、生成済み診断レポート、モデル、dataset設定はこのPRに含めていません。